### PR TITLE
feat: add sane defaults to telemetrystore

### DIFF
--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -455,7 +455,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -463,7 +463,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
@@ -575,7 +575,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -583,7 +583,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"

--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -458,6 +458,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -467,6 +471,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -560,6 +578,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -569,6 +591,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -177,7 +177,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -425,9 +425,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -450,6 +450,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -511,9 +527,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -536,6 +552,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -427,9 +427,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -452,6 +452,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -513,9 +529,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -538,6 +554,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -456,6 +456,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -465,6 +469,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -558,6 +576,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -567,6 +589,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -162,9 +170,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -242,6 +254,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -251,6 +264,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -259,6 +273,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -267,6 +282,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -323,9 +323,9 @@ services:
             shard: "01"
         profiles:
             default:
+                allow_simdjson: 0
                 load_balancing: random
                 log_queries: 1
-                max_memory_usage: 10000000000
         quotas:
             default:
                 interval:
@@ -348,6 +348,22 @@ services:
           node:
             - host: signoz-telemetrykeeper-clickhousekeeper-0
               port: 9181
+        query_log:
+            flush_interval_milliseconds: 30000
+            partition_by: toYYYYMM(event_date)
+            ttl: "event_date + INTERVAL 3 DAY DELETE"
+        query_thread_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        part_log:
+            ttl: "event_date + INTERVAL 3 DAY DELETE"
+        metric_log:
+            flush_interval_milliseconds: 30000
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        asynchronous_metric_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        trace_log:
+            flush_interval_milliseconds: 30000
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
         tcp_port: 9000
         user_defined_executable_functions_config: '*function.yaml'
         user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -322,9 +322,9 @@ services:
             shard: "01"
         profiles:
             default:
+                allow_simdjson: 0
                 load_balancing: random
                 log_queries: 1
-                max_memory_usage: 10000000000
         quotas:
             default:
                 interval:
@@ -347,6 +347,22 @@ services:
           node:
             - host: signoz-telemetrykeeper-clickhousekeeper-0
               port: 9181
+        query_log:
+            flush_interval_milliseconds: 30000
+            partition_by: toYYYYMM(event_date)
+            ttl: "event_date + INTERVAL 3 DAY DELETE"
+        query_thread_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        part_log:
+            ttl: "event_date + INTERVAL 3 DAY DELETE"
+        metric_log:
+            flush_interval_milliseconds: 30000
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        asynchronous_metric_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        trace_log:
+            flush_interval_milliseconds: 30000
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
         tcp_port: 9000
         user_defined_executable_functions_config: '*function.yaml'
         user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -353,6 +353,10 @@ services:
             ttl: "event_date + INTERVAL 3 DAY DELETE"
         query_thread_log:
             ttl: "event_date + INTERVAL 1 DAY DELETE"
+        query_metric_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        query_views_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
         part_log:
             ttl: "event_date + INTERVAL 3 DAY DELETE"
         metric_log:
@@ -362,6 +366,20 @@ services:
             ttl: "event_date + INTERVAL 1 DAY DELETE"
         trace_log:
             flush_interval_milliseconds: 30000
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        error_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        latency_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        processors_profile_log:
+            flush_interval_milliseconds: 30000
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        session_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        text_log:
+            flush_interval_milliseconds: 30000
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        zookeeper_log:
             ttl: "event_date + INTERVAL 1 DAY DELETE"
         tcp_port: 9000
         user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -354,6 +354,10 @@ services:
             ttl: "event_date + INTERVAL 3 DAY DELETE"
         query_thread_log:
             ttl: "event_date + INTERVAL 1 DAY DELETE"
+        query_metric_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        query_views_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
         part_log:
             ttl: "event_date + INTERVAL 3 DAY DELETE"
         metric_log:
@@ -363,6 +367,20 @@ services:
             ttl: "event_date + INTERVAL 1 DAY DELETE"
         trace_log:
             flush_interval_milliseconds: 30000
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        error_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        latency_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        processors_profile_log:
+            flush_interval_milliseconds: 30000
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        session_log:
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        text_log:
+            flush_interval_milliseconds: 30000
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
+        zookeeper_log:
             ttl: "event_date + INTERVAL 1 DAY DELETE"
         tcp_port: 9000
         user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -44,9 +44,13 @@ services:
               http:
                 endpoint: "0.0.0.0:4318"
         processors:
+          memory_limiter:
+            check_interval: 1s
+            limit_percentage: 75
+            spike_limit_percentage: 15
           batch:
-            send_batch_size: 20000
-            send_batch_max_size: 25000
+            send_batch_size: 50000
+            send_batch_max_size: 55000
             timeout: 1s
           batch/meter:
             send_batch_size: 20000
@@ -124,6 +128,7 @@ services:
               receivers:
                 - otlp
               processors:
+                - memory_limiter
                 - signozspanmetrics/delta
                 - batch
               exporters:
@@ -133,6 +138,7 @@ services:
               receivers:
                 - otlp
               processors:
+                - memory_limiter
                 - batch
               exporters:
                 - signozclickhousemetrics
@@ -141,6 +147,7 @@ services:
               receivers:
                 - otlp
               processors:
+                - memory_limiter
                 - batch
               exporters:
                 - clickhouselogsexporter
@@ -149,6 +156,7 @@ services:
               receivers:
                 - signozmeter
               processors:
+                - memory_limiter
                 - batch/meter
               exporters:
                 - signozclickhousemeter

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -51,7 +51,7 @@ services:
           batch:
             send_batch_size: 50000
             send_batch_max_size: 55000
-            timeout: 1s
+            timeout: 5s
           batch/meter:
             send_batch_size: 20000
             send_batch_max_size: 25000

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -351,7 +351,7 @@ services:
         query_log:
             flush_interval_milliseconds: 30000
             partition_by: toYYYYMM(event_date)
-            ttl: "event_date + INTERVAL 3 DAY DELETE"
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
         query_thread_log:
             ttl: "event_date + INTERVAL 1 DAY DELETE"
         query_metric_log:
@@ -359,7 +359,7 @@ services:
         query_views_log:
             ttl: "event_date + INTERVAL 1 DAY DELETE"
         part_log:
-            ttl: "event_date + INTERVAL 3 DAY DELETE"
+            ttl: "event_date + INTERVAL 1 DAY DELETE"
         metric_log:
             flush_interval_milliseconds: 30000
             ttl: "event_date + INTERVAL 1 DAY DELETE"

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -455,7 +455,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -463,7 +463,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
@@ -575,7 +575,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -583,7 +583,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -458,6 +458,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -467,6 +471,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -560,6 +578,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -569,6 +591,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -177,7 +177,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -425,9 +425,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -450,6 +450,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -511,9 +527,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -536,6 +552,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -427,9 +427,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -452,6 +452,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -513,9 +529,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -538,6 +554,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -456,6 +456,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -465,6 +469,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -558,6 +576,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -567,6 +589,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -162,9 +170,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -242,6 +254,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -251,6 +264,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -259,6 +273,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -267,6 +282,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/docker/compose/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose/pours/deployment/compose.yaml
@@ -10,13 +10,6 @@ services:
       /signoz-otel-collector --config=/etc/otel-collector-config.yaml --manager-config=/etc/opamp-config.yaml --copy-path=/var/tmp/collector-config.yaml
     deploy:
       replicas: 1
-      resources:
-        limits:
-          cpus: "1"
-          memory: 512M
-        reservations:
-          cpus: "0.1"
-          memory: 128M
       restart_policy:
         condition: on-failure
     entrypoint:

--- a/docs/examples/docker/compose/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose/pours/deployment/compose.yaml
@@ -8,9 +8,6 @@ services:
     - |
       /signoz-otel-collector migrate sync check &&
       /signoz-otel-collector --config=/etc/otel-collector-config.yaml --manager-config=/etc/opamp-config.yaml --copy-path=/var/tmp/collector-config.yaml
-    depends_on:
-      signoz-telemetrystore-clickhouse-0-0:
-        condition: service_healthy
     deploy:
       replicas: 1
       resources:

--- a/docs/examples/docker/compose/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose/pours/deployment/compose.yaml
@@ -8,8 +8,18 @@ services:
     - |
       /signoz-otel-collector migrate sync check &&
       /signoz-otel-collector --config=/etc/otel-collector-config.yaml --manager-config=/etc/opamp-config.yaml --copy-path=/var/tmp/collector-config.yaml
+    depends_on:
+      signoz-telemetrystore-clickhouse-0-0:
+        condition: service_healthy
     deploy:
       replicas: 1
+      resources:
+        limits:
+          cpus: "1"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
       restart_policy:
         condition: on-failure
     entrypoint:

--- a/docs/examples/docker/compose/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/docker/compose/pours/deployment/ingester/ingester.yaml
@@ -36,13 +36,17 @@ extensions:
     endpoint: 0.0.0.0:13133
 processors:
   batch:
-    send_batch_max_size: 25000
-    send_batch_size: 20000
+    send_batch_max_size: 55000
+    send_batch_size: 50000
     timeout: 1s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000
     timeout: 1s
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
   signozspanmetrics/delta:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
     dimensions:
@@ -91,6 +95,7 @@ service:
       - clickhouselogsexporter
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -99,6 +104,7 @@ service:
       - signozclickhousemetrics
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -106,6 +112,7 @@ service:
       exporters:
       - signozclickhousemeter
       processors:
+      - memory_limiter
       - batch/meter
       receivers:
       - signozmeter
@@ -114,6 +121,7 @@ service:
       - clickhousetraces
       - signozmeter
       processors:
+      - memory_limiter
       - signozspanmetrics/delta
       - batch
       receivers:

--- a/docs/examples/docker/compose/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/docker/compose/pours/deployment/ingester/ingester.yaml
@@ -38,7 +38,7 @@ processors:
   batch:
     send_batch_max_size: 55000
     send_batch_size: 50000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000

--- a/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config.yaml
+++ b/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config.yaml
@@ -1,3 +1,5 @@
+asynchronous_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 dictionaries_config: '*_dictionary.xml'
 display_name: cluster
 distributed_ddl:
@@ -16,12 +18,23 @@ logger:
 macros:
   replica: "01"
   shard: "01"
+metric_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
+part_log:
+  ttl: event_date + INTERVAL 3 DAY DELETE
 path: /var/lib/clickhouse/
 profiles:
   default:
