### PR TITLE
feat(foundryctl): ingester resource settings

### DIFF
--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -177,7 +177,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -162,9 +170,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -242,6 +254,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -251,6 +264,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -259,6 +273,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -267,6 +282,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -44,9 +44,13 @@ services:
               http:
                 endpoint: "0.0.0.0:4318"
         processors:
+          memory_limiter:
+            check_interval: 1s
+            limit_percentage: 75
+            spike_limit_percentage: 15
           batch:
-            send_batch_size: 20000
-            send_batch_max_size: 25000
+            send_batch_size: 50000
+            send_batch_max_size: 55000
             timeout: 1s
           batch/meter:
             send_batch_size: 20000
@@ -124,6 +128,7 @@ services:
               receivers:
                 - otlp
               processors:
+                - memory_limiter
                 - signozspanmetrics/delta
                 - batch
               exporters:
@@ -133,6 +138,7 @@ services:
               receivers:
                 - otlp
               processors:
+                - memory_limiter
                 - batch
               exporters:
                 - signozclickhousemetrics
@@ -141,6 +147,7 @@ services:
               receivers:
                 - otlp
               processors:
+                - memory_limiter
                 - batch
               exporters:
                 - clickhouselogsexporter
@@ -149,6 +156,7 @@ services:
               receivers:
                 - signozmeter
               processors:
+                - memory_limiter
                 - batch/meter
               exporters:
                 - signozclickhousemeter

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -51,7 +51,7 @@ services:
           batch:
             send_batch_size: 50000
             send_batch_max_size: 55000
-            timeout: 1s
+            timeout: 5s
           batch/meter:
             send_batch_size: 20000
             send_batch_max_size: 25000

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -177,7 +177,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -162,9 +170,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -242,6 +254,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -251,6 +264,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -259,6 +273,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -267,6 +282,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/docker/compose/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose/pours/deployment/compose.yaml
@@ -8,8 +8,18 @@ services:
     - |
       /signoz-otel-collector migrate sync check &&
       /signoz-otel-collector --config=/etc/otel-collector-config.yaml --manager-config=/etc/opamp-config.yaml --copy-path=/var/tmp/collector-config.yaml
+    depends_on:
+      signoz-telemetrystore-clickhouse-0-0:
+        condition: service_healthy
     deploy:
       replicas: 1
+      resources:
+        limits:
+          cpus: "1"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
       restart_policy:
         condition: on-failure
     entrypoint:

--- a/docs/examples/docker/compose/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/docker/compose/pours/deployment/ingester/ingester.yaml
@@ -36,13 +36,17 @@ extensions:
     endpoint: 0.0.0.0:13133
 processors:
   batch:
-    send_batch_max_size: 25000
-    send_batch_size: 20000
+    send_batch_max_size: 55000
+    send_batch_size: 50000
     timeout: 1s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000
     timeout: 1s
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
   signozspanmetrics/delta:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
     dimensions:
@@ -91,6 +95,7 @@ service:
       - clickhouselogsexporter
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -99,6 +104,7 @@ service:
       - signozclickhousemetrics
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -106,6 +112,7 @@ service:
       exporters:
       - signozclickhousemeter
       processors:
+      - memory_limiter
       - batch/meter
       receivers:
       - signozmeter
@@ -114,6 +121,7 @@ service:
       - clickhousetraces
       - signozmeter
       processors:
+      - memory_limiter
       - signozspanmetrics/delta
       - batch
       receivers:

--- a/docs/examples/docker/compose/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/docker/compose/pours/deployment/ingester/ingester.yaml
@@ -38,7 +38,7 @@ processors:
   batch:
     send_batch_max_size: 55000
     send_batch_size: 50000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -177,7 +177,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -162,9 +170,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -242,6 +254,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -251,6 +264,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -259,6 +273,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -267,6 +282,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/docker/swarm/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/ingester/ingester.yaml
@@ -36,13 +36,17 @@ extensions:
     endpoint: 0.0.0.0:13133
 processors:
   batch:
-    send_batch_max_size: 25000
-    send_batch_size: 20000
+    send_batch_max_size: 55000
+    send_batch_size: 50000
     timeout: 1s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000
     timeout: 1s
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
   signozspanmetrics/delta:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
     dimensions:
