### PR TITLE
fix: Correct example yaml "custom binary path" for systemd-deployment

### DIFF
--- a/docs/examples/systemd/binary/README.md
+++ b/docs/examples/systemd/binary/README.md
@@ -124,7 +124,7 @@ metadata:
   annotations:
         foundry.signoz.io/signoz-binary-path: /opt/signoz/bin/signoz
         foundry.signoz.io/ingester-binary-path: /opt/ingester/bin/signoz-otel-collector
-        foundry.signoz.io/metastore-binary-path: /usr/bin/postgres
+        foundry.signoz.io/metastore-postgres-binary-path: /usr/bin/postgres
 spec:
   deployment:
     flavor: binary


### PR DESCRIPTION
#### Fixes

- Syncs the yaml example of systemd-deployment metadata with the actual field-name given in the table above.

Outdated name: `metastore-binary-path`
Updated name: `metastore-postgres-binary-path`