+    allow_simdjson: 0
     load_balancing: random
     log_queries: 1
-    max_memory_usage: 10000000000
+query_log:
+  flush_interval_milliseconds: 30000
+  partition_by: toYYYYMM(event_date)
+  ttl: event_date + INTERVAL 3 DAY DELETE
+query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 quotas:
   default:
     interval:
@@ -39,6 +52,9 @@ remote_servers:
         port: 9000
 tcp_port: 9000
 tmp_path: /var/lib/clickhouse/tmp/
+trace_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:

--- a/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config.yaml
+++ b/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config.yaml
@@ -4,9 +4,13 @@ dictionaries_config: '*_dictionary.xml'
 display_name: cluster
 distributed_ddl:
   path: /clickhouse/task_queue/ddl
+error_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 format_schema_path: /var/lib/clickhouse/format_schemas/
 http_port: 8123
 interserver_http_port: 9009
+latency_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 listen_host: 0.0.0.0
 logger:
   console: 1
@@ -24,6 +28,9 @@ metric_log:
 part_log:
   ttl: event_date + INTERVAL 3 DAY DELETE
 path: /var/lib/clickhouse/
+processors_profile_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 profiles:
   default:
     allow_simdjson: 0
@@ -33,7 +40,11 @@ query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
   ttl: event_date + INTERVAL 3 DAY DELETE
+query_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+query_views_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 quotas:
   default:
@@ -50,7 +61,12 @@ remote_servers:
     - replica:
       - host: signoz-telemetrystore-clickhouse-0-0
         port: 9000
+session_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 tcp_port: 9000
+text_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
@@ -76,3 +92,5 @@ zookeeper:
   node:
   - host: signoz-telemetrykeeper-clickhousekeeper-0
     port: 9181
+zookeeper_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE

--- a/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config.yaml
+++ b/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config.yaml
@@ -26,7 +26,7 @@ metric_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
 part_log:
-  ttl: event_date + INTERVAL 3 DAY DELETE
+  ttl: event_date + INTERVAL 1 DAY DELETE
 path: /var/lib/clickhouse/
 processors_profile_log:
   flush_interval_milliseconds: 30000
@@ -39,7 +39,7 @@ profiles:
 query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
-  ttl: event_date + INTERVAL 3 DAY DELETE
+  ttl: event_date + INTERVAL 1 DAY DELETE
 query_metric_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 query_thread_log:

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -455,7 +455,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -463,7 +463,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
@@ -575,7 +575,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -583,7 +583,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -458,6 +458,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -467,6 +471,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -560,6 +578,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -569,6 +591,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -177,7 +177,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -425,9 +425,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -450,6 +450,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -511,9 +527,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -536,6 +552,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -427,9 +427,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -452,6 +452,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -513,9 +529,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -538,6 +554,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -456,6 +456,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -465,6 +469,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -558,6 +576,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -567,6 +589,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -162,9 +170,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -242,6 +254,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -251,6 +264,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -259,6 +273,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -267,6 +282,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/docker/swarm/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/ingester/ingester.yaml
@@ -36,13 +36,17 @@ extensions:
     endpoint: 0.0.0.0:13133
 processors:
   batch:
-    send_batch_max_size: 25000
-    send_batch_size: 20000
+    send_batch_max_size: 55000
+    send_batch_size: 50000
     timeout: 1s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000
     timeout: 1s
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
   signozspanmetrics/delta:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
     dimensions:
@@ -91,6 +95,7 @@ service:
       - clickhouselogsexporter
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -99,6 +104,7 @@ service:
       - signozclickhousemetrics
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -106,6 +112,7 @@ service:
       exporters:
       - signozclickhousemeter
       processors:
+      - memory_limiter
       - batch/meter
       receivers:
       - signozmeter
@@ -114,6 +121,7 @@ service:
       - clickhousetraces
       - signozmeter
       processors:
+      - memory_limiter
       - signozspanmetrics/delta
       - batch
       receivers:

--- a/docs/examples/docker/swarm/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/ingester/ingester.yaml
@@ -38,7 +38,7 @@ processors:
   batch:
     send_batch_max_size: 55000
     send_batch_size: 50000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000

--- a/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config.yaml
@@ -1,3 +1,5 @@
+asynchronous_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 dictionaries_config: '*_dictionary.xml'
 display_name: cluster
 distributed_ddl:
@@ -16,12 +18,23 @@ logger:
 macros:
   replica: "01"
   shard: "01"
+metric_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
+part_log:
+  ttl: event_date + INTERVAL 3 DAY DELETE
 path: /var/lib/clickhouse/
 profiles:
   default:
+    allow_simdjson: 0
     load_balancing: random
     log_queries: 1
-    max_memory_usage: 10000000000
+query_log:
+  flush_interval_milliseconds: 30000
+  partition_by: toYYYYMM(event_date)
+  ttl: event_date + INTERVAL 3 DAY DELETE
+query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 quotas:
   default:
     interval:
@@ -39,6 +52,9 @@ remote_servers:
         port: 9000
 tcp_port: 9000
 tmp_path: /var/lib/clickhouse/tmp/
+trace_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:

--- a/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config.yaml
@@ -4,9 +4,13 @@ dictionaries_config: '*_dictionary.xml'
 display_name: cluster
 distributed_ddl:
   path: /clickhouse/task_queue/ddl
+error_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 format_schema_path: /var/lib/clickhouse/format_schemas/
 http_port: 8123
 interserver_http_port: 9009
+latency_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 listen_host: 0.0.0.0
 logger:
   console: 1
@@ -24,6 +28,9 @@ metric_log:
 part_log:
   ttl: event_date + INTERVAL 3 DAY DELETE
 path: /var/lib/clickhouse/
+processors_profile_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 profiles:
   default:
     allow_simdjson: 0
@@ -33,7 +40,11 @@ query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
   ttl: event_date + INTERVAL 3 DAY DELETE
+query_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+query_views_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 quotas:
   default:
@@ -50,7 +61,12 @@ remote_servers:
     - replica:
       - host: signoz-telemetrystore-clickhouse-0-0
         port: 9000
+session_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 tcp_port: 9000
+text_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
@@ -76,3 +92,5 @@ zookeeper:
   node:
   - host: signoz-telemetrykeeper-clickhousekeeper-0
     port: 9181
+zookeeper_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE

--- a/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config.yaml
@@ -26,7 +26,7 @@ metric_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
 part_log:
-  ttl: event_date + INTERVAL 3 DAY DELETE
+  ttl: event_date + INTERVAL 1 DAY DELETE
 path: /var/lib/clickhouse/
 processors_profile_log:
   flush_interval_milliseconds: 30000
@@ -39,7 +39,7 @@ profiles:
 query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
-  ttl: event_date + INTERVAL 3 DAY DELETE
+  ttl: event_date + INTERVAL 1 DAY DELETE
 query_metric_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 query_thread_log:

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -455,7 +455,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -463,7 +463,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
@@ -575,7 +575,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -583,7 +583,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -458,6 +458,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -467,6 +471,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -560,6 +578,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -569,6 +591,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -425,9 +425,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -450,6 +450,22 @@ spec:
               node:
                 - host: telemetrykeeper-clickhousekeeper.signoz.local
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -511,9 +527,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -536,6 +552,22 @@ spec:
               node:
                 - host: telemetrykeeper-clickhousekeeper.signoz.local
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -427,9 +427,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -452,6 +452,22 @@ spec:
               node:
                 - host: telemetrykeeper-clickhousekeeper.signoz.local
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -513,9 +529,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -538,6 +554,22 @@ spec:
               node:
                 - host: telemetrykeeper-clickhousekeeper.signoz.local
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -456,6 +456,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -465,6 +469,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -558,6 +576,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -567,6 +589,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -28,9 +28,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -108,6 +112,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -117,6 +122,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -125,6 +131,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -133,6 +140,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -162,9 +170,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -242,6 +254,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -251,6 +264,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -259,6 +273,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -267,6 +282,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -35,7 +35,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -177,7 +177,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/ingester/ingester.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/ingester/ingester.yaml
@@ -36,13 +36,17 @@ extensions:
     endpoint: 0.0.0.0:13133
 processors:
   batch:
-    send_batch_max_size: 25000
-    send_batch_size: 20000
+    send_batch_max_size: 55000
+    send_batch_size: 50000
     timeout: 1s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000
     timeout: 1s
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
   signozspanmetrics/delta:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
     dimensions:
@@ -91,6 +95,7 @@ service:
       - clickhouselogsexporter
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -99,6 +104,7 @@ service:
       - signozclickhousemetrics
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -106,6 +112,7 @@ service:
       exporters:
       - signozclickhousemeter
       processors:
+      - memory_limiter
       - batch/meter
       receivers:
       - signozmeter
@@ -114,6 +121,7 @@ service:
       - clickhousetraces
       - signozmeter
       processors:
+      - memory_limiter
       - signozspanmetrics/delta
       - batch
       receivers:

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/ingester/ingester.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/ingester/ingester.yaml
@@ -38,7 +38,7 @@ processors:
   batch:
     send_batch_max_size: 55000
     send_batch_size: 50000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config.yaml
@@ -1,3 +1,5 @@
+asynchronous_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 dictionaries_config: '*_dictionary.xml'
 display_name: cluster
 distributed_ddl:
@@ -16,12 +18,23 @@ logger:
 macros:
   replica: "01"
   shard: "01"
+metric_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
+part_log:
+  ttl: event_date + INTERVAL 3 DAY DELETE
 path: /var/lib/clickhouse/
 profiles:
   default:
+    allow_simdjson: 0
     load_balancing: random
     log_queries: 1
-    max_memory_usage: 10000000000
+query_log:
+  flush_interval_milliseconds: 30000
+  partition_by: toYYYYMM(event_date)
+  ttl: event_date + INTERVAL 3 DAY DELETE
+query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 quotas:
   default:
     interval:
@@ -39,6 +52,9 @@ remote_servers:
         port: 9000
 tcp_port: 9000
 tmp_path: /var/lib/clickhouse/tmp/
+trace_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config.yaml
@@ -4,9 +4,13 @@ dictionaries_config: '*_dictionary.xml'
 display_name: cluster
 distributed_ddl:
   path: /clickhouse/task_queue/ddl