@@ -91,6 +95,7 @@ service:
       - clickhouselogsexporter
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -99,6 +104,7 @@ service:
       - signozclickhousemetrics
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -106,6 +112,7 @@ service:
       exporters:
       - signozclickhousemeter
       processors:
+      - memory_limiter
       - batch/meter
       receivers:
       - signozmeter
@@ -114,6 +121,7 @@ service:
       - clickhousetraces
       - signozmeter
       processors:
+      - memory_limiter
       - signozspanmetrics/delta
       - batch
       receivers:

--- a/docs/examples/docker/swarm/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/ingester/ingester.yaml
@@ -38,7 +38,7 @@ processors:
   batch:
     send_batch_max_size: 55000
     send_batch_size: 50000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -28,9 +28,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -108,6 +112,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -117,6 +122,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -125,6 +131,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -133,6 +140,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -162,9 +170,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -242,6 +254,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -251,6 +264,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -259,6 +273,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -267,6 +282,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -35,7 +35,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -177,7 +177,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/ingester/ingester.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/ingester/ingester.yaml
@@ -36,13 +36,17 @@ extensions:
     endpoint: 0.0.0.0:13133
 processors:
   batch:
-    send_batch_max_size: 25000
-    send_batch_size: 20000
+    send_batch_max_size: 55000
+    send_batch_size: 50000
     timeout: 1s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000
     timeout: 1s
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
   signozspanmetrics/delta:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
     dimensions:
@@ -91,6 +95,7 @@ service:
       - clickhouselogsexporter
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -99,6 +104,7 @@ service:
       - signozclickhousemetrics
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -106,6 +112,7 @@ service:
       exporters:
       - signozclickhousemeter
       processors:
+      - memory_limiter
       - batch/meter
       receivers:
       - signozmeter
@@ -114,6 +121,7 @@ service:
       - clickhousetraces
       - signozmeter
       processors:
+      - memory_limiter
       - signozspanmetrics/delta
       - batch
       receivers:

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/ingester/ingester.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/ingester/ingester.yaml
@@ -38,7 +38,7 @@ processors:
   batch:
     send_batch_max_size: 55000
     send_batch_size: 50000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -161,9 +169,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -241,6 +253,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -250,6 +263,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -258,6 +272,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -266,6 +281,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -176,7 +176,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -161,9 +169,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -241,6 +253,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -250,6 +263,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -258,6 +272,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -266,6 +281,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -176,7 +176,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/kubernetes/kustomize/pours/deployment/ingester/configmap.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/ingester/configmap.yaml
@@ -23,7 +23,7 @@ data:
       batch:
         send_batch_size: 50000
         send_batch_max_size: 55000
-        timeout: 1s
+        timeout: 5s
       batch/meter:
         send_batch_size: 20000
         send_batch_max_size: 25000

--- a/docs/examples/kubernetes/kustomize/pours/deployment/ingester/configmap.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/ingester/configmap.yaml
@@ -16,9 +16,13 @@ data:
           http:
             endpoint: "0.0.0.0:4318"
     processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
       batch:
-        send_batch_size: 20000
-        send_batch_max_size: 25000
+        send_batch_size: 50000
+        send_batch_max_size: 55000
         timeout: 1s
       batch/meter:
         send_batch_size: 20000
@@ -96,6 +100,7 @@ data:
           receivers:
             - otlp
           processors:
+            - memory_limiter
             - signozspanmetrics/delta
             - batch
           exporters:
@@ -105,6 +110,7 @@ data:
           receivers:
             - otlp
           processors:
+            - memory_limiter
             - batch
           exporters:
             - signozclickhousemetrics
@@ -113,6 +119,7 @@ data:
           receivers:
             - otlp
           processors:
+            - memory_limiter
             - batch
           exporters:
             - clickhouselogsexporter
@@ -121,6 +128,7 @@ data:
           receivers:
             - signozmeter
           processors:
+            - memory_limiter
             - batch/meter
           exporters:
             - signozclickhousemeter

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -177,7 +177,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -162,9 +170,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -242,6 +254,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -251,6 +264,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -259,6 +273,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -267,6 +282,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/railway/template/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/railway/template/pours/deployment/ingester/ingester.yaml
@@ -36,13 +36,17 @@ extensions:
     endpoint: 0.0.0.0:13133
 processors:
   batch:
