### PR TITLE
feat: add download binary intstructions for macos and windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,32 @@ Foundry abstracts away the complexities of the installation process so you can s
 
 **1. Install foundryctl**
 
-You can install `foundryctl` by downloading the latest release directly from [GitHub Releases](https://github.com/signoz/foundry/releases). To quickly get the correct binary for your architecture via the command line, run:
+You can install `foundryctl` by downloading a release from [GitHub Releases](https://github.com/signoz/foundry/releases).
+
+To quickly get the correct binary for your architecture via the command line, run
+
+**Linux:**
 
 ```bash
-curl -L https://github.com/SigNoz/foundry/releases/latest/download/foundry_linux_$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g').tar.gz -o foundry.tar.gz
+FOUNDRY_VERSION=v0.0.1-rc.2
+curl -L "https://github.com/SigNoz/foundry/releases/download/${FOUNDRY_VERSION}/foundry_linux_$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g').tar.gz" -o foundry.tar.gz
+tar -xzf foundry.tar.gz
+```
+
+**macOS:**
+
+```bash
+FOUNDRY_VERSION=v0.0.1-rc.2
+curl -L "https://github.com/SigNoz/foundry/releases/download/${FOUNDRY_VERSION}/foundry_darwin_$(uname -m | sed 's/x86_64/amd64/g' | sed 's/arm64/arm64/g').tar.gz" -o foundry.tar.gz
+tar -xzf foundry.tar.gz
+```
+
+**Windows (PowerShell):**
+
+```bash
+$FOUNDRY_VERSION = "v0.0.1-rc.2"
+$ARCH = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "amd64" }
+Invoke-WebRequest -Uri "https://github.com/SigNoz/foundry/releases/download/$FOUNDRY_VERSION/foundry_windows_${ARCH}.tar.gz" -OutFile foundry.tar.gz -UseBasicParsing
 tar -xzf foundry.tar.gz
 ```
 


### PR DESCRIPTION
#### Features

- Adds instructions for downloading binaries for macos and Windows

Related:  https://github.com/SigNoz/platform-pod/issues/1594

_NOTE_: Pinning the version to `v0.0.1-rc.2` because the latest tag doesn't work with pre-releases. We will remove the pinned version once we do a release.