+error_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 format_schema_path: /var/lib/clickhouse/format_schemas/
 http_port: 8123
 interserver_http_port: 9009
+latency_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 listen_host: 0.0.0.0
 logger:
   console: 1
@@ -24,6 +28,9 @@ metric_log:
 part_log:
   ttl: event_date + INTERVAL 3 DAY DELETE
 path: /var/lib/clickhouse/
+processors_profile_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 profiles:
   default:
     allow_simdjson: 0
@@ -33,7 +40,11 @@ query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
   ttl: event_date + INTERVAL 3 DAY DELETE
+query_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+query_views_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 quotas:
   default:
@@ -50,7 +61,12 @@ remote_servers:
     - replica:
       - host: telemetrystore-clickhouse.signoz.local
         port: 9000
+session_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 tcp_port: 9000
+text_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
@@ -76,3 +92,5 @@ zookeeper:
   node:
   - host: telemetrykeeper-clickhousekeeper.signoz.local
     port: 9181
+zookeeper_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config.yaml
@@ -26,7 +26,7 @@ metric_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
 part_log:
-  ttl: event_date + INTERVAL 3 DAY DELETE
+  ttl: event_date + INTERVAL 1 DAY DELETE
 path: /var/lib/clickhouse/
 processors_profile_log:
   flush_interval_milliseconds: 30000
@@ -39,7 +39,7 @@ profiles:
 query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
-  ttl: event_date + INTERVAL 3 DAY DELETE
+  ttl: event_date + INTERVAL 1 DAY DELETE
 query_metric_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 query_thread_log:

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -425,9 +425,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -450,6 +450,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-zookeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -511,9 +527,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -536,6 +552,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-zookeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -453,7 +453,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -461,7 +461,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
@@ -573,7 +573,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -581,7 +581,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -161,9 +169,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -241,6 +253,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -250,6 +263,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -258,6 +272,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -266,6 +281,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -176,7 +176,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -456,6 +456,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -465,6 +469,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -558,6 +576,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -567,6 +589,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -454,6 +454,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -463,6 +467,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -556,6 +574,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -565,6 +587,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -423,9 +423,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -448,6 +448,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-zookeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -509,9 +525,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -534,6 +550,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-zookeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -443,7 +443,7 @@ spec:
               flush_interval_milliseconds: 30000
               ttl: event_date + INTERVAL 1 DAY DELETE
             part_log:
-              ttl: event_date + INTERVAL 3 DAY DELETE
+              ttl: event_date + INTERVAL 1 DAY DELETE
             path: /var/lib/clickhouse/
             processors_profile_log:
               flush_interval_milliseconds: 30000
@@ -468,7 +468,7 @@ spec:
             query_log:
               flush_interval_milliseconds: 30000
               partition_by: toYYYYMM(event_date)
-              ttl: event_date + INTERVAL 3 DAY DELETE
+              ttl: event_date + INTERVAL 1 DAY DELETE
             query_metric_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             query_thread_log:
@@ -617,7 +617,7 @@ spec:
               flush_interval_milliseconds: 30000
               ttl: event_date + INTERVAL 1 DAY DELETE
             part_log:
-              ttl: event_date + INTERVAL 3 DAY DELETE
+              ttl: event_date + INTERVAL 1 DAY DELETE
             path: /var/lib/clickhouse/
             processors_profile_log:
               flush_interval_milliseconds: 30000
@@ -642,7 +642,7 @@ spec:
             query_log:
               flush_interval_milliseconds: 30000
               partition_by: toYYYYMM(event_date)
-              ttl: event_date + INTERVAL 3 DAY DELETE
+              ttl: event_date + INTERVAL 1 DAY DELETE
             query_metric_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             query_thread_log:

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -401,6 +401,8 @@ spec:
         data:
           config.yaml: |
             async_load_databases: false
+            asynchronous_metric_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             dictionaries_config: '*_dictionary.xml'
             display_name: cluster
             distributed_ddl:
@@ -435,6 +437,11 @@ spec:
               shard: "01"
             merge_tree:
               storage_policy: data
+            metric_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
+            part_log:
+              ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
             profiles:
               admin:
@@ -444,17 +451,23 @@ spec:
               default:
                 allow_experimental_window_functions: "1"
                 allow_nondeterministic_mutations: "1"
+                allow_simdjson: 0
                 load_balancing: random
                 log_queries: 1
-                max_memory_usage: 10000000000
                 max_threads: 16
                 query_plan_max_limit_for_lazy_materialization: "0"
                 secondary_indices_enable_bulk_filtering: "0"
             prometheus:
               endpoint: /metrics
               port: 9363
+            query_log:
+              flush_interval_milliseconds: 30000
+              partition_by: toYYYYMM(event_date)
+              ttl: event_date + INTERVAL 3 DAY DELETE
             query_metric_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
+            query_thread_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
                 interval:
@@ -491,6 +504,9 @@ spec:
             text_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             tmp_path: /var/lib/clickhouse/tmp/
+            trace_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             user_defined_executable_functions_config: /etc/clickhouse-server/functions/custom-functions.xml
             user_directories:
               users_xml:
@@ -549,6 +565,8 @@ spec:
         data:
           config.yaml: |
             async_load_databases: false
+            asynchronous_metric_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             dictionaries_config: '*_dictionary.xml'
             display_name: cluster
             distributed_ddl:
@@ -583,6 +601,11 @@ spec:
               shard: "01"
             merge_tree:
               storage_policy: data
+            metric_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
+            part_log:
+              ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
             profiles:
               admin:
@@ -592,17 +615,23 @@ spec:
               default:
                 allow_experimental_window_functions: "1"
                 allow_nondeterministic_mutations: "1"
+                allow_simdjson: 0
                 load_balancing: random
                 log_queries: 1
-                max_memory_usage: 10000000000
                 max_threads: 16
                 query_plan_max_limit_for_lazy_materialization: "0"
                 secondary_indices_enable_bulk_filtering: "0"
             prometheus:
               endpoint: /metrics
               port: 9363
+            query_log:
+              flush_interval_milliseconds: 30000
+              partition_by: toYYYYMM(event_date)
+              ttl: event_date + INTERVAL 3 DAY DELETE
             query_metric_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
+            query_thread_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
                 interval:
@@ -639,6 +668,9 @@ spec:
             text_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             tmp_path: /var/lib/clickhouse/tmp/
+            trace_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             user_defined_executable_functions_config: /etc/clickhouse-server/functions/custom-functions.xml
             user_directories:
               users_xml:

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -445,6 +445,9 @@ spec:
             part_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
+            processors_profile_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             profiles:
               admin:
                 max_threads: 16
@@ -470,6 +473,8 @@ spec:
               ttl: event_date + INTERVAL 3 DAY DELETE
             query_thread_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
+            query_views_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
                 interval:
@@ -487,6 +492,8 @@ spec:
                     port: 9000
             send_crash_reports:
               enabled: false
+            session_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             storage_configuration:
               disks:
                 data0:
@@ -504,6 +511,7 @@ spec:
                       disk: default
             tcp_port: 9000
             text_log:
+              flush_interval_milliseconds: 30000
               ttl: event_date + INTERVAL 3 DAY DELETE
             tmp_path: /var/lib/clickhouse/tmp/
             trace_log:
@@ -542,6 +550,8 @@ spec:
               node:
               - host: signoz-clickhouse-keeper-0
                 port: 9181
+            zookeeper_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
           functions.yaml: |
             functions:
               argument:
@@ -609,6 +619,9 @@ spec:
             part_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
+            processors_profile_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             profiles:
               admin:
                 max_threads: 16
@@ -634,6 +647,8 @@ spec:
               ttl: event_date + INTERVAL 3 DAY DELETE
             query_thread_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
+            query_views_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
                 interval:
@@ -651,6 +666,8 @@ spec:
                     port: 9000
             send_crash_reports:
               enabled: false
+            session_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             storage_configuration:
               disks:
                 data0:
@@ -668,6 +685,7 @@ spec:
                       disk: default
             tcp_port: 9000
             text_log:
+              flush_interval_milliseconds: 30000
               ttl: event_date + INTERVAL 3 DAY DELETE
             tmp_path: /var/lib/clickhouse/tmp/
             trace_log:
@@ -706,6 +724,8 @@ spec:
               node:
               - host: signoz-clickhouse-keeper-0
                 port: 9181
+            zookeeper_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
           functions.yaml: |
             functions:
               argument:

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -161,9 +169,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -241,6 +253,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -250,6 +263,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -258,6 +272,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -266,6 +281,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -176,7 +176,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -403,6 +403,8 @@ spec:
         data:
           config.yaml: |
             async_load_databases: false
+            asynchronous_metric_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             dictionaries_config: '*_dictionary.xml'
             display_name: cluster
             distributed_ddl:
@@ -437,6 +439,11 @@ spec:
               shard: "01"
             merge_tree:
               storage_policy: data
+            metric_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
+            part_log:
+              ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
             profiles:
               admin:
@@ -446,17 +453,23 @@ spec:
               default:
                 allow_experimental_window_functions: "1"
                 allow_nondeterministic_mutations: "1"
+                allow_simdjson: 0
                 load_balancing: random
                 log_queries: 1
-                max_memory_usage: 10000000000
                 max_threads: 16
                 query_plan_max_limit_for_lazy_materialization: "0"
                 secondary_indices_enable_bulk_filtering: "0"
             prometheus:
               endpoint: /metrics
               port: 9363
+            query_log:
+              flush_interval_milliseconds: 30000
+              partition_by: toYYYYMM(event_date)
+              ttl: event_date + INTERVAL 3 DAY DELETE
             query_metric_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
+            query_thread_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
                 interval:
@@ -493,6 +506,9 @@ spec:
             text_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             tmp_path: /var/lib/clickhouse/tmp/
+            trace_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             user_defined_executable_functions_config: /etc/clickhouse-server/functions/custom-functions.xml
             user_directories:
               users_xml:
@@ -551,6 +567,8 @@ spec:
         data:
           config.yaml: |
             async_load_databases: false
+            asynchronous_metric_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             dictionaries_config: '*_dictionary.xml'
             display_name: cluster
             distributed_ddl:
@@ -585,6 +603,11 @@ spec:
               shard: "01"
             merge_tree:
               storage_policy: data
+            metric_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
+            part_log:
+              ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
             profiles:
               admin:
@@ -594,17 +617,23 @@ spec:
               default:
                 allow_experimental_window_functions: "1"
                 allow_nondeterministic_mutations: "1"
+                allow_simdjson: 0
                 load_balancing: random
                 log_queries: 1
-                max_memory_usage: 10000000000
                 max_threads: 16
                 query_plan_max_limit_for_lazy_materialization: "0"
                 secondary_indices_enable_bulk_filtering: "0"
             prometheus:
               endpoint: /metrics
               port: 9363
+            query_log:
+              flush_interval_milliseconds: 30000
+              partition_by: toYYYYMM(event_date)
+              ttl: event_date + INTERVAL 3 DAY DELETE
             query_metric_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
+            query_thread_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
                 interval:
@@ -641,6 +670,9 @@ spec:
             text_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             tmp_path: /var/lib/clickhouse/tmp/
+            trace_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             user_defined_executable_functions_config: /etc/clickhouse-server/functions/custom-functions.xml
             user_directories:
               users_xml:

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -443,6 +443,9 @@ spec:
             part_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
+            processors_profile_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             profiles:
               admin:
                 max_threads: 16
@@ -468,6 +471,8 @@ spec:
               ttl: event_date + INTERVAL 3 DAY DELETE
             query_thread_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
+            query_views_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
                 interval:
@@ -485,6 +490,8 @@ spec:
                     port: 9000
             send_crash_reports:
               enabled: false
+            session_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             storage_configuration:
               disks:
                 data0:
@@ -502,6 +509,7 @@ spec:
                       disk: default
             tcp_port: 9000
             text_log:
+              flush_interval_milliseconds: 30000
               ttl: event_date + INTERVAL 3 DAY DELETE
             tmp_path: /var/lib/clickhouse/tmp/
             trace_log:
@@ -540,6 +548,8 @@ spec:
               node:
               - host: signoz-clickhouse-keeper-0
                 port: 9181
+            zookeeper_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
           functions.yaml: |
             functions:
               argument:
@@ -607,6 +617,9 @@ spec:
             part_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
+            processors_profile_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             profiles:
               admin:
                 max_threads: 16
@@ -632,6 +645,8 @@ spec:
               ttl: event_date + INTERVAL 3 DAY DELETE
             query_thread_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
+            query_views_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
                 interval:
@@ -649,6 +664,8 @@ spec:
                     port: 9000
             send_crash_reports:
               enabled: false
+            session_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             storage_configuration:
               disks:
                 data0:
@@ -666,6 +683,7 @@ spec:
                       disk: default
             tcp_port: 9000
             text_log:
+              flush_interval_milliseconds: 30000
               ttl: event_date + INTERVAL 3 DAY DELETE
             tmp_path: /var/lib/clickhouse/tmp/
             trace_log:
@@ -704,6 +722,8 @@ spec:
               node:
               - host: signoz-clickhouse-keeper-0
                 port: 9181
+            zookeeper_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
           functions.yaml: |
             functions:
               argument:

--- a/docs/examples/kubernetes/kustomize/pours/deployment/ingester/configmap.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/ingester/configmap.yaml
@@ -23,7 +23,7 @@ data:
       batch:
         send_batch_size: 50000
         send_batch_max_size: 55000
-        timeout: 1s
+        timeout: 5s
       batch/meter:
         send_batch_size: 20000
         send_batch_max_size: 25000

--- a/docs/examples/kubernetes/kustomize/pours/deployment/ingester/configmap.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/ingester/configmap.yaml
@@ -16,9 +16,13 @@ data:
           http:
             endpoint: "0.0.0.0:4318"
     processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
       batch:
-        send_batch_size: 20000
-        send_batch_max_size: 25000
+        send_batch_size: 50000
+        send_batch_max_size: 55000
         timeout: 1s
       batch/meter:
         send_batch_size: 20000
@@ -96,6 +100,7 @@ data:
           receivers:
             - otlp
           processors:
+            - memory_limiter
             - signozspanmetrics/delta
             - batch
           exporters:
@@ -105,6 +110,7 @@ data:
           receivers:
             - otlp
           processors:
+            - memory_limiter
             - batch
           exporters:
             - signozclickhousemetrics
@@ -113,6 +119,7 @@ data:
           receivers:
             - otlp
           processors:
+            - memory_limiter
             - batch
           exporters:
             - clickhouselogsexporter
@@ -121,6 +128,7 @@ data:
           receivers:
             - signozmeter
           processors:
+            - memory_limiter
             - batch/meter
           exporters:
             - signozclickhousemeter

--- a/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
@@ -21,12 +21,28 @@ spec:
         send_crash_reports:
           enabled: false
       config.d/extra.yaml: |
+        asynchronous_metric_log:
+          ttl: event_date + INTERVAL 1 DAY DELETE
         dictionaries_config: '*_dictionary.xml'
         format_schema_path: /etc/clickhouse-server/config.d/
+        metric_log:
+          flush_interval_milliseconds: 30000
+          ttl: event_date + INTERVAL 1 DAY DELETE
+        part_log:
+          ttl: event_date + INTERVAL 3 DAY DELETE
         prometheus:
           endpoint: /metrics
           port: 9363
+        query_log:
+          flush_interval_milliseconds: 30000
+          partition_by: toYYYYMM(event_date)
+          ttl: event_date + INTERVAL 3 DAY DELETE
+        query_thread_log:
+          ttl: event_date + INTERVAL 1 DAY DELETE
         tmp_path: /var/lib/clickhouse/tmp/
+        trace_log:
+          flush_interval_milliseconds: 30000
+          ttl: event_date + INTERVAL 1 DAY DELETE
         user_defined_executable_functions_config: /etc/clickhouse-server/functions/custom-functions.xml
         user_directories:
           users_xml:
@@ -100,9 +116,9 @@ spec:
       admin/secondary_indices_enable_bulk_filtering: "0"
       default/allow_experimental_window_functions: "1"
       default/allow_nondeterministic_mutations: "1"
+      default/allow_simdjson: 0
       default/load_balancing: random
       default/log_queries: 1
-      default/max_memory_usage: 10000000000
       default/max_threads: 16
       default/query_plan_max_limit_for_lazy_materialization: "0"
       default/secondary_indices_enable_bulk_filtering: "0"

--- a/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
@@ -30,6 +30,9 @@ spec:
           ttl: event_date + INTERVAL 1 DAY DELETE
         part_log:
           ttl: event_date + INTERVAL 3 DAY DELETE
+        processors_profile_log:
+          flush_interval_milliseconds: 30000
+          ttl: event_date + INTERVAL 1 DAY DELETE
         prometheus:
           endpoint: /metrics
           port: 9363
@@ -38,6 +41,10 @@ spec:
           partition_by: toYYYYMM(event_date)
           ttl: event_date + INTERVAL 3 DAY DELETE
         query_thread_log:
+          ttl: event_date + INTERVAL 1 DAY DELETE
+        query_views_log:
+          ttl: event_date + INTERVAL 1 DAY DELETE
+        session_log:
           ttl: event_date + INTERVAL 1 DAY DELETE
         tmp_path: /var/lib/clickhouse/tmp/
         trace_log:
@@ -49,6 +56,8 @@ spec:
             path: users.xml
         user_files_path: /var/lib/clickhouse/user_files/
         user_scripts_path: /var/lib/clickhouse/user_scripts/
+        zookeeper_log:
+          ttl: event_date + INTERVAL 1 DAY DELETE
       config.d/formatting.yaml: |
         logger:
           console: 1
@@ -97,6 +106,7 @@ spec:
         query_metric_log:
           ttl: event_date + INTERVAL 3 DAY DELETE
         text_log:
+          flush_interval_milliseconds: 30000
           ttl: event_date + INTERVAL 3 DAY DELETE
       events.proto: |
         syntax = "proto3";

--- a/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
@@ -29,7 +29,7 @@ spec:
           flush_interval_milliseconds: 30000
           ttl: event_date + INTERVAL 1 DAY DELETE
         part_log:
-          ttl: event_date + INTERVAL 3 DAY DELETE
+          ttl: event_date + INTERVAL 1 DAY DELETE
         processors_profile_log:
           flush_interval_milliseconds: 30000
           ttl: event_date + INTERVAL 1 DAY DELETE
@@ -39,7 +39,7 @@ spec:
         query_log:
           flush_interval_milliseconds: 30000
           partition_by: toYYYYMM(event_date)
-          ttl: event_date + INTERVAL 3 DAY DELETE
+          ttl: event_date + INTERVAL 1 DAY DELETE
         query_thread_log:
           ttl: event_date + INTERVAL 1 DAY DELETE
         query_views_log:

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -424,9 +424,13 @@ spec:
             display_name: cluster
             distributed_ddl:
               path: /clickhouse/task_queue/ddl
+            error_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             format_schema_path: /var/lib/clickhouse/format_schemas/
             http_port: 8123
             interserver_http_port: 9009
+            latency_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             listen_host: '::'
             logger:
               console: 1
@@ -444,6 +448,9 @@ spec:
             part_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
+            processors_profile_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             profiles:
               default:
                 allow_simdjson: 0
@@ -453,7 +460,11 @@ spec:
               flush_interval_milliseconds: 30000
               partition_by: toYYYYMM(event_date)
               ttl: event_date + INTERVAL 3 DAY DELETE
+            query_metric_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             query_thread_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
+            query_views_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
@@ -470,7 +481,12 @@ spec:
                 - replica:
                     host: localhost
                     port: 9000
+            session_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             tcp_port: 9000
+            text_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             tmp_path: /var/lib/clickhouse/tmp/
             trace_log:
               flush_interval_milliseconds: 30000
@@ -496,6 +512,8 @@ spec:
               node:
               - host: signoz-telemetrykeeper-clickhousekeeper.railway.internal
                 port: 9181
+            zookeeper_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
           functions.yaml: |
             functions:
               argument:
@@ -526,9 +544,13 @@ spec:
             display_name: cluster
             distributed_ddl:
               path: /clickhouse/task_queue/ddl
+            error_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             format_schema_path: /var/lib/clickhouse/format_schemas/
             http_port: 8123
             interserver_http_port: 9009
+            latency_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             listen_host: '::'
             logger:
               console: 1
@@ -546,6 +568,9 @@ spec:
             part_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