-    send_batch_max_size: 25000
-    send_batch_size: 20000
+    send_batch_max_size: 55000
+    send_batch_size: 50000
     timeout: 1s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000
     timeout: 1s
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
   signozspanmetrics/delta:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
     dimensions:
@@ -91,6 +95,7 @@ service:
       - clickhouselogsexporter
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -99,6 +104,7 @@ service:
       - signozclickhousemetrics
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -106,6 +112,7 @@ service:
       exporters:
       - signozclickhousemeter
       processors:
+      - memory_limiter
       - batch/meter
       receivers:
       - signozmeter
@@ -114,6 +121,7 @@ service:
       - clickhousetraces
       - signozmeter
       processors:
+      - memory_limiter
       - signozspanmetrics/delta
       - batch
       receivers:

--- a/docs/examples/railway/template/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/railway/template/pours/deployment/ingester/ingester.yaml
@@ -38,7 +38,7 @@ processors:
   batch:
     send_batch_max_size: 55000
     send_batch_size: 50000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -177,7 +177,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -162,9 +170,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -242,6 +254,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -251,6 +264,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -259,6 +273,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -267,6 +282,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/render/blueprint/pours/deployment/configs/ingester/ingester.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/ingester/ingester.yaml
@@ -36,13 +36,17 @@ extensions:
     endpoint: 0.0.0.0:13133
 processors:
   batch:
-    send_batch_max_size: 25000
-    send_batch_size: 20000
+    send_batch_max_size: 55000
+    send_batch_size: 50000
     timeout: 1s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000
     timeout: 1s
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
   signozspanmetrics/delta:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
     dimensions:
@@ -91,6 +95,7 @@ service:
       - clickhouselogsexporter
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -99,6 +104,7 @@ service:
       - signozclickhousemetrics
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -106,6 +112,7 @@ service:
       exporters:
       - signozclickhousemeter
       processors:
+      - memory_limiter
       - batch/meter
       receivers:
       - signozmeter
@@ -114,6 +121,7 @@ service:
       - clickhousetraces
       - signozmeter
       processors:
+      - memory_limiter
       - signozspanmetrics/delta
       - batch
       receivers:

--- a/docs/examples/render/blueprint/pours/deployment/configs/ingester/ingester.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/ingester/ingester.yaml
@@ -38,7 +38,7 @@ processors:
   batch:
     send_batch_max_size: 55000
     send_batch_size: 50000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -38,7 +38,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -183,7 +183,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -31,9 +31,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -111,6 +115,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -120,6 +125,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -128,6 +134,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -136,6 +143,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -168,9 +176,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -248,6 +260,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -257,6 +270,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -265,6 +279,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -273,6 +288,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/systemd/binary/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/ingester/ingester.yaml
@@ -36,13 +36,17 @@ extensions:
     endpoint: 0.0.0.0:13133
 processors:
   batch:
-    send_batch_max_size: 25000
-    send_batch_size: 20000
+    send_batch_max_size: 55000
+    send_batch_size: 50000
     timeout: 1s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000
     timeout: 1s
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
   signozspanmetrics/delta:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
     dimensions:
@@ -91,6 +95,7 @@ service:
       - clickhouselogsexporter
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -99,6 +104,7 @@ service:
       - signozclickhousemetrics
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -106,6 +112,7 @@ service:
       exporters:
       - signozclickhousemeter
       processors:
+      - memory_limiter
       - batch/meter
       receivers:
       - signozmeter
@@ -114,6 +121,7 @@ service:
       - clickhousetraces
       - signozmeter
       processors:
+      - memory_limiter
       - signozspanmetrics/delta
       - batch
       receivers:

--- a/docs/examples/systemd/binary/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/ingester/ingester.yaml
@@ -38,7 +38,7 @@ processors:
   batch:
     send_batch_max_size: 55000
     send_batch_size: 50000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -118,6 +118,13 @@ services:
     image: {{ $.Spec.Ingester.Spec.Image }}
     networks:
       - {{ $.Metadata.Name }}-network