+            processors_profile_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             profiles:
               default:
                 allow_simdjson: 0
@@ -555,7 +580,11 @@ spec:
               flush_interval_milliseconds: 30000
               partition_by: toYYYYMM(event_date)
               ttl: event_date + INTERVAL 3 DAY DELETE
+            query_metric_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             query_thread_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
+            query_views_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
@@ -572,7 +601,12 @@ spec:
                 - replica:
                     host: localhost
                     port: 9000
+            session_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             tcp_port: 9000
+            text_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             tmp_path: /var/lib/clickhouse/tmp/
             trace_log:
               flush_interval_milliseconds: 30000
@@ -598,6 +632,8 @@ spec:
               node:
               - host: signoz-telemetrykeeper-clickhousekeeper.railway.internal
                 port: 9181
+            zookeeper_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
           functions.yaml: |
             functions:
               argument:

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -448,7 +448,7 @@ spec:
               flush_interval_milliseconds: 30000
               ttl: event_date + INTERVAL 1 DAY DELETE
             part_log:
-              ttl: event_date + INTERVAL 3 DAY DELETE
+              ttl: event_date + INTERVAL 1 DAY DELETE
             path: /var/lib/clickhouse/
             processors_profile_log:
               flush_interval_milliseconds: 30000
@@ -461,7 +461,7 @@ spec:
             query_log:
               flush_interval_milliseconds: 30000
               partition_by: toYYYYMM(event_date)
-              ttl: event_date + INTERVAL 3 DAY DELETE
+              ttl: event_date + INTERVAL 1 DAY DELETE
             query_metric_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
             query_thread_log:
@@ -568,7 +568,7 @@ spec:
               flush_interval_milliseconds: 30000
               ttl: event_date + INTERVAL 1 DAY DELETE
             part_log:
-              ttl: event_date + INTERVAL 3 DAY DELETE
+              ttl: event_date + INTERVAL 1 DAY DELETE
             path: /var/lib/clickhouse/
             processors_profile_log:
               flush_interval_milliseconds: 30000
@@ -581,7 +581,7 @@ spec:
             query_log:
               flush_interval_milliseconds: 30000
               partition_by: toYYYYMM(event_date)
-              ttl: event_date + INTERVAL 3 DAY DELETE
+              ttl: event_date + INTERVAL 1 DAY DELETE
             query_metric_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
             query_thread_log:

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -177,7 +177,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -418,6 +418,8 @@ spec:
       config:
         data:
           config.yaml: |
+            asynchronous_metric_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             dictionaries_config: '*_dictionary.xml'
             display_name: cluster
             distributed_ddl:
@@ -436,12 +438,23 @@ spec:
             macros:
               replica: "01"
               shard: "01"
+            metric_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
+            part_log:
+              ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
             profiles:
               default:
+                allow_simdjson: 0
                 load_balancing: random
                 log_queries: 1
-                max_memory_usage: 10000000000
+            query_log:
+              flush_interval_milliseconds: 30000
+              partition_by: toYYYYMM(event_date)
+              ttl: event_date + INTERVAL 3 DAY DELETE
+            query_thread_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
                 interval:
@@ -459,6 +472,9 @@ spec:
                     port: 9000
             tcp_port: 9000
             tmp_path: /var/lib/clickhouse/tmp/
+            trace_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             user_defined_executable_functions_config: '*function.yaml'
             user_directories:
               users_xml:
@@ -504,6 +520,8 @@ spec:
       config:
         data:
           config.yaml: |
+            asynchronous_metric_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             dictionaries_config: '*_dictionary.xml'
             display_name: cluster
             distributed_ddl:
@@ -522,12 +540,23 @@ spec:
             macros:
               replica: "01"
               shard: "01"
+            metric_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
+            part_log:
+              ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
             profiles:
               default:
+                allow_simdjson: 0
                 load_balancing: random
                 log_queries: 1
-                max_memory_usage: 10000000000
+            query_log:
+              flush_interval_milliseconds: 30000
+              partition_by: toYYYYMM(event_date)
+              ttl: event_date + INTERVAL 3 DAY DELETE
+            query_thread_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
                 interval:
@@ -545,6 +574,9 @@ spec:
                     port: 9000
             tcp_port: 9000
             tmp_path: /var/lib/clickhouse/tmp/
+            trace_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             user_defined_executable_functions_config: '*function.yaml'
             user_directories:
               users_xml:

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -420,6 +420,8 @@ spec:
       config:
         data:
           config.yaml: |
+            asynchronous_metric_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             dictionaries_config: '*_dictionary.xml'
             display_name: cluster
             distributed_ddl:
@@ -438,12 +440,23 @@ spec:
             macros:
               replica: "01"
               shard: "01"
+            metric_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
+            part_log:
+              ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
             profiles:
               default:
+                allow_simdjson: 0
                 load_balancing: random
                 log_queries: 1
-                max_memory_usage: 10000000000
+            query_log:
+              flush_interval_milliseconds: 30000
+              partition_by: toYYYYMM(event_date)
+              ttl: event_date + INTERVAL 3 DAY DELETE
+            query_thread_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
                 interval:
@@ -461,6 +474,9 @@ spec:
                     port: 9000
             tcp_port: 9000
             tmp_path: /var/lib/clickhouse/tmp/
+            trace_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             user_defined_executable_functions_config: '*function.yaml'
             user_directories:
               users_xml:
@@ -506,6 +522,8 @@ spec:
       config:
         data:
           config.yaml: |
+            asynchronous_metric_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             dictionaries_config: '*_dictionary.xml'
             display_name: cluster
             distributed_ddl:
@@ -524,12 +542,23 @@ spec:
             macros:
               replica: "01"
               shard: "01"
+            metric_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
+            part_log:
+              ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
             profiles:
               default:
+                allow_simdjson: 0
                 load_balancing: random
                 log_queries: 1
-                max_memory_usage: 10000000000
+            query_log:
+              flush_interval_milliseconds: 30000
+              partition_by: toYYYYMM(event_date)
+              ttl: event_date + INTERVAL 3 DAY DELETE
+            query_thread_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
                 interval:
@@ -547,6 +576,9 @@ spec:
                     port: 9000
             tcp_port: 9000
             tmp_path: /var/lib/clickhouse/tmp/
+            trace_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             user_defined_executable_functions_config: '*function.yaml'
             user_directories:
               users_xml:

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -426,9 +426,13 @@ spec:
             display_name: cluster
             distributed_ddl:
               path: /clickhouse/task_queue/ddl
+            error_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             format_schema_path: /var/lib/clickhouse/format_schemas/
             http_port: 8123
             interserver_http_port: 9009
+            latency_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             listen_host: '::'
             logger:
               console: 1
@@ -446,6 +450,9 @@ spec:
             part_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
+            processors_profile_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             profiles:
               default:
                 allow_simdjson: 0
@@ -455,7 +462,11 @@ spec:
               flush_interval_milliseconds: 30000
               partition_by: toYYYYMM(event_date)
               ttl: event_date + INTERVAL 3 DAY DELETE
+            query_metric_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             query_thread_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
+            query_views_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
@@ -472,7 +483,12 @@ spec:
                 - replica:
                     host: localhost
                     port: 9000
+            session_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             tcp_port: 9000
+            text_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             tmp_path: /var/lib/clickhouse/tmp/
             trace_log:
               flush_interval_milliseconds: 30000
@@ -498,6 +514,8 @@ spec:
               node:
               - host: signoz-telemetrykeeper-clickhousekeeper.railway.internal
                 port: 9181
+            zookeeper_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
           functions.yaml: |
             functions:
               argument:
@@ -528,9 +546,13 @@ spec:
             display_name: cluster
             distributed_ddl:
               path: /clickhouse/task_queue/ddl
+            error_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             format_schema_path: /var/lib/clickhouse/format_schemas/
             http_port: 8123
             interserver_http_port: 9009
+            latency_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             listen_host: '::'
             logger:
               console: 1
@@ -548,6 +570,9 @@ spec:
             part_log:
               ttl: event_date + INTERVAL 3 DAY DELETE
             path: /var/lib/clickhouse/
+            processors_profile_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             profiles:
               default:
                 allow_simdjson: 0
@@ -557,7 +582,11 @@ spec:
               flush_interval_milliseconds: 30000
               partition_by: toYYYYMM(event_date)
               ttl: event_date + INTERVAL 3 DAY DELETE
+            query_metric_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             query_thread_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
+            query_views_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
             quotas:
               default:
@@ -574,7 +603,12 @@ spec:
                 - replica:
                     host: localhost
                     port: 9000
+            session_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
             tcp_port: 9000
+            text_log:
+              flush_interval_milliseconds: 30000
+              ttl: event_date + INTERVAL 1 DAY DELETE
             tmp_path: /var/lib/clickhouse/tmp/
             trace_log:
               flush_interval_milliseconds: 30000
@@ -600,6 +634,8 @@ spec:
               node:
               - host: signoz-telemetrykeeper-clickhousekeeper.railway.internal
                 port: 9181
+            zookeeper_log:
+              ttl: event_date + INTERVAL 1 DAY DELETE
           functions.yaml: |
             functions:
               argument:

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -162,9 +170,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -242,6 +254,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -251,6 +264,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -259,6 +273,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -267,6 +282,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/railway/template/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/railway/template/pours/deployment/ingester/ingester.yaml
@@ -36,13 +36,17 @@ extensions:
     endpoint: 0.0.0.0:13133
 processors:
   batch:
-    send_batch_max_size: 25000
-    send_batch_size: 20000
+    send_batch_max_size: 55000
+    send_batch_size: 50000
     timeout: 1s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000
     timeout: 1s
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
   signozspanmetrics/delta:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
     dimensions:
@@ -91,6 +95,7 @@ service:
       - clickhouselogsexporter
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -99,6 +104,7 @@ service:
       - signozclickhousemetrics
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -106,6 +112,7 @@ service:
       exporters:
       - signozclickhousemeter
       processors:
+      - memory_limiter
       - batch/meter
       receivers:
       - signozmeter
@@ -114,6 +121,7 @@ service:
       - clickhousetraces
       - signozmeter
       processors:
+      - memory_limiter
       - signozspanmetrics/delta
       - batch
       receivers:

--- a/docs/examples/railway/template/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/railway/template/pours/deployment/ingester/ingester.yaml
@@ -38,7 +38,7 @@ processors:
   batch:
     send_batch_max_size: 55000
     send_batch_size: 50000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000

--- a/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config.yaml
+++ b/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config.yaml
@@ -4,9 +4,13 @@ dictionaries_config: '*_dictionary.xml'
 display_name: cluster
 distributed_ddl:
   path: /clickhouse/task_queue/ddl
+error_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 format_schema_path: /var/lib/clickhouse/format_schemas/
 http_port: 8123
 interserver_http_port: 9009
+latency_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 listen_host: '::'
 logger:
   console: 1
@@ -24,6 +28,9 @@ metric_log:
 part_log:
   ttl: event_date + INTERVAL 3 DAY DELETE
 path: /var/lib/clickhouse/
+processors_profile_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 profiles:
   default:
     allow_simdjson: 0
@@ -33,7 +40,11 @@ query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
   ttl: event_date + INTERVAL 3 DAY DELETE
+query_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+query_views_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 quotas:
   default:
@@ -50,7 +61,12 @@ remote_servers:
     - replica:
         host: localhost
         port: 9000
+session_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 tcp_port: 9000
+text_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
@@ -76,3 +92,5 @@ zookeeper:
   node:
   - host: signoz-telemetrykeeper-clickhousekeeper.railway.internal
     port: 9181
+zookeeper_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE

--- a/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config.yaml
+++ b/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config.yaml
@@ -1,3 +1,5 @@
+asynchronous_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 dictionaries_config: '*_dictionary.xml'
 display_name: cluster
 distributed_ddl:
@@ -16,12 +18,23 @@ logger:
 macros:
   replica: "01"
   shard: "01"
+metric_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
+part_log:
+  ttl: event_date + INTERVAL 3 DAY DELETE
 path: /var/lib/clickhouse/
 profiles:
   default:
+    allow_simdjson: 0
     load_balancing: random
     log_queries: 1
-    max_memory_usage: 10000000000
+query_log:
+  flush_interval_milliseconds: 30000
+  partition_by: toYYYYMM(event_date)
+  ttl: event_date + INTERVAL 3 DAY DELETE
+query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 quotas:
   default:
     interval:
@@ -39,6 +52,9 @@ remote_servers:
         port: 9000
 tcp_port: 9000
 tmp_path: /var/lib/clickhouse/tmp/
+trace_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:

--- a/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config.yaml
+++ b/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config.yaml
@@ -26,7 +26,7 @@ metric_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
 part_log:
-  ttl: event_date + INTERVAL 3 DAY DELETE
+  ttl: event_date + INTERVAL 1 DAY DELETE
 path: /var/lib/clickhouse/
 processors_profile_log:
   flush_interval_milliseconds: 30000
@@ -39,7 +39,7 @@ profiles:
 query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
-  ttl: event_date + INTERVAL 3 DAY DELETE
+  ttl: event_date + INTERVAL 1 DAY DELETE
 query_metric_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 query_thread_log:

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -455,6 +455,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -464,6 +468,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -557,6 +575,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -566,6 +588,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -34,7 +34,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -177,7 +177,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -454,7 +454,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -462,7 +462,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
@@ -574,7 +574,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -582,7 +582,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -424,9 +424,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -449,6 +449,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -510,9 +526,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -535,6 +551,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -457,6 +457,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -466,6 +470,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -559,6 +577,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -568,6 +590,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -426,9 +426,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -451,6 +451,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -512,9 +528,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -537,6 +553,22 @@ spec:
               node:
                 - host: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -27,9 +27,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -107,6 +111,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -116,6 +121,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -124,6 +130,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -132,6 +139,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -162,9 +170,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -242,6 +254,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -251,6 +264,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -259,6 +273,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -267,6 +282,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/render/blueprint/pours/deployment/configs/ingester/ingester.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/ingester/ingester.yaml
@@ -36,13 +36,17 @@ extensions:
     endpoint: 0.0.0.0:13133
 processors:
   batch:
-    send_batch_max_size: 25000
-    send_batch_size: 20000
+    send_batch_max_size: 55000
+    send_batch_size: 50000
     timeout: 1s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000
     timeout: 1s
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
   signozspanmetrics/delta:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
     dimensions:
@@ -91,6 +95,7 @@ service:
       - clickhouselogsexporter
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -99,6 +104,7 @@ service:
       - signozclickhousemetrics
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -106,6 +112,7 @@ service:
       exporters:
       - signozclickhousemeter
       processors:
+      - memory_limiter
       - batch/meter
       receivers:
       - signozmeter
@@ -114,6 +121,7 @@ service:
       - clickhousetraces
       - signozmeter
       processors:
+      - memory_limiter
       - signozspanmetrics/delta
       - batch
       receivers:

--- a/docs/examples/render/blueprint/pours/deployment/configs/ingester/ingester.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/ingester/ingester.yaml
@@ -38,7 +38,7 @@ processors:
   batch:
     send_batch_max_size: 55000
     send_batch_size: 50000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config.yaml
@@ -1,3 +1,5 @@
+asynchronous_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 dictionaries_config: '*_dictionary.xml'
 display_name: cluster
 distributed_ddl:
@@ -16,12 +18,23 @@ logger:
 macros:
   replica: "01"
   shard: "01"
+metric_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
+part_log:
+  ttl: event_date + INTERVAL 3 DAY DELETE
 path: /var/lib/clickhouse/
 profiles:
   default:
+    allow_simdjson: 0
     load_balancing: random
     log_queries: 1
-    max_memory_usage: 10000000000
+query_log:
+  flush_interval_milliseconds: 30000
+  partition_by: toYYYYMM(event_date)
+  ttl: event_date + INTERVAL 3 DAY DELETE
+query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 quotas:
   default:
     interval:
@@ -39,6 +52,9 @@ remote_servers:
         port: 9000
 tcp_port: 9000
 tmp_path: /var/lib/clickhouse/tmp/
+trace_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config.yaml
@@ -4,9 +4,13 @@ dictionaries_config: '*_dictionary.xml'
 display_name: cluster
 distributed_ddl:
   path: /clickhouse/task_queue/ddl
+error_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 format_schema_path: /var/lib/clickhouse/format_schemas/
 http_port: 8123
 interserver_http_port: 9009
+latency_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 listen_host: 0.0.0.0
 logger:
   console: 1
@@ -24,6 +28,9 @@ metric_log:
 part_log:
   ttl: event_date + INTERVAL 3 DAY DELETE
 path: /var/lib/clickhouse/
+processors_profile_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 profiles:
   default:
     allow_simdjson: 0
@@ -33,7 +40,11 @@ query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
   ttl: event_date + INTERVAL 3 DAY DELETE
+query_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+query_views_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 quotas:
   default:
@@ -50,7 +61,12 @@ remote_servers:
     - replica:
       - host: signoz-telemetrystore-clickhouse-0-0
         port: 9000
+session_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 tcp_port: 9000
+text_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
@@ -76,3 +92,5 @@ zookeeper:
   node:
   - host: signoz-telemetrykeeper-clickhousekeeper-0
     port: 9181
+zookeeper_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config.yaml
@@ -26,7 +26,7 @@ metric_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
 part_log:
-  ttl: event_date + INTERVAL 3 DAY DELETE
+  ttl: event_date + INTERVAL 1 DAY DELETE
 path: /var/lib/clickhouse/
 processors_profile_log:
   flush_interval_milliseconds: 30000
@@ -39,7 +39,7 @@ profiles:
 query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
-  ttl: event_date + INTERVAL 3 DAY DELETE
+  ttl: event_date + INTERVAL 1 DAY DELETE
 query_metric_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 query_thread_log:

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -38,7 +38,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000
@@ -183,7 +183,7 @@ spec:
               batch:
                 send_batch_size: 50000
                 send_batch_max_size: 55000
-                timeout: 1s
+                timeout: 5s
               batch/meter:
                 send_batch_size: 20000
                 send_batch_max_size: 25000

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -433,9 +433,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -458,6 +458,22 @@ spec:
               node:
                 - host: localhost
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -519,9 +535,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -544,6 +560,22 @@ spec:
               node:
                 - host: localhost
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -464,6 +464,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -473,6 +477,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -566,6 +584,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -575,6 +597,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -435,9 +435,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -460,6 +460,22 @@ spec:
               node:
                 - host: localhost
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
@@ -521,9 +537,9 @@ spec:
                 shard: "01"
             profiles:
                 default:
+                    allow_simdjson: 0
                     load_balancing: random
                     log_queries: 1
-                    max_memory_usage: 10000000000
             quotas:
                 default:
                     interval:
@@ -546,6 +562,22 @@ spec:
               node:
                 - host: localhost
                   port: 9181
+            query_log:
+                flush_interval_milliseconds: 30000
+                partition_by: toYYYYMM(event_date)
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            query_thread_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            part_log:
+                ttl: "event_date + INTERVAL 3 DAY DELETE"
+            metric_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            asynchronous_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            trace_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -31,9 +31,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -111,6 +115,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -120,6 +125,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -128,6 +134,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -136,6 +143,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter
@@ -168,9 +176,13 @@ spec:
                   http:
                     endpoint: "0.0.0.0:4318"
             processors:
+              memory_limiter:
+                check_interval: 1s
+                limit_percentage: 75
+                spike_limit_percentage: 15
               batch:
-                send_batch_size: 20000
-                send_batch_max_size: 25000
+                send_batch_size: 50000
+                send_batch_max_size: 55000
                 timeout: 1s
               batch/meter:
                 send_batch_size: 20000
@@ -248,6 +260,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - signozspanmetrics/delta
                     - batch
                   exporters:
@@ -257,6 +270,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - signozclickhousemetrics
@@ -265,6 +279,7 @@ spec:
                   receivers:
                     - otlp
                   processors:
+                    - memory_limiter
                     - batch
                   exporters:
                     - clickhouselogsexporter
@@ -273,6 +288,7 @@ spec:
                   receivers:
                     - signozmeter
                   processors:
+                    - memory_limiter
                     - batch/meter
                   exporters:
                     - signozclickhousemeter

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -466,6 +466,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -475,6 +479,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
@@ -568,6 +586,10 @@ spec:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_metric_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            query_views_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
                 ttl: "event_date + INTERVAL 3 DAY DELETE"
             metric_log:
@@ -577,6 +599,20 @@ spec:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             trace_log:
                 flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            error_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            latency_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            processors_profile_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            session_log:
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            text_log:
+                flush_interval_milliseconds: 30000
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
+            zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -463,7 +463,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -471,7 +471,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
@@ -583,7 +583,7 @@ spec:
             query_log:
                 flush_interval_milliseconds: 30000
                 partition_by: toYYYYMM(event_date)
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_thread_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             query_metric_log:
@@ -591,7 +591,7 @@ spec:
             query_views_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             part_log:
-                ttl: "event_date + INTERVAL 3 DAY DELETE"
+                ttl: "event_date + INTERVAL 1 DAY DELETE"
             metric_log:
                 flush_interval_milliseconds: 30000
                 ttl: "event_date + INTERVAL 1 DAY DELETE"

--- a/docs/examples/systemd/binary/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/ingester/ingester.yaml
@@ -36,13 +36,17 @@ extensions:
     endpoint: 0.0.0.0:13133
 processors:
   batch:
-    send_batch_max_size: 25000
-    send_batch_size: 20000
+    send_batch_max_size: 55000
+    send_batch_size: 50000
     timeout: 1s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000
     timeout: 1s
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
   signozspanmetrics/delta:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
     dimensions:
@@ -91,6 +95,7 @@ service:
       - clickhouselogsexporter
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -99,6 +104,7 @@ service:
       - signozclickhousemetrics
       - signozmeter
       processors:
+      - memory_limiter
       - batch
       receivers:
       - otlp
@@ -106,6 +112,7 @@ service:
       exporters:
       - signozclickhousemeter
       processors:
+      - memory_limiter
       - batch/meter
       receivers:
       - signozmeter
@@ -114,6 +121,7 @@ service:
       - clickhousetraces
       - signozmeter
       processors:
+      - memory_limiter
       - signozspanmetrics/delta
       - batch
       receivers:

--- a/docs/examples/systemd/binary/pours/deployment/ingester/ingester.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/ingester/ingester.yaml
@@ -38,7 +38,7 @@ processors:
   batch:
     send_batch_max_size: 55000
     send_batch_size: 50000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_max_size: 25000
     send_batch_size: 20000

--- a/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config.yaml
@@ -1,3 +1,5 @@
+asynchronous_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 dictionaries_config: '*_dictionary.xml'
 display_name: cluster
 distributed_ddl:
@@ -16,12 +18,23 @@ logger:
 macros:
   replica: "01"
   shard: "01"
+metric_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
+part_log:
+  ttl: event_date + INTERVAL 3 DAY DELETE
 path: /var/lib/clickhouse/
 profiles:
   default:
+    allow_simdjson: 0
     load_balancing: random
     log_queries: 1
-    max_memory_usage: 10000000000
+query_log:
+  flush_interval_milliseconds: 30000
+  partition_by: toYYYYMM(event_date)
+  ttl: event_date + INTERVAL 3 DAY DELETE
+query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 quotas:
   default:
     interval:
@@ -39,6 +52,9 @@ remote_servers:
         port: 9000
 tcp_port: 9000
 tmp_path: /var/lib/clickhouse/tmp/
+trace_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:

--- a/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config.yaml
@@ -4,9 +4,13 @@ dictionaries_config: '*_dictionary.xml'
 display_name: cluster
 distributed_ddl:
   path: /clickhouse/task_queue/ddl
+error_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 format_schema_path: /var/lib/clickhouse/format_schemas/
 http_port: 8123
 interserver_http_port: 9009
+latency_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 listen_host: 0.0.0.0
 logger:
   console: 1
@@ -24,6 +28,9 @@ metric_log:
 part_log:
   ttl: event_date + INTERVAL 3 DAY DELETE
 path: /var/lib/clickhouse/
+processors_profile_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 profiles:
   default:
     allow_simdjson: 0
@@ -33,7 +40,11 @@ query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
   ttl: event_date + INTERVAL 3 DAY DELETE
+query_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+query_views_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 quotas:
   default:
@@ -50,7 +61,12 @@ remote_servers:
     - replica:
       - host: localhost
         port: 9000
+session_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
 tcp_port: 9000
+text_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
 tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
@@ -76,3 +92,5 @@ zookeeper:
   node:
   - host: localhost
     port: 9181
+zookeeper_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE

--- a/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config.yaml
@@ -26,7 +26,7 @@ metric_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
 part_log:
-  ttl: event_date + INTERVAL 3 DAY DELETE
+  ttl: event_date + INTERVAL 1 DAY DELETE
 path: /var/lib/clickhouse/
 processors_profile_log:
   flush_interval_milliseconds: 30000
@@ -39,7 +39,7 @@ profiles:
 query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
-  ttl: event_date + INTERVAL 3 DAY DELETE
+  ttl: event_date + INTERVAL 1 DAY DELETE
 query_metric_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 query_thread_log:

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -155,13 +155,6 @@ services:
       replicas: {{ int $.Spec.Ingester.Spec.Cluster.Replicas }}
       restart_policy:
         condition: on-failure
-      resources:
-        reservations:
-          cpus: '0.1'
-          memory: 128M
-        limits:
-          cpus: '1'
-          memory: 512M
   {{ $.Metadata.Name }}-signoz:
     image: {{ $.Spec.Signoz.Spec.Image }}
     networks:

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -118,13 +118,6 @@ services:
     image: {{ $.Spec.Ingester.Spec.Image }}
     networks:
       - {{ $.Metadata.Name }}-network
-    depends_on:
-      {{- range $shardIdx := until (int $.Spec.TelemetryStore.Spec.Cluster.Shards) }}
-      {{- range $replicaIdx := until (int (add 1 (int $.Spec.TelemetryStore.Spec.Cluster.Replicas))) }}
-      {{ $.Metadata.Name }}-telemetrystore-{{ $.Spec.TelemetryStore.Kind }}-{{ $shardIdx }}-{{ $replicaIdx }}:
-        condition: service_healthy
-      {{- end }}
-      {{- end }}
     entrypoint:
       - /bin/sh
     command:

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -118,6 +118,13 @@ services:
     image: {{ $.Spec.Ingester.Spec.Image }}
     networks:
       - {{ $.Metadata.Name }}-network
+    depends_on:
+      {{- range $shardIdx := until (int $.Spec.TelemetryStore.Spec.Cluster.Shards) }}
+      {{- range $replicaIdx := until (int (add 1 (int $.Spec.TelemetryStore.Spec.Cluster.Replicas))) }}
+      {{ $.Metadata.Name }}-telemetrystore-{{ $.Spec.TelemetryStore.Kind }}-{{ $shardIdx }}-{{ $replicaIdx }}:
+        condition: service_healthy
+      {{- end }}
+      {{- end }}
     entrypoint:
       - /bin/sh
     command:
@@ -155,6 +162,13 @@ services:
       replicas: {{ int $.Spec.Ingester.Spec.Cluster.Replicas }}
       restart_policy:
         condition: on-failure
+      resources:
+        reservations:
+          cpus: '0.1'
+          memory: 128M
+        limits:
+          cpus: '1'
+          memory: 512M
   {{ $.Metadata.Name }}-signoz:
     image: {{ $.Spec.Signoz.Spec.Image }}
     networks:

--- a/internal/molding/ingestermolding/ingester.go
+++ b/internal/molding/ingestermolding/ingester.go
@@ -92,11 +92,12 @@ func (molding *ingester) getData(config *v1alpha1.Casting) (Data, error) {
 	}
 
 	return Data{
-		SignozOpampAddress:             signozAddress,
-		TelemetryStoreTracesAddress:    strings.Join(telemetryStoreTracesAddresses, ","),
-		TelemetryStoreMetricsAddress:   strings.Join(telemetryStoreMetricsAddresses, ","),
-		TelemetryStoreLogsAddress:      strings.Join(telemetryStoreLogsAddresses, ","),
-		TelemetryStoreMeterAddress:     strings.Join(telemetryStoreMeterAddresses, ","),
-		TelemetryStoreMetadataAddress:  strings.Join(telemetryStoreMetadataAddresses, ","),
+		SignozOpampAddress:            signozAddress,
+		TelemetryStoreTracesAddress:  strings.Join(telemetryStoreTracesAddresses, ","),
+		TelemetryStoreMetricsAddress: strings.Join(telemetryStoreMetricsAddresses, ","),
+		TelemetryStoreLogsAddress:    strings.Join(telemetryStoreLogsAddresses, ","),
+		TelemetryStoreMeterAddress:   strings.Join(telemetryStoreMeterAddresses, ","),
+		TelemetryStoreMetadataAddress: strings.Join(telemetryStoreMetadataAddresses, ","),
+		IsContainer:                  config.Spec.Deployment.Platform != "linux",
 	}, nil
 }

--- a/internal/molding/ingestermolding/ingester.go
+++ b/internal/molding/ingestermolding/ingester.go
@@ -92,5 +92,6 @@ func (molding *ingester) getData(config *v1alpha1.Casting) (Data, error) {
 		TelemetryStoreMetricsAddress: strings.Join(telemetryStoreMetricsAddresses, ","),
 		TelemetryStoreLogsAddress:    strings.Join(telemetryStoreLogsAddresses, ","),
 		TelemetryStoreMeterAddress:   strings.Join(telemetryStoreMeterAddresses, ","),
+		IsContainer:                  config.Spec.Deployment.Platform != "linux",
 	}, nil
 }

--- a/internal/molding/ingestermolding/ingester.go
+++ b/internal/molding/ingestermolding/ingester.go
@@ -93,11 +93,10 @@ func (molding *ingester) getData(config *v1alpha1.Casting) (Data, error) {
 
 	return Data{
 		SignozOpampAddress:            signozAddress,
-		TelemetryStoreTracesAddress:  strings.Join(telemetryStoreTracesAddresses, ","),
-		TelemetryStoreMetricsAddress: strings.Join(telemetryStoreMetricsAddresses, ","),
-		TelemetryStoreLogsAddress:    strings.Join(telemetryStoreLogsAddresses, ","),
-		TelemetryStoreMeterAddress:   strings.Join(telemetryStoreMeterAddresses, ","),
+		TelemetryStoreTracesAddress:   strings.Join(telemetryStoreTracesAddresses, ","),
+		TelemetryStoreMetricsAddress:  strings.Join(telemetryStoreMetricsAddresses, ","),
+		TelemetryStoreLogsAddress:     strings.Join(telemetryStoreLogsAddresses, ","),
+		TelemetryStoreMeterAddress:    strings.Join(telemetryStoreMeterAddresses, ","),
 		TelemetryStoreMetadataAddress: strings.Join(telemetryStoreMetadataAddresses, ","),
-		IsContainer:                  config.Spec.Deployment.Platform != "linux",
 	}, nil
 }