+    depends_on:
+      {{- range $shardIdx := until (int $.Spec.TelemetryStore.Spec.Cluster.Shards) }}
+      {{- range $replicaIdx := until (int (add 1 (int $.Spec.TelemetryStore.Spec.Cluster.Replicas))) }}
+      {{ $.Metadata.Name }}-telemetrystore-{{ $.Spec.TelemetryStore.Kind }}-{{ $shardIdx }}-{{ $replicaIdx }}:
+        condition: service_healthy
+      {{- end }}
+      {{- end }}
     entrypoint:
       - /bin/sh
     command:
@@ -155,6 +162,13 @@ services:
       replicas: {{ int $.Spec.Ingester.Spec.Cluster.Replicas }}
       restart_policy:
         condition: on-failure
+      resources:
+        reservations:
+          cpus: '0.1'
+          memory: 128M
+        limits:
+          cpus: '1'
+          memory: 512M
   {{ $.Metadata.Name }}-signoz:
     image: {{ $.Spec.Signoz.Spec.Image }}
     networks:

--- a/internal/molding/ingestermolding/ingester.go
+++ b/internal/molding/ingestermolding/ingester.go
@@ -92,5 +92,6 @@ func (molding *ingester) getData(config *v1alpha1.Casting) (Data, error) {
 		TelemetryStoreMetricsAddress: strings.Join(telemetryStoreMetricsAddresses, ","),
 		TelemetryStoreLogsAddress:    strings.Join(telemetryStoreLogsAddresses, ","),
 		TelemetryStoreMeterAddress:   strings.Join(telemetryStoreMeterAddresses, ","),
+		IsContainer:                  config.Spec.Deployment.Platform != "linux",
 	}, nil
 }

--- a/internal/molding/ingestermolding/template.go
+++ b/internal/molding/ingestermolding/template.go
@@ -20,4 +20,5 @@ type Data struct {
 	TelemetryStoreMetricsAddress string
 	TelemetryStoreLogsAddress    string
 	TelemetryStoreMeterAddress   string
+	IsContainer                  bool
 }

--- a/internal/molding/ingestermolding/templates/config.v0129x.yaml.gotmpl
+++ b/internal/molding/ingestermolding/templates/config.v0129x.yaml.gotmpl
@@ -13,9 +13,18 @@ receivers:
       http:
         endpoint: "0.0.0.0:4318"
 processors:
+  memory_limiter:
+    check_interval: 1s
+    {{- if .IsContainer }}
+    limit_percentage: 75
+    spike_limit_percentage: 15
+    {{- else }}
+    limit_mib: 512
+    spike_limit_mib: 128
+    {{- end }}
   batch:
-    send_batch_size: 20000
-    send_batch_max_size: 25000
+    send_batch_size: 50000
+    send_batch_max_size: 55000
     timeout: 1s
   batch/meter:
     send_batch_size: 20000
@@ -93,6 +102,7 @@ service:
       receivers:
         - otlp
       processors:
+        - memory_limiter
         - signozspanmetrics/delta
         - batch
       exporters:
@@ -102,6 +112,7 @@ service:
       receivers:
         - otlp
       processors:
+        - memory_limiter
         - batch
       exporters:
         - signozclickhousemetrics
@@ -110,6 +121,7 @@ service:
       receivers:
         - otlp
       processors:
+        - memory_limiter
         - batch
       exporters:
         - clickhouselogsexporter
@@ -118,6 +130,7 @@ service:
       receivers:
         - signozmeter
       processors:
+        - memory_limiter
         - batch/meter
       exporters:
         - signozclickhousemeter

--- a/internal/molding/ingestermolding/templates/config.v0129x.yaml.gotmpl
+++ b/internal/molding/ingestermolding/templates/config.v0129x.yaml.gotmpl
@@ -25,7 +25,7 @@ processors:
   batch:
     send_batch_size: 50000
     send_batch_max_size: 55000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_size: 20000
     send_batch_max_size: 25000


### PR DESCRIPTION
#### Features
- Set sane default for memory_limiter based on platform
- Set initial container requests for docker, k8s needs to be done in the helm chart.
- Depends on Ingester to wait for ClikcHouse to prevent it from flooding and failing before backend is up
- Bigger initial batch sizes to avoid small frequent parts