--- a/internal/molding/ingestermolding/template.go
+++ b/internal/molding/ingestermolding/template.go
@@ -15,10 +15,11 @@ var (
 )
 
 type Data struct {
-	SignozOpampAddress              string
-	TelemetryStoreTracesAddress    string
-	TelemetryStoreMetricsAddress   string
-	TelemetryStoreLogsAddress      string
-	TelemetryStoreMeterAddress     string
-	TelemetryStoreMetadataAddress  string
+	SignozOpampAddress             string
+	TelemetryStoreTracesAddress   string
+	TelemetryStoreMetricsAddress  string
+	TelemetryStoreLogsAddress     string
+	TelemetryStoreMeterAddress    string
+	TelemetryStoreMetadataAddress string
+	IsContainer                   bool
 }

--- a/internal/molding/ingestermolding/template.go
+++ b/internal/molding/ingestermolding/template.go
@@ -20,4 +20,5 @@ type Data struct {
 	TelemetryStoreMetricsAddress string
 	TelemetryStoreLogsAddress    string
 	TelemetryStoreMeterAddress   string
+	IsContainer                  bool
 }

--- a/internal/molding/ingestermolding/template.go
+++ b/internal/molding/ingestermolding/template.go
@@ -15,11 +15,10 @@ var (
 )
 
 type Data struct {
-	SignozOpampAddress             string
+	SignozOpampAddress            string
 	TelemetryStoreTracesAddress   string
 	TelemetryStoreMetricsAddress  string
 	TelemetryStoreLogsAddress     string
 	TelemetryStoreMeterAddress    string
 	TelemetryStoreMetadataAddress string
-	IsContainer                   bool
 }

--- a/internal/molding/ingestermolding/templates/config.v0129x.yaml.gotmpl
+++ b/internal/molding/ingestermolding/templates/config.v0129x.yaml.gotmpl
@@ -13,6 +13,15 @@ receivers:
       http:
         endpoint: "0.0.0.0:4318"
 processors:
+  memory_limiter:
+    check_interval: 1s
+    {{- if .IsContainer }}
+    limit_percentage: 75
+    spike_limit_percentage: 15
+    {{- else }}
+    limit_mib: 512
+    spike_limit_mib: 128
+    {{- end }}
   batch:
     send_batch_size: 20000
     send_batch_max_size: 25000
@@ -99,6 +108,7 @@ service:
       receivers:
         - otlp
       processors:
+        - memory_limiter
         - signozspanmetrics/delta
         - batch
       exporters:
@@ -109,6 +119,7 @@ service:
       receivers:
         - otlp
       processors:
+        - memory_limiter
         - batch
       exporters:
         - signozclickhousemetrics
@@ -118,6 +129,7 @@ service:
       receivers:
         - otlp
       processors:
+        - memory_limiter
         - batch
       exporters:
         - clickhouselogsexporter
@@ -127,6 +139,7 @@ service:
       receivers:
         - signozmeter
       processors:
+        - memory_limiter
         - batch/meter
       exporters:
         - signozclickhousemeter

--- a/internal/molding/ingestermolding/templates/config.v0129x.yaml.gotmpl
+++ b/internal/molding/ingestermolding/templates/config.v0129x.yaml.gotmpl
@@ -13,9 +13,18 @@ receivers:
       http:
         endpoint: "0.0.0.0:4318"
 processors:
+  memory_limiter:
+    check_interval: 1s
+    {{- if .IsContainer }}
+    limit_percentage: 75
+    spike_limit_percentage: 15
+    {{- else }}
+    limit_mib: 512
+    spike_limit_mib: 128
+    {{- end }}
   batch:
-    send_batch_size: 20000
-    send_batch_max_size: 25000
+    send_batch_size: 50000
+    send_batch_max_size: 55000
     timeout: 1s
   batch/meter:
     send_batch_size: 20000
@@ -93,6 +102,7 @@ service:
       receivers:
         - otlp
       processors:
+        - memory_limiter
         - signozspanmetrics/delta
         - batch
       exporters:
@@ -102,6 +112,7 @@ service:
       receivers:
         - otlp
       processors:
+        - memory_limiter
         - batch
       exporters:
         - signozclickhousemetrics
@@ -110,6 +121,7 @@ service:
       receivers:
         - otlp
       processors:
+        - memory_limiter
         - batch
       exporters:
         - clickhouselogsexporter
@@ -118,6 +130,7 @@ service:
       receivers:
         - signozmeter
       processors:
+        - memory_limiter
         - batch/meter
       exporters:
         - signozclickhousemeter

--- a/internal/molding/ingestermolding/templates/config.v0129x.yaml.gotmpl
+++ b/internal/molding/ingestermolding/templates/config.v0129x.yaml.gotmpl
@@ -13,15 +13,6 @@ receivers:
       http:
         endpoint: "0.0.0.0:4318"
 processors:
-  memory_limiter:
-    check_interval: 1s
-    {{- if .IsContainer }}
-    limit_percentage: 75
-    spike_limit_percentage: 15
-    {{- else }}
-    limit_mib: 512
-    spike_limit_mib: 128
-    {{- end }}
   batch:
     send_batch_size: 20000
     send_batch_max_size: 25000
@@ -108,7 +99,6 @@ service:
       receivers:
         - otlp
       processors:
-        - memory_limiter
         - signozspanmetrics/delta
         - batch
       exporters:
@@ -119,7 +109,6 @@ service:
       receivers:
         - otlp
       processors:
-        - memory_limiter
         - batch
       exporters:
         - signozclickhousemetrics
@@ -129,7 +118,6 @@ service:
       receivers:
         - otlp
       processors:
-        - memory_limiter
         - batch
       exporters:
         - clickhouselogsexporter
@@ -139,7 +127,6 @@ service:
       receivers:
         - signozmeter
       processors:
-        - memory_limiter
         - batch/meter
       exporters:
         - signozclickhousemeter

--- a/internal/molding/ingestermolding/templates/config.v0129x.yaml.gotmpl
+++ b/internal/molding/ingestermolding/templates/config.v0129x.yaml.gotmpl
@@ -25,7 +25,7 @@ processors:
   batch:
     send_batch_size: 50000
     send_batch_max_size: 55000
-    timeout: 1s
+    timeout: 5s
   batch/meter:
     send_batch_size: 20000
     send_batch_max_size: 25000

--- a/internal/molding/telemetrystoremolding/templates/config.clickhouse.v2556.yaml.gotmpl
+++ b/internal/molding/telemetrystoremolding/templates/config.clickhouse.v2556.yaml.gotmpl
@@ -21,9 +21,9 @@ macros:
     shard: "01"
 profiles:
     default:
+        allow_simdjson: 0
         load_balancing: random
         log_queries: 1
-        max_memory_usage: 10000000000
 quotas:
     default:
         interval:
@@ -54,6 +54,22 @@ zookeeper:
     - host: {{ $addr.Host }}
       port: {{ $addr.Port }}
 {{- end }}
+query_log:
+    flush_interval_milliseconds: 30000
+    partition_by: toYYYYMM(event_date)
+    ttl: "event_date + INTERVAL 3 DAY DELETE"
+query_thread_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+part_log:
+    ttl: "event_date + INTERVAL 3 DAY DELETE"
+metric_log:
+    flush_interval_milliseconds: 30000
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+asynchronous_metric_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+trace_log:
+    flush_interval_milliseconds: 30000
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
 tcp_port: 9000
 user_defined_executable_functions_config: '*function.yaml'
 user_scripts_path: /var/lib/clickhouse/user_scripts/

--- a/internal/molding/telemetrystoremolding/templates/config.clickhouse.v2556.yaml.gotmpl
+++ b/internal/molding/telemetrystoremolding/templates/config.clickhouse.v2556.yaml.gotmpl
@@ -57,7 +57,7 @@ zookeeper:
 query_log:
     flush_interval_milliseconds: 30000
     partition_by: toYYYYMM(event_date)
-    ttl: "event_date + INTERVAL 3 DAY DELETE"
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
 query_thread_log:
     ttl: "event_date + INTERVAL 1 DAY DELETE"
 query_metric_log:
@@ -65,7 +65,7 @@ query_metric_log:
 query_views_log:
     ttl: "event_date + INTERVAL 1 DAY DELETE"
 part_log:
-    ttl: "event_date + INTERVAL 3 DAY DELETE"
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
 metric_log:
     flush_interval_milliseconds: 30000
     ttl: "event_date + INTERVAL 1 DAY DELETE"

--- a/internal/molding/telemetrystoremolding/templates/config.clickhouse.v2556.yaml.gotmpl
+++ b/internal/molding/telemetrystoremolding/templates/config.clickhouse.v2556.yaml.gotmpl
@@ -60,6 +60,10 @@ query_log:
     ttl: "event_date + INTERVAL 3 DAY DELETE"
 query_thread_log:
     ttl: "event_date + INTERVAL 1 DAY DELETE"
+query_metric_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+query_views_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
 part_log:
     ttl: "event_date + INTERVAL 3 DAY DELETE"
 metric_log:
@@ -69,6 +73,20 @@ asynchronous_metric_log:
     ttl: "event_date + INTERVAL 1 DAY DELETE"
 trace_log:
     flush_interval_milliseconds: 30000
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+error_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+latency_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+processors_profile_log:
+    flush_interval_milliseconds: 30000
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+session_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+text_log:
+    flush_interval_milliseconds: 30000
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+zookeeper_log:
     ttl: "event_date + INTERVAL 1 DAY DELETE"
 tcp_port: 9000
 user_defined_executable_functions_config: '*function.yaml'


### PR DESCRIPTION
#### Features
- Disable simdjson engine to avoid issues with CPUs that do not support AVX2
- Remove max memory server limits
- Reduce retention for system logs/tables
- Increase flush interval to help with data flushes
