### PR TITLE
refactor: rename types package to domain

### DIFF
--- a/api/v1alpha1/ingester.go
+++ b/api/v1alpha1/ingester.go
@@ -1,6 +1,6 @@
 package v1alpha1
 
-import "github.com/signoz/foundry/internal/types"
+import "github.com/signoz/foundry/internal/domain"
 
 type Ingester struct {
 	// Specification for the ingester.
@@ -29,9 +29,9 @@ type IngesterStatusAddresses struct {
 func DefaultIngester() Ingester {
 	return Ingester{
 		Spec: MoldingSpec{
-			Enabled: types.NewBoolPtr(true),
+			Enabled: domain.NewBoolPtr(true),
 			Cluster: TypeCluster{
-				Replicas: types.NewIntPtr(1),
+				Replicas: domain.NewIntPtr(1),
 			},
 			Version: "latest",
 			Image:   "signoz/signoz-otel-collector:latest",

--- a/api/v1alpha1/ingester.go
+++ b/api/v1alpha1/ingester.go
@@ -1,7 +1,5 @@
 package v1alpha1
 
-import "github.com/signoz/foundry/internal/domain"
-
 type Ingester struct {
 	// Specification for the ingester.
 	Spec MoldingSpec `json:"spec" yaml:"spec" jsonschema:"description=Specification for the ingester"`
@@ -29,9 +27,9 @@ type IngesterStatusAddresses struct {
 func DefaultIngester() Ingester {
 	return Ingester{
 		Spec: MoldingSpec{
-			Enabled: domain.NewBoolPtr(true),
+			Enabled: boolPtr(true),
 			Cluster: TypeCluster{
-				Replicas: domain.NewIntPtr(1),
+				Replicas: intPtr(1),
 			},
 			Version: "latest",
 			Image:   "signoz/signoz-otel-collector:latest",

--- a/api/v1alpha1/metastore.go
+++ b/api/v1alpha1/metastore.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 type MetaStore struct {
@@ -27,17 +27,17 @@ type MetaStoreStatus struct {
 
 type MetaStoreStatusAddresses struct {
 	// DSN addresses.
-	DSN []string  `json:"dsn" yaml:"dsn" description:"DSN addresses"`
-	_   struct{}  `additionalProperties:"false"`
+	DSN []string `json:"dsn" yaml:"dsn" description:"DSN addresses"`
+	_   struct{} `additionalProperties:"false"`
 }
 
 func DefaultMetaStore() MetaStore {
 	return MetaStore{
 		Kind: MetaStoreKindPostgres,
 		Spec: MoldingSpec{
-			Enabled: types.NewBoolPtr(true),
+			Enabled: domain.NewBoolPtr(true),
 			Cluster: TypeCluster{
-				Replicas: types.NewIntPtr(1),
+				Replicas: domain.NewIntPtr(1),
 			},
 			Version: "16",
 			Image:   "postgres:16",

--- a/api/v1alpha1/metastore.go
+++ b/api/v1alpha1/metastore.go
@@ -1,9 +1,5 @@
 package v1alpha1
 
-import (
-	"github.com/signoz/foundry/internal/domain"
-)
-
 type MetaStore struct {
 	// Kind of the meta store to use.
 	Kind MetaStoreKind `json:"kind,omitzero" yaml:"kind,omitempty" description:"Kind of the meta store to use" examples:"[\"postgres\",\"sqlite\"]"`
@@ -35,9 +31,9 @@ func DefaultMetaStore() MetaStore {
 	return MetaStore{
 		Kind: MetaStoreKindPostgres,
 		Spec: MoldingSpec{
-			Enabled: domain.NewBoolPtr(true),
+			Enabled: boolPtr(true),
 			Cluster: TypeCluster{
-				Replicas: domain.NewIntPtr(1),
+				Replicas: intPtr(1),
 			},
 			Version: "16",
 			Image:   "postgres:16",

--- a/api/v1alpha1/pointer.go
+++ b/api/v1alpha1/pointer.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+func intPtr(v int) *int {
+	return &v
+}

--- a/api/v1alpha1/signoz.go
+++ b/api/v1alpha1/signoz.go
@@ -1,6 +1,6 @@
 package v1alpha1
 
-import "github.com/signoz/foundry/internal/types"
+import "github.com/signoz/foundry/internal/domain"
 
 type SigNoz struct {
 	// Specification for signoz.
@@ -33,9 +33,9 @@ type SigNozStatusAddresses struct {
 func DefaultSigNoz() SigNoz {
 	return SigNoz{
 		Spec: MoldingSpec{
-			Enabled: types.NewBoolPtr(true),
+			Enabled: domain.NewBoolPtr(true),
 			Cluster: TypeCluster{
-				Replicas: types.NewIntPtr(1),
+				Replicas: domain.NewIntPtr(1),
 			},
 			Version: "latest",
 			Image:   "signoz/signoz:latest",

--- a/api/v1alpha1/signoz.go
+++ b/api/v1alpha1/signoz.go
@@ -1,7 +1,5 @@
 package v1alpha1
 
-import "github.com/signoz/foundry/internal/domain"
-
 type SigNoz struct {
 	// Specification for signoz.
 	Spec MoldingSpec `json:"spec" yaml:"spec" jsonschema:"description=Specification for SigNoz"`
@@ -33,9 +31,9 @@ type SigNozStatusAddresses struct {
 func DefaultSigNoz() SigNoz {
 	return SigNoz{
 		Spec: MoldingSpec{
-			Enabled: domain.NewBoolPtr(true),
+			Enabled: boolPtr(true),
 			Cluster: TypeCluster{
-				Replicas: domain.NewIntPtr(1),
+				Replicas: intPtr(1),
 			},
 			Version: "latest",
 			Image:   "signoz/signoz:latest",

--- a/api/v1alpha1/telemetrykeeper.go
+++ b/api/v1alpha1/telemetrykeeper.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 type TelemetryKeeper struct {
@@ -40,9 +40,9 @@ func DefaultTelemetryKeeper() TelemetryKeeper {
 	return TelemetryKeeper{
 		Kind: TelemetryKeeperKindClickhouseKeeper,
 		Spec: MoldingSpec{
-			Enabled: types.NewBoolPtr(true),
+			Enabled: domain.NewBoolPtr(true),
 			Cluster: TypeCluster{
-				Replicas: types.NewIntPtr(1),
+				Replicas: domain.NewIntPtr(1),
 			},
 			Version: "25.5.6",
 			Image:   "clickhouse/clickhouse-keeper:25.5.6",

--- a/api/v1alpha1/telemetrykeeper.go
+++ b/api/v1alpha1/telemetrykeeper.go
@@ -1,9 +1,5 @@
 package v1alpha1
 
-import (
-	"github.com/signoz/foundry/internal/domain"
-)
-
 type TelemetryKeeper struct {
 	// Kind of the telemetry keeper to use.
 	Kind TelemetryKeeperKind `json:"kind,omitzero" yaml:"kind,omitempty" description:"Kind of the telemetry keeper to use" examples:"[\"clickhousekeeper\"]"`
@@ -40,9 +36,9 @@ func DefaultTelemetryKeeper() TelemetryKeeper {
 	return TelemetryKeeper{
 		Kind: TelemetryKeeperKindClickhouseKeeper,
 		Spec: MoldingSpec{
-			Enabled: domain.NewBoolPtr(true),
+			Enabled: boolPtr(true),
 			Cluster: TypeCluster{
-				Replicas: domain.NewIntPtr(1),
+				Replicas: intPtr(1),
 			},
 			Version: "25.5.6",
 			Image:   "clickhouse/clickhouse-keeper:25.5.6",

--- a/api/v1alpha1/telemetrystore.go
+++ b/api/v1alpha1/telemetrystore.go
@@ -1,9 +1,5 @@
 package v1alpha1
 
-import (
-	"github.com/signoz/foundry/internal/domain"
-)
-
 type TelemetryStore struct {
 	// Kind of the telemetry store to use.
 	Kind TelemetryStoreKind `json:"kind,omitzero" yaml:"kind,omitempty" description:"Kind of the telemetry store to use" examples:"[\"clickhouse\"]"`
@@ -36,10 +32,10 @@ func DefaultTelemetryStore() TelemetryStore {
 	return TelemetryStore{
 		Kind: TelemetryStoreKindClickhouse,
 		Spec: MoldingSpec{
-			Enabled: domain.NewBoolPtr(true),
+			Enabled: boolPtr(true),
 			Cluster: TypeCluster{
-				Replicas: domain.NewIntPtr(0),
-				Shards:   domain.NewIntPtr(1),
+				Replicas: intPtr(0),
+				Shards:   intPtr(1),
 			},
 			Version: "25.5.6",
 			Image:   "clickhouse/clickhouse-server:25.5.6",

--- a/api/v1alpha1/telemetrystore.go
+++ b/api/v1alpha1/telemetrystore.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 type TelemetryStore struct {
@@ -36,10 +36,10 @@ func DefaultTelemetryStore() TelemetryStore {
 	return TelemetryStore{
 		Kind: TelemetryStoreKindClickhouse,
 		Spec: MoldingSpec{
-			Enabled: types.NewBoolPtr(true),
+			Enabled: domain.NewBoolPtr(true),
 			Cluster: TypeCluster{
-				Replicas: types.NewIntPtr(0),
-				Shards:   types.NewIntPtr(1),
+				Replicas: domain.NewIntPtr(0),
+				Shards:   domain.NewIntPtr(1),
 			},
 			Version: "25.5.6",
 			Image:   "clickhouse/clickhouse-server:25.5.6",

--- a/cmd/foundryctl/gen.go
+++ b/cmd/foundryctl/gen.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	foundryerrors "github.com/signoz/foundry/internal/errors"
 	"github.com/signoz/foundry/internal/foundry"
 	"github.com/signoz/foundry/internal/instrumentation"
 	"github.com/signoz/foundry/internal/ledger/noopledger"
-	"github.com/signoz/foundry/internal/types"
 	"github.com/spf13/cobra"
 	"github.com/swaggest/jsonschema-go"
 )
@@ -81,7 +81,7 @@ func runGenExamples(ctx context.Context, logger *slog.Logger) error {
 			return err
 		}
 
-		err = os.WriteFile(filepath.Join(rootPath, "casting.yaml"), types.MustMarshalYAML(config), 0644)
+		err = os.WriteFile(filepath.Join(rootPath, "casting.yaml"), domain.MustMarshalYAML(config), 0644)
 		if err != nil {
 			return err
 		}

--- a/internal/casting/casting.go
+++ b/internal/casting/casting.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 // DeploymentDir is the subdirectory within the pours directory where
@@ -17,7 +17,7 @@ type Casting interface {
 	Enricher(ctx context.Context, config *v1alpha1.Casting) (molding.MoldingEnricher, error)
 
 	// Generates all the files needed for casting.
-	Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]types.Material, error)
+	Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]domain.Material, error)
 
 	// Runs the forged files.
 	Cast(ctx context.Context, config v1alpha1.Casting, poursPath string) error

--- a/internal/casting/coolifycasting/casting.go
+++ b/internal/casting/coolifycasting/casting.go
@@ -9,21 +9,21 @@ import (
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	rootcasting "github.com/signoz/foundry/internal/casting"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ rootcasting.Casting = (*coolifyCasting)(nil)
 
 type coolifyCasting struct {
 	logger   *slog.Logger
-	castings []*types.Template
+	castings []*domain.Template
 }
 
 func New(logger *slog.Logger) *coolifyCasting {
 	return &coolifyCasting{
 		logger: logger,
-		castings: []*types.Template{
+		castings: []*domain.Template{
 			coolifyYAMLTemplate,
 		},
 	}
@@ -33,19 +33,19 @@ func (c *coolifyCasting) Enricher(ctx context.Context, config *v1alpha1.Casting)
 	return newCoolifyMoldingEnricher(config)
 }
 
-func (c *coolifyCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]types.Material, error) {
+func (c *coolifyCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]domain.Material, error) {
 	buf := bytes.NewBuffer(nil)
 	err := coolifyYAMLTemplate.Execute(buf, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute coolify yaml template: %w", err)
 	}
 
-	coolifyMaterial, err := types.NewYAMLMaterial(buf.Bytes(), filepath.Join(rootcasting.DeploymentDir, "coolify.yaml"))
+	coolifyMaterial, err := domain.NewYAMLMaterial(buf.Bytes(), filepath.Join(rootcasting.DeploymentDir, "coolify.yaml"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create coolify yaml material: %w", err)
 	}
 
-	return []types.Material{coolifyMaterial}, nil
+	return []domain.Material{coolifyMaterial}, nil
 }
 
 func (c *coolifyCasting) Cast(ctx context.Context, config v1alpha1.Casting, poursPath string) error {
@@ -56,11 +56,11 @@ func (c *coolifyCasting) Cast(ctx context.Context, config v1alpha1.Casting, pour
 	return nil
 }
 
-func getCoolifyMaterial(config *v1alpha1.Casting, path string) (types.Material, error) {
+func getCoolifyMaterial(config *v1alpha1.Casting, path string) (domain.Material, error) {
 	buf := bytes.NewBuffer(nil)
 	err := coolifyYAMLTemplate.Execute(buf, config)
 	if err != nil {
-		return types.Material{}, fmt.Errorf("failed to execute coolify yaml template: %w", err)
+		return domain.Material{}, fmt.Errorf("failed to execute coolify yaml template: %w", err)
 	}
-	return types.NewYAMLMaterial(buf.Bytes(), path)
+	return domain.NewYAMLMaterial(buf.Bytes(), path)
 }

--- a/internal/casting/coolifycasting/embed.go
+++ b/internal/casting/coolifycasting/embed.go
@@ -3,12 +3,12 @@ package coolifycasting
 import (
 	"embed"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/*.gotmpl
 var templates embed.FS
 
 var (
-	coolifyYAMLTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/coolify.yaml.gotmpl", types.FormatYAML)
+	coolifyYAMLTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/coolify.yaml.gotmpl", domain.FormatYAML)
 )

--- a/internal/casting/coolifycasting/enricher.go
+++ b/internal/casting/coolifycasting/enricher.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	rootcasting "github.com/signoz/foundry/internal/casting"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ molding.MoldingEnricher = (*coolifyMoldingEnricher)(nil)
 
 type coolifyMoldingEnricher struct {
-	material types.Material
+	material domain.Material
 }
 
 func newCoolifyMoldingEnricher(config *v1alpha1.Casting) (*coolifyMoldingEnricher, error) {
@@ -37,7 +37,7 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		var telemetrystoreContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "telemetrystore-clickhouse") && !strings.Contains(containerName, "user-scripts") {
-				telemetrystoreContainerNames = append(telemetrystoreContainerNames, types.FormatAddress("tcp", containerName, 9000))
+				telemetrystoreContainerNames = append(telemetrystoreContainerNames, domain.FormatAddress("tcp", containerName, 9000))
 			}
 		}
 		config.Spec.TelemetryStore.Status.Addresses.TCP = telemetrystoreContainerNames
@@ -52,8 +52,8 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		var opampAddr []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "-signoz") {
-				apiServerAddr = append(apiServerAddr, types.FormatAddress("tcp", containerName, 8080))
-				opampAddr = append(opampAddr, types.FormatAddress("ws", containerName, 4320))
+				apiServerAddr = append(apiServerAddr, domain.FormatAddress("tcp", containerName, 8080))
+				opampAddr = append(opampAddr, domain.FormatAddress("ws", containerName, 4320))
 			}
 		}
 		config.Spec.Signoz.Status.Addresses.APIServer = apiServerAddr
@@ -68,7 +68,7 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		var telemetrykeeperContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "telemetrykeeper") {
-				telemetrykeeperContainerNames = append(telemetrykeeperContainerNames, types.FormatAddress("tcp", containerName, 9181))
+				telemetrykeeperContainerNames = append(telemetrykeeperContainerNames, domain.FormatAddress("tcp", containerName, 9181))
 			}
 		}
 		config.Spec.TelemetryKeeper.Status.Addresses.Client = telemetrykeeperContainerNames
@@ -76,7 +76,7 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		var telemetryRaftaddress []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "telemetrykeeper") {
-				telemetryRaftaddress = append(telemetryRaftaddress, types.FormatAddress("tcp", containerName, 9234))
+				telemetryRaftaddress = append(telemetryRaftaddress, domain.FormatAddress("tcp", containerName, 9234))
 			}
 		}
 		config.Spec.TelemetryKeeper.Status.Addresses.Raft = telemetryRaftaddress
@@ -90,7 +90,7 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		var metastoreContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "metastore") {
-				metastoreContainerNames = append(metastoreContainerNames, types.FormatAddress("tcp", containerName, 5432))
+				metastoreContainerNames = append(metastoreContainerNames, domain.FormatAddress("tcp", containerName, 5432))
 			}
 		}
 		config.Spec.MetaStore.Status.Addresses.DSN = metastoreContainerNames
@@ -104,7 +104,7 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		var ingesterContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "ingester") {
-				ingesterContainerNames = append(ingesterContainerNames, types.FormatAddress("tcp", containerName, 4318))
+				ingesterContainerNames = append(ingesterContainerNames, domain.FormatAddress("tcp", containerName, 4318))
 			}
 		}
 		config.Spec.Ingester.Status.Addresses.OTLP = ingesterContainerNames

--- a/internal/casting/dockercomposecasting/casting.go
+++ b/internal/casting/dockercomposecasting/casting.go
@@ -14,21 +14,21 @@ import (
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	rootcasting "github.com/signoz/foundry/internal/casting"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ rootcasting.Casting = (*dockerComposeCasting)(nil)
 
 type dockerComposeCasting struct {
 	logger   *slog.Logger
-	castings []*types.Template
+	castings []*domain.Template
 }
 
 func New(logger *slog.Logger) *dockerComposeCasting {
 	return &dockerComposeCasting{
 		logger: logger,
-		castings: []*types.Template{
+		castings: []*domain.Template{
 			composeYAMLTemplate,
 		},
 	}
@@ -38,23 +38,23 @@ func (casting *dockerComposeCasting) Enricher(ctx context.Context, config *v1alp
 	return newDockerComposeMoldingEnricher(config)
 }
 
-func (casting *dockerComposeCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]types.Material, error) {
+func (casting *dockerComposeCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]domain.Material, error) {
 	buf := bytes.NewBuffer(nil)
 	err := composeYAMLTemplate.Execute(buf, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute compose yaml template: %w", err)
 	}
 
-	composeMaterial, err := types.NewYAMLMaterial(buf.Bytes(), filepath.Join(rootcasting.DeploymentDir, "compose.yaml"))
+	composeMaterial, err := domain.NewYAMLMaterial(buf.Bytes(), filepath.Join(rootcasting.DeploymentDir, "compose.yaml"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create compose yaml material: %w", err)
 	}
 
-	materials := []types.Material{composeMaterial}
+	materials := []domain.Material{composeMaterial}
 
 	// Add telemetrykeeper config files
 	for filename, content := range config.Spec.TelemetryKeeper.Spec.Config.Data {
-		material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "telemetrykeeper", config.Spec.TelemetryKeeper.Kind.String(), filename))
+		material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "telemetrykeeper", config.Spec.TelemetryKeeper.Kind.String(), filename))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create telemetrykeeper config material: %w", err)
 		}
@@ -63,7 +63,7 @@ func (casting *dockerComposeCasting) Forge(ctx context.Context, config v1alpha1.
 
 	// Add telemetrystore config files
 	for filename, content := range config.Spec.TelemetryStore.Spec.Config.Data {
-		material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "telemetrystore", config.Spec.TelemetryStore.Kind.String(), filename))
+		material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "telemetrystore", config.Spec.TelemetryStore.Kind.String(), filename))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create telemetrystore config material: %w", err)
 		}
@@ -72,7 +72,7 @@ func (casting *dockerComposeCasting) Forge(ctx context.Context, config v1alpha1.
 
 	// Add metastore config files
 	for filename, content := range config.Spec.MetaStore.Spec.Config.Data {
-		material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "metastore", config.Spec.MetaStore.Kind.String(), filename))
+		material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "metastore", config.Spec.MetaStore.Kind.String(), filename))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create metastore config material: %w", err)
 		}
@@ -81,7 +81,7 @@ func (casting *dockerComposeCasting) Forge(ctx context.Context, config v1alpha1.
 
 	// Add signoz config files
 	for filename, content := range config.Spec.Signoz.Spec.Config.Data {
-		material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "signoz", filename))
+		material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "signoz", filename))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create signoz config material: %w", err)
 		}
@@ -90,7 +90,7 @@ func (casting *dockerComposeCasting) Forge(ctx context.Context, config v1alpha1.
 
 	// Add ingester config files
 	for filename, content := range config.Spec.Ingester.Spec.Config.Data {
-		material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "ingester", filename))
+		material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "ingester", filename))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create ingester config material: %w", err)
 		}
@@ -139,14 +139,14 @@ func (casting *dockerComposeCasting) Cast(ctx context.Context, config v1alpha1.C
 	return nil
 }
 
-func getComposeMaterial(config *v1alpha1.Casting, path string) (types.Material, error) {
+func getComposeMaterial(config *v1alpha1.Casting, path string) (domain.Material, error) {
 	buf := bytes.NewBuffer(nil)
 	err := composeYAMLTemplate.Execute(buf, config)
 	if err != nil {
-		return types.Material{}, fmt.Errorf("failed to execute compose yaml template: %w", err)
+		return domain.Material{}, fmt.Errorf("failed to execute compose yaml template: %w", err)
 	}
 
-	return types.NewYAMLMaterial(buf.Bytes(), path)
+	return domain.NewYAMLMaterial(buf.Bytes(), path)
 }
 
 // getComposeCommand detects the available docker compose command.

--- a/internal/casting/dockercomposecasting/embed.go
+++ b/internal/casting/dockercomposecasting/embed.go
@@ -3,12 +3,12 @@ package dockercomposecasting
 import (
 	"embed"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/*.gotmpl
 var templates embed.FS
 
 var (
-	composeYAMLTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/compose.yaml.gotmpl", types.FormatYAML)
+	composeYAMLTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/compose.yaml.gotmpl", domain.FormatYAML)
 )

--- a/internal/casting/dockercomposecasting/enricher.go
+++ b/internal/casting/dockercomposecasting/enricher.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	rootcasting "github.com/signoz/foundry/internal/casting"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ molding.MoldingEnricher = (*dockerComposeMoldingEnricher)(nil)
 
 type dockerComposeMoldingEnricher struct {
-	material types.Material
+	material domain.Material
 }
 
 func newDockerComposeMoldingEnricher(config *v1alpha1.Casting) (*dockerComposeMoldingEnricher, error) {
@@ -39,7 +39,7 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		var telemetrystoreContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "telemetrystore-clickhouse") && !strings.Contains(containerName, "user-scripts") {
-				telemetrystoreContainerNames = append(telemetrystoreContainerNames, types.FormatAddress("tcp", containerName, 9000))
+				telemetrystoreContainerNames = append(telemetrystoreContainerNames, domain.FormatAddress("tcp", containerName, 9000))
 			}
 		}
 
@@ -56,8 +56,8 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		var opampAddr []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "-signoz") {
-				apiServerAddr = append(apiServerAddr, types.FormatAddress("tcp", containerName, 8080))
-				opampAddr = append(opampAddr, types.FormatAddress("ws", containerName, 4320))
+				apiServerAddr = append(apiServerAddr, domain.FormatAddress("tcp", containerName, 8080))
+				opampAddr = append(opampAddr, domain.FormatAddress("ws", containerName, 4320))
 			}
 		}
 		config.Spec.Signoz.Status.Addresses.APIServer = apiServerAddr
@@ -73,7 +73,7 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		var telemetrykeeperContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "telemetrykeeper") {
-				telemetrykeeperContainerNames = append(telemetrykeeperContainerNames, types.FormatAddress("tcp", containerName, 9181))
+				telemetrykeeperContainerNames = append(telemetrykeeperContainerNames, domain.FormatAddress("tcp", containerName, 9181))
 			}
 		}
 
@@ -82,7 +82,7 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		var telemetryRaftaddress []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "telemetrykeeper") {
-				telemetryRaftaddress = append(telemetryRaftaddress, types.FormatAddress("tcp", containerName, 9234))
+				telemetryRaftaddress = append(telemetryRaftaddress, domain.FormatAddress("tcp", containerName, 9234))
 			}
 		}
 
@@ -98,7 +98,7 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		var metastoreContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "metastore") {
-				metastoreContainerNames = append(metastoreContainerNames, types.FormatAddress("tcp", containerName, 5432))
+				metastoreContainerNames = append(metastoreContainerNames, domain.FormatAddress("tcp", containerName, 5432))
 			}
 		}
 
@@ -114,7 +114,7 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		var ingesterContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "ingester") {
-				ingesterContainerNames = append(ingesterContainerNames, types.FormatAddress("tcp", containerName, 4317))
+				ingesterContainerNames = append(ingesterContainerNames, domain.FormatAddress("tcp", containerName, 4317))
 			}
 		}
 

--- a/internal/casting/dockerswarmcasting/casting.go
+++ b/internal/casting/dockerswarmcasting/casting.go
@@ -13,21 +13,21 @@ import (
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	rootcasting "github.com/signoz/foundry/internal/casting"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ rootcasting.Casting = (*dockerSwarmCasting)(nil)
 
 type dockerSwarmCasting struct {
 	logger   *slog.Logger
-	castings []*types.Template
+	castings []*domain.Template
 }
 
 func New(logger *slog.Logger) *dockerSwarmCasting {
 	return &dockerSwarmCasting{
 		logger: logger,
-		castings: []*types.Template{
+		castings: []*domain.Template{
 			composeYAMLTemplate,
 		},
 	}
@@ -37,7 +37,7 @@ func (casting *dockerSwarmCasting) Enricher(ctx context.Context, config *v1alpha
 	return newDockerSwarmMoldingEnricher(config)
 }
 
-func (casting *dockerSwarmCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]types.Material, error) {
+func (casting *dockerSwarmCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]domain.Material, error) {
 
 	buf := bytes.NewBuffer(nil)
 	err := composeYAMLTemplate.Execute(buf, config)
@@ -45,15 +45,15 @@ func (casting *dockerSwarmCasting) Forge(ctx context.Context, config v1alpha1.Ca
 		return nil, fmt.Errorf("failed to execute compose yaml template: %w", err)
 	}
 
-	composeMaterial, err := types.NewYAMLMaterial(buf.Bytes(), filepath.Join(rootcasting.DeploymentDir, "compose.yaml"))
+	composeMaterial, err := domain.NewYAMLMaterial(buf.Bytes(), filepath.Join(rootcasting.DeploymentDir, "compose.yaml"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create compose yaml material: %w", err)
 	}
 
-	materials := []types.Material{composeMaterial}
+	materials := []domain.Material{composeMaterial}
 
 	for filename, content := range config.Spec.TelemetryKeeper.Spec.Config.Data {
-		material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "telemetrykeeper", config.Spec.TelemetryKeeper.Kind.String(), filename))
+		material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "telemetrykeeper", config.Spec.TelemetryKeeper.Kind.String(), filename))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create telemetrykeeper config material: %w", err)
 		}
@@ -61,7 +61,7 @@ func (casting *dockerSwarmCasting) Forge(ctx context.Context, config v1alpha1.Ca
 	}
 
 	for filename, content := range config.Spec.TelemetryStore.Spec.Config.Data {
-		material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "telemetrystore", config.Spec.TelemetryStore.Kind.String(), filename))
+		material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "telemetrystore", config.Spec.TelemetryStore.Kind.String(), filename))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create telemetrystore config material: %w", err)
 		}
@@ -69,7 +69,7 @@ func (casting *dockerSwarmCasting) Forge(ctx context.Context, config v1alpha1.Ca
 	}
 
 	for filename, content := range config.Spec.MetaStore.Spec.Config.Data {
-		material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "metastore", config.Spec.MetaStore.Kind.String(), filename))
+		material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "metastore", config.Spec.MetaStore.Kind.String(), filename))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create metastore config material: %w", err)
 		}
@@ -77,7 +77,7 @@ func (casting *dockerSwarmCasting) Forge(ctx context.Context, config v1alpha1.Ca
 	}
 
 	for filename, content := range config.Spec.Signoz.Spec.Config.Data {
-		material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "signoz", filename))
+		material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "signoz", filename))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create signoz config material: %w", err)
 		}
@@ -85,7 +85,7 @@ func (casting *dockerSwarmCasting) Forge(ctx context.Context, config v1alpha1.Ca
 	}
 
 	for filename, content := range config.Spec.Ingester.Spec.Config.Data {
-		material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "ingester", filename))
+		material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, "ingester", filename))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create ingester config material: %w", err)
 		}
@@ -127,12 +127,12 @@ func (casting *dockerSwarmCasting) Cast(ctx context.Context, config v1alpha1.Cas
 	return nil
 }
 
-func getComposeMaterial(config *v1alpha1.Casting, path string) (types.Material, error) {
+func getComposeMaterial(config *v1alpha1.Casting, path string) (domain.Material, error) {
 	buf := bytes.NewBuffer(nil)
 	err := composeYAMLTemplate.Execute(buf, config)
 	if err != nil {
-		return types.Material{}, fmt.Errorf("failed to execute compose yaml template: %w", err)
+		return domain.Material{}, fmt.Errorf("failed to execute compose yaml template: %w", err)
 	}
 
-	return types.NewYAMLMaterial(buf.Bytes(), path)
+	return domain.NewYAMLMaterial(buf.Bytes(), path)
 }

--- a/internal/casting/dockerswarmcasting/embed.go
+++ b/internal/casting/dockerswarmcasting/embed.go
@@ -3,12 +3,12 @@ package dockerswarmcasting
 import (
 	"embed"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/*.gotmpl
 var templates embed.FS
 
 var (
-	composeYAMLTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/compose.yaml.gotmpl", types.FormatYAML)
+	composeYAMLTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/compose.yaml.gotmpl", domain.FormatYAML)
 )

--- a/internal/casting/dockerswarmcasting/enricher.go
+++ b/internal/casting/dockerswarmcasting/enricher.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	rootcasting "github.com/signoz/foundry/internal/casting"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ molding.MoldingEnricher = (*dockerSwarmMoldingEnricher)(nil)
 
 type dockerSwarmMoldingEnricher struct {
-	material types.Material
+	material domain.Material
 }
 
 func newDockerSwarmMoldingEnricher(config *v1alpha1.Casting) (*dockerSwarmMoldingEnricher, error) {
@@ -38,7 +38,7 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		var telemetrystoreAddresses []string
 		for _, name := range containerNames {
 			if strings.Contains(name, "telemetrystore-clickhouse") && !strings.Contains(name, "user-scripts") {
-				telemetrystoreAddresses = append(telemetrystoreAddresses, types.FormatAddress("tcp", name, 9000))
+				telemetrystoreAddresses = append(telemetrystoreAddresses, domain.FormatAddress("tcp", name, 9000))
 			}
 		}
 
@@ -54,8 +54,8 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		var opampAddr []string
 		for _, name := range containerNames {
 			if strings.Contains(name, "-signoz") {
-				apiServerAddr = append(apiServerAddr, types.FormatAddress("tcp", name, 8080))
-				opampAddr = append(opampAddr, types.FormatAddress("ws", name, 4320))
+				apiServerAddr = append(apiServerAddr, domain.FormatAddress("tcp", name, 8080))
+				opampAddr = append(opampAddr, domain.FormatAddress("ws", name, 4320))
 			}
 		}
 		config.Spec.Signoz.Status.Addresses.APIServer = apiServerAddr
@@ -70,7 +70,7 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		var clientAddresses []string
 		for _, name := range containerNames {
 			if strings.Contains(name, "telemetrykeeper") {
-				clientAddresses = append(clientAddresses, types.FormatAddress("tcp", name, 9181))
+				clientAddresses = append(clientAddresses, domain.FormatAddress("tcp", name, 9181))
 			}
 		}
 		config.Spec.TelemetryKeeper.Status.Addresses.Client = clientAddresses
@@ -78,7 +78,7 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		var raftAddresses []string
 		for _, name := range containerNames {
 			if strings.Contains(name, "telemetrykeeper") {
-				raftAddresses = append(raftAddresses, types.FormatAddress("tcp", name, 9234))
+				raftAddresses = append(raftAddresses, domain.FormatAddress("tcp", name, 9234))
 			}
 		}
 		config.Spec.TelemetryKeeper.Status.Addresses.Raft = raftAddresses
@@ -92,7 +92,7 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		var metastoreAddresses []string
 		for _, name := range containerNames {
 			if strings.Contains(name, "metastore") {
-				metastoreAddresses = append(metastoreAddresses, types.FormatAddress("tcp", name, 5432))
+				metastoreAddresses = append(metastoreAddresses, domain.FormatAddress("tcp", name, 5432))
 			}
 		}
 		config.Spec.MetaStore.Status.Addresses.DSN = metastoreAddresses
@@ -106,7 +106,7 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		var ingesterAddresses []string
 		for _, name := range containerNames {
 			if strings.Contains(name, "ingester") {
-				ingesterAddresses = append(ingesterAddresses, types.FormatAddress("tcp", name, 9000))
+				ingesterAddresses = append(ingesterAddresses, domain.FormatAddress("tcp", name, 9000))
 			}
 		}
 		config.Spec.Ingester.Status.Addresses.OTLP = ingesterAddresses

--- a/internal/casting/ecsterraformcasting/casting.go
+++ b/internal/casting/ecsterraformcasting/casting.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	rootcasting "github.com/signoz/foundry/internal/casting"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ rootcasting.Casting = (*ecsCasting)(nil)
@@ -33,14 +33,14 @@ func (c *ecsCasting) Enricher(ctx context.Context, config *v1alpha1.Casting) (mo
 	return newEcsMoldingEnricher(config)
 }
 
-func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]types.Material, error) {
-	var materials []types.Material
+func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]domain.Material, error) {
+	var materials []domain.Material
 
 	deployDir := rootcasting.DeploymentDir
 	moduleDir := filepath.Join(deployDir, "module")
 
 	// Root Terraform files
-	rootTemplates := map[string]*types.Template{
+	rootTemplates := map[string]*domain.Template{
 		"main.tf.json":          mainTF,
 		"variables.tf.json":     variablesTF,
 		"terraform.tfvars.json": tfarsTF,
@@ -54,7 +54,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 	}
 
 	// Module shared files
-	moduleTemplates := map[string]*types.Template{
+	moduleTemplates := map[string]*domain.Template{
 		"main.tf.json":      moduleMainTF,
 		"variables.tf.json": moduleVariablesTF,
 		"outputs.tf.json":   moduleOutputsTF,
@@ -76,7 +76,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 		materials = append(materials, m)
 
 		for filename, content := range config.Spec.TelemetryKeeper.Spec.Config.Data {
-			material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(moduleDir, "telemetrykeeper", config.Spec.TelemetryKeeper.Kind.String(), filename))
+			material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(moduleDir, "telemetrykeeper", config.Spec.TelemetryKeeper.Kind.String(), filename))
 			if err != nil {
 				return nil, err
 			}
@@ -93,7 +93,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 		materials = append(materials, m)
 
 		for filename, content := range config.Spec.TelemetryStore.Spec.Config.Data {
-			material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(moduleDir, "telemetrystore", config.Spec.TelemetryStore.Kind.String(), filename))
+			material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(moduleDir, "telemetrystore", config.Spec.TelemetryStore.Kind.String(), filename))
 			if err != nil {
 				return nil, err
 			}
@@ -119,7 +119,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 		materials = append(materials, m)
 
 		for filename, content := range config.Spec.MetaStore.Spec.Config.Data {
-			material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(moduleDir, "metastore", config.Spec.MetaStore.Kind.String(), filename))
+			material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(moduleDir, "metastore", config.Spec.MetaStore.Kind.String(), filename))
 			if err != nil {
 				return nil, err
 			}
@@ -145,7 +145,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 		materials = append(materials, m)
 
 		for filename, content := range config.Spec.Ingester.Spec.Config.Data {
-			material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(moduleDir, "ingester", filename))
+			material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(moduleDir, "ingester", filename))
 			if err != nil {
 				return nil, err
 			}
@@ -198,19 +198,19 @@ func (c *ecsCasting) Cast(ctx context.Context, config v1alpha1.Casting, outputPa
 }
 
 // executeTemplate renders a template and returns a JSONMaterial at the given path.
-func executeTemplate(tmpl *types.Template, config v1alpha1.Casting, path string) (types.Material, error) {
+func executeTemplate(tmpl *domain.Template, config v1alpha1.Casting, path string) (domain.Material, error) {
 	buf := bytes.NewBuffer(nil)
 	if err := tmpl.Execute(buf, config); err != nil {
-		return types.Material{}, fmt.Errorf("failed to execute template for %s: %w", path, err)
+		return domain.Material{}, fmt.Errorf("failed to execute template for %s: %w", path, err)
 	}
-	return types.NewJSONMaterial(buf.Bytes(), path)
+	return domain.NewJSONMaterial(buf.Bytes(), path)
 }
 
 // getMaterials renders all module templates and returns them as JSONMaterials.
-func getMaterials(config *v1alpha1.Casting) ([]types.Material, error) {
-	var materials []types.Material
+func getMaterials(config *v1alpha1.Casting) ([]domain.Material, error) {
+	var materials []domain.Material
 
-	for _, tmpl := range []*types.Template{
+	for _, tmpl := range []*domain.Template{
 		moduleMainTF,
 		moduleTelemetryStoreTF,
 		moduleTelemetryKeeperTF,

--- a/internal/casting/ecsterraformcasting/embed.go
+++ b/internal/casting/ecsterraformcasting/embed.go
@@ -3,7 +3,7 @@ package ecsterraformcasting
 import (
 	"embed"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/*.gotmpl templates/module/*.gotmpl
@@ -11,21 +11,21 @@ var templates embed.FS
 
 // Root Terraform templates.
 var (
-	mainTF      = types.MustNewTemplateFromFS(templates, "templates/main.tf.json.gotmpl", types.FormatJSON)
-	variablesTF = types.MustNewTemplateFromFS(templates, "templates/variables.tf.json.gotmpl", types.FormatJSON)
-	tfarsTF     = types.MustNewTemplateFromFS(templates, "templates/terraform.tfvars.json.gotmpl", types.FormatJSON)
+	mainTF      = domain.MustNewTemplateFromFS(templates, "templates/main.tf.json.gotmpl", domain.FormatJSON)
+	variablesTF = domain.MustNewTemplateFromFS(templates, "templates/variables.tf.json.gotmpl", domain.FormatJSON)
+	tfarsTF     = domain.MustNewTemplateFromFS(templates, "templates/terraform.tfvars.json.gotmpl", domain.FormatJSON)
 )
 
 // Module Terraform templates.
 var (
-	moduleMainTF      = types.MustNewTemplateFromFS(templates, "templates/module/main.tf.json.gotmpl", types.FormatJSON)
-	moduleVariablesTF = types.MustNewTemplateFromFS(templates, "templates/module/variables.tf.json.gotmpl", types.FormatJSON)
-	moduleOutputsTF   = types.MustNewTemplateFromFS(templates, "templates/module/outputs.tf.json.gotmpl", types.FormatJSON)
+	moduleMainTF      = domain.MustNewTemplateFromFS(templates, "templates/module/main.tf.json.gotmpl", domain.FormatJSON)
+	moduleVariablesTF = domain.MustNewTemplateFromFS(templates, "templates/module/variables.tf.json.gotmpl", domain.FormatJSON)
+	moduleOutputsTF   = domain.MustNewTemplateFromFS(templates, "templates/module/outputs.tf.json.gotmpl", domain.FormatJSON)
 
-	moduleTelemetryKeeperTF = types.MustNewTemplateFromFS(templates, "templates/module/telemetrykeeper.tf.json.gotmpl", types.FormatJSON)
-	moduleTelemetryStoreTF  = types.MustNewTemplateFromFS(templates, "templates/module/telemetrystore.tf.json.gotmpl", types.FormatJSON)
-	moduleMigratorTF        = types.MustNewTemplateFromFS(templates, "templates/module/telemetrystore_migrator.tf.json.gotmpl", types.FormatJSON)
-	moduleMetaStoreTF       = types.MustNewTemplateFromFS(templates, "templates/module/metastore.tf.json.gotmpl", types.FormatJSON)
-	moduleSignozTF          = types.MustNewTemplateFromFS(templates, "templates/module/signoz.tf.json.gotmpl", types.FormatJSON)
-	moduleIngesterTF        = types.MustNewTemplateFromFS(templates, "templates/module/ingester.tf.json.gotmpl", types.FormatJSON)
+	moduleTelemetryKeeperTF = domain.MustNewTemplateFromFS(templates, "templates/module/telemetrykeeper.tf.json.gotmpl", domain.FormatJSON)
+	moduleTelemetryStoreTF  = domain.MustNewTemplateFromFS(templates, "templates/module/telemetrystore.tf.json.gotmpl", domain.FormatJSON)
+	moduleMigratorTF        = domain.MustNewTemplateFromFS(templates, "templates/module/telemetrystore_migrator.tf.json.gotmpl", domain.FormatJSON)
+	moduleMetaStoreTF       = domain.MustNewTemplateFromFS(templates, "templates/module/metastore.tf.json.gotmpl", domain.FormatJSON)
+	moduleSignozTF          = domain.MustNewTemplateFromFS(templates, "templates/module/signoz.tf.json.gotmpl", domain.FormatJSON)
+	moduleIngesterTF        = domain.MustNewTemplateFromFS(templates, "templates/module/ingester.tf.json.gotmpl", domain.FormatJSON)
 )

--- a/internal/casting/ecsterraformcasting/embed_test.go
+++ b/internal/casting/ecsterraformcasting/embed_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	"github.com/signoz/foundry/api/v1alpha1"
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNotEmptyAndValid(t *testing.T) {
-	templates := map[string]*types.Template{
+	templates := map[string]*domain.Template{
 		"mainTF":                  mainTF,
 		"variablesTF":             variablesTF,
 		"moduleMainTF":            moduleMainTF,

--- a/internal/casting/ecsterraformcasting/enricher.go
+++ b/internal/casting/ecsterraformcasting/enricher.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 var _ molding.MoldingEnricher = (*ecsMoldingEnricher)(nil)
 
 type ecsMoldingEnricher struct {
-	materials []types.Material
+	materials []domain.Material
 }
 
 func newEcsMoldingEnricher(config *v1alpha1.Casting) (*ecsMoldingEnricher, error) {
@@ -47,7 +47,7 @@ func (enricher *ecsMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alp
 			return fmt.Errorf("failed to get telemetrystore service discovery name: %w", err)
 		}
 		fqdn := fmt.Sprintf("%s.%s", string(sdName), namespace)
-		config.Spec.TelemetryStore.Status.Addresses.TCP = []string{types.FormatAddress("tcp", fqdn, telemetryStorePort)}
+		config.Spec.TelemetryStore.Status.Addresses.TCP = []string{domain.FormatAddress("tcp", fqdn, telemetryStorePort)}
 
 	case v1alpha1.MoldingKindTelemetryKeeper:
 		sdName, err := enricher.materials[2].GetBytes("resource.aws_service_discovery_service.telemetrykeeper.name")
@@ -55,8 +55,8 @@ func (enricher *ecsMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alp
 			return fmt.Errorf("failed to get telemetrykeeper service discovery name: %w", err)
 		}
 		fqdn := fmt.Sprintf("%s.%s", string(sdName), namespace)
-		config.Spec.TelemetryKeeper.Status.Addresses.Client = []string{types.FormatAddress("tcp", fqdn, telemetryKeeperClientPort)}
-		config.Spec.TelemetryKeeper.Status.Addresses.Raft = []string{types.FormatAddress("tcp", fqdn, telemetryKeeperRaftPort)}
+		config.Spec.TelemetryKeeper.Status.Addresses.Client = []string{domain.FormatAddress("tcp", fqdn, telemetryKeeperClientPort)}
+		config.Spec.TelemetryKeeper.Status.Addresses.Raft = []string{domain.FormatAddress("tcp", fqdn, telemetryKeeperRaftPort)}
 
 	case v1alpha1.MoldingKindMetaStore:
 		sdName, err := enricher.materials[3].GetBytes("resource.aws_service_discovery_service.metastore.name")
@@ -64,7 +64,7 @@ func (enricher *ecsMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alp
 			return fmt.Errorf("failed to get metastore service discovery name: %w", err)
 		}
 		fqdn := fmt.Sprintf("%s.%s", string(sdName), namespace)
-		config.Spec.MetaStore.Status.Addresses.DSN = []string{types.FormatAddress("tcp", fqdn, metaStorePort)}
+		config.Spec.MetaStore.Status.Addresses.DSN = []string{domain.FormatAddress("tcp", fqdn, metaStorePort)}
 
 	case v1alpha1.MoldingKindSignoz:
 		sdName, err := enricher.materials[4].GetBytes("resource.aws_service_discovery_service.signoz.name")
@@ -72,8 +72,8 @@ func (enricher *ecsMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alp
 			return fmt.Errorf("failed to get signoz service discovery name: %w", err)
 		}
 		fqdn := fmt.Sprintf("%s.%s", string(sdName), namespace)
-		config.Spec.Signoz.Status.Addresses.APIServer = []string{types.FormatAddress("tcp", fqdn, signozAPIPort)}
-		config.Spec.Signoz.Status.Addresses.Opamp = []string{types.FormatAddress("ws", fqdn, signozOpampPort)}
+		config.Spec.Signoz.Status.Addresses.APIServer = []string{domain.FormatAddress("tcp", fqdn, signozAPIPort)}
+		config.Spec.Signoz.Status.Addresses.Opamp = []string{domain.FormatAddress("ws", fqdn, signozOpampPort)}
 	}
 
 	return nil

--- a/internal/casting/kuberneteshelmcasting/casting.go
+++ b/internal/casting/kuberneteshelmcasting/casting.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	rootcasting "github.com/signoz/foundry/internal/casting"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
@@ -37,7 +37,7 @@ var _ rootcasting.Casting = (*helmCasting)(nil)
 
 type helmCasting struct {
 	logger  *slog.Logger
-	casting *types.Template
+	casting *domain.Template
 }
 
 func New(logger *slog.Logger) *helmCasting {
@@ -51,7 +51,7 @@ func (c *helmCasting) Enricher(ctx context.Context, config *v1alpha1.Casting) (m
 	return newHelmMoldingEnricher(config), nil
 }
 
-func (c *helmCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]types.Material, error) {
+func (c *helmCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]domain.Material, error) {
 	buf := bytes.NewBuffer(nil)
 	err := valuesYAMLTemplate.Execute(buf, config)
 	if err != nil {
@@ -60,12 +60,12 @@ func (c *helmCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursP
 
 	valuesBytes := buf.Bytes()
 
-	valuesMaterial, err := types.NewYAMLMaterial(valuesBytes, filepath.Join(rootcasting.DeploymentDir, "values.yaml"))
+	valuesMaterial, err := domain.NewYAMLMaterial(valuesBytes, filepath.Join(rootcasting.DeploymentDir, "values.yaml"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create values yaml material: %w", err)
 	}
 
-	return []types.Material{valuesMaterial}, nil
+	return []domain.Material{valuesMaterial}, nil
 }
 
 func (c *helmCasting) Cast(ctx context.Context, config v1alpha1.Casting, poursPath string) error {

--- a/internal/casting/kuberneteshelmcasting/embed.go
+++ b/internal/casting/kuberneteshelmcasting/embed.go
@@ -3,10 +3,10 @@ package kuberneteshelmcasting
 import (
 	"embed"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/values.yaml.gotmpl
 var templates embed.FS
 
-var valuesYAMLTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/values.yaml.gotmpl", types.FormatYAML)
+var valuesYAMLTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/values.yaml.gotmpl", domain.FormatYAML)

--- a/internal/casting/kuberneteshelmcasting/enricher.go
+++ b/internal/casting/kuberneteshelmcasting/enricher.go
@@ -5,18 +5,18 @@ import (
 	"fmt"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ molding.MoldingEnricher = (*helmMoldingEnricher)(nil)
 
 type helmMoldingEnricher struct {
-	materials []types.Material
+	materials []domain.Material
 }
 
 func newHelmMoldingEnricher(_ *v1alpha1.Casting) *helmMoldingEnricher {
-	return &helmMoldingEnricher{materials: []types.Material{}}
+	return &helmMoldingEnricher{materials: []domain.Material{}}
 }
 
 func (e *helmMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alpha1.MoldingKind, config *v1alpha1.Casting) error {
@@ -37,7 +37,7 @@ func (e *helmMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alpha1.Mo
 
 func (e *helmMoldingEnricher) enrichTelemetryStore(config *v1alpha1.Casting) error {
 	name := fmt.Sprintf("%s-telemetrystore-%s", config.Metadata.Name, config.Spec.TelemetryStore.Kind)
-	config.Spec.TelemetryStore.Status.Addresses.TCP = []string{types.FormatAddress("tcp", name, 9000)}
+	config.Spec.TelemetryStore.Status.Addresses.TCP = []string{domain.FormatAddress("tcp", name, 9000)}
 	return nil
 }
 
@@ -54,8 +54,8 @@ func (e *helmMoldingEnricher) enrichTelemetryKeeper(config *v1alpha1.Casting) er
 	base := fmt.Sprintf("%s-telemetrykeeper-zookeeper", config.Metadata.Name)
 	var client, raft []string
 	for i := 0; i < replicas; i++ {
-		client = append(client, types.FormatAddress("tcp", fmt.Sprintf("%s-%d", base, i), 9181))
-		raft = append(raft, types.FormatAddress("tcp", fmt.Sprintf("%s-%d", base, i), 9234))
+		client = append(client, domain.FormatAddress("tcp", fmt.Sprintf("%s-%d", base, i), 9181))
+		raft = append(raft, domain.FormatAddress("tcp", fmt.Sprintf("%s-%d", base, i), 9234))
 	}
 	config.Spec.TelemetryKeeper.Status.Addresses.Client = client
 	config.Spec.TelemetryKeeper.Status.Addresses.Raft = raft
@@ -73,7 +73,7 @@ func (e *helmMoldingEnricher) enrichMetaStore(config *v1alpha1.Casting) error {
 func (e *helmMoldingEnricher) enrichSignoz(config *v1alpha1.Casting) error {
 	// Chart uses signoz.fullname which resolves to fullnameOverride directly.
 	name := config.Metadata.Name
-	config.Spec.Signoz.Status.Addresses.Opamp = []string{types.FormatAddress("tcp", name, 4320)}
+	config.Spec.Signoz.Status.Addresses.Opamp = []string{domain.FormatAddress("tcp", name, 4320)}
 	return nil
 }
 

--- a/internal/casting/kuberneteskustomizecasting/casting.go
+++ b/internal/casting/kuberneteskustomizecasting/casting.go
@@ -13,21 +13,21 @@ import (
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	rootcasting "github.com/signoz/foundry/internal/casting"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ rootcasting.Casting = (*kustomizeCasting)(nil)
 
 type kustomizeCasting struct {
 	logger   *slog.Logger
-	castings []*types.Template
+	castings []*domain.Template
 }
 
 func New(logger *slog.Logger) *kustomizeCasting {
 	return &kustomizeCasting{
 		logger: logger,
-		castings: []*types.Template{
+		castings: []*domain.Template{
 			clickhouseOperatorClusterrole,
 			clickhouseOperatorClusterrolebinding,
 			clickhouseOperatorConfigmap,
@@ -65,8 +65,8 @@ func (c *kustomizeCasting) Enricher(ctx context.Context, config *v1alpha1.Castin
 	return newKustomizeMoldingEnricher(config)
 }
 
-func (c *kustomizeCasting) Forge(ctx context.Context, cfg v1alpha1.Casting, poursPath string) ([]types.Material, error) {
-	var materials []types.Material
+func (c *kustomizeCasting) Forge(ctx context.Context, cfg v1alpha1.Casting, poursPath string) ([]domain.Material, error) {
+	var materials []domain.Material
 	for _, tmpl := range c.castings {
 		m, err := c.forgeCasting(tmpl, &cfg, poursPath)
 		if err != nil {
@@ -141,7 +141,7 @@ func (c *kustomizeCasting) applyCRDs(ctx context.Context) error {
 	return nil
 }
 
-func (c *kustomizeCasting) forgeCasting(tmpl *types.Template, cfg *v1alpha1.Casting, poursPath string) ([]types.Material, error) {
+func (c *kustomizeCasting) forgeCasting(tmpl *domain.Template, cfg *v1alpha1.Casting, poursPath string) ([]domain.Material, error) {
 	templatePath := tmpl.GetPath()
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, cfg); err != nil {
@@ -150,21 +150,21 @@ func (c *kustomizeCasting) forgeCasting(tmpl *types.Template, cfg *v1alpha1.Cast
 	relPath := strings.TrimPrefix(templatePath, "templates/")
 	relPath = strings.TrimSuffix(relPath, filepath.Ext(relPath))
 	path := filepath.Join(rootcasting.DeploymentDir, relPath)
-	material, err := types.NewYAMLMaterial(buf.Bytes(), path)
+	material, err := domain.NewYAMLMaterial(buf.Bytes(), path)
 	if err != nil {
 		return nil, fmt.Errorf("create material %s: %w", templatePath, err)
 	}
-	return []types.Material{material}, nil
+	return []domain.Material{material}, nil
 }
 
-func getOverrideMaterials(config *v1alpha1.Casting) ([]types.Material, error) {
-	var materials []types.Material
+func getOverrideMaterials(config *v1alpha1.Casting) ([]domain.Material, error) {
+	var materials []domain.Material
 
 	storeBuf := bytes.NewBuffer(nil)
 	if err := telemetryStoreOverrideTemplate.Execute(storeBuf, config); err != nil {
 		return nil, fmt.Errorf("failed to execute store override template: %w", err)
 	}
-	storeMaterial, err := types.NewYAMLMaterial(storeBuf.Bytes(), "store_overrides.yaml")
+	storeMaterial, err := domain.NewYAMLMaterial(storeBuf.Bytes(), "store_overrides.yaml")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create store override material: %w", err)
 	}
@@ -173,14 +173,14 @@ func getOverrideMaterials(config *v1alpha1.Casting) ([]types.Material, error) {
 	return materials, nil
 }
 
-func getServiceMaterials(config *v1alpha1.Casting) ([]types.Material, error) {
-	var materials []types.Material
+func getServiceMaterials(config *v1alpha1.Casting) ([]domain.Material, error) {
+	var materials []domain.Material
 
 	telemetryStoreInstallationBuf := bytes.NewBuffer(nil)
 	if err := clickhouseInstanceInstallation.Execute(telemetryStoreInstallationBuf, config); err != nil {
 		return nil, fmt.Errorf("failed to execute store installation template: %w", err)
 	}
-	telemetryStoreInstallationMaterial, err := types.NewYAMLMaterial(telemetryStoreInstallationBuf.Bytes(), "clickhouseInstallation.yaml")
+	telemetryStoreInstallationMaterial, err := domain.NewYAMLMaterial(telemetryStoreInstallationBuf.Bytes(), "clickhouseInstallation.yaml")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create keeper override material: %w", err)
 	}
@@ -190,7 +190,7 @@ func getServiceMaterials(config *v1alpha1.Casting) ([]types.Material, error) {
 	if err := metastoreService.Execute(metaStoreServiceBuf, config); err != nil {
 		return nil, fmt.Errorf("failed to execute store installation template: %w", err)
 	}
-	metaStoreServiceMaterial, err := types.NewYAMLMaterial(metaStoreServiceBuf.Bytes(), "metastoreServie.yaml")
+	metaStoreServiceMaterial, err := domain.NewYAMLMaterial(metaStoreServiceBuf.Bytes(), "metastoreServie.yaml")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metastore service material: %w", err)
 	}

--- a/internal/casting/kuberneteskustomizecasting/embed.go
+++ b/internal/casting/kuberneteskustomizecasting/embed.go
@@ -3,7 +3,7 @@ package kuberneteskustomizecasting
 import (
 	"embed"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/*/*.gotmpl templates/*/*/*.gotmpl templates/*.gotmpl
@@ -11,50 +11,50 @@ var templates embed.FS
 
 var (
 	// telemetrystore/clickhouse-operator.
-	clickhouseOperatorClusterrole        = types.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/clusterrole.yaml.gotmpl", types.FormatYAML)
-	clickhouseOperatorClusterrolebinding = types.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/clusterrolebinding.yaml.gotmpl", types.FormatYAML)
-	clickhouseOperatorConfigmap          = types.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/configmap.yaml.gotmpl", types.FormatYAML)
-	clickhouseOperatorDeployment         = types.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/deployment.yaml.gotmpl", types.FormatYAML)
-	clickhouseOperatorService            = types.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/service.yaml.gotmpl", types.FormatYAML)
-	clickhouseOperatorServiceaccount     = types.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/serviceaccount.yaml.gotmpl", types.FormatYAML)
-	clickhouseOperatorKustomization      = types.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/kustomization.yaml.gotmpl", types.FormatYAML)
+	clickhouseOperatorClusterrole        = domain.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/clusterrole.yaml.gotmpl", domain.FormatYAML)
+	clickhouseOperatorClusterrolebinding = domain.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/clusterrolebinding.yaml.gotmpl", domain.FormatYAML)
+	clickhouseOperatorConfigmap          = domain.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/configmap.yaml.gotmpl", domain.FormatYAML)
+	clickhouseOperatorDeployment         = domain.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/deployment.yaml.gotmpl", domain.FormatYAML)
+	clickhouseOperatorService            = domain.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/service.yaml.gotmpl", domain.FormatYAML)
+	clickhouseOperatorServiceaccount     = domain.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/serviceaccount.yaml.gotmpl", domain.FormatYAML)
+	clickhouseOperatorKustomization      = domain.MustNewTemplateFromFS(templates, "templates/clickhouse-operator/kustomization.yaml.gotmpl", domain.FormatYAML)
 
 	// telemetrystore/clickhouse.
-	clickhouseInstanceInstallation      = types.MustNewTemplateFromFS(templates, "templates/telemetrystore/clickhouse/clickhouseinstallation.yaml.gotmpl", types.FormatYAML)
-	clickhouseInstanceConfigmap         = types.MustNewTemplateFromFS(templates, "templates/telemetrystore/clickhouse/configmap.yaml.gotmpl", types.FormatYAML)
-	clickhouseInstallationKustomization = types.MustNewTemplateFromFS(templates, "templates/telemetrystore/clickhouse/kustomization.yaml.gotmpl", types.FormatYAML)
+	clickhouseInstanceInstallation      = domain.MustNewTemplateFromFS(templates, "templates/telemetrystore/clickhouse/clickhouseinstallation.yaml.gotmpl", domain.FormatYAML)
+	clickhouseInstanceConfigmap         = domain.MustNewTemplateFromFS(templates, "templates/telemetrystore/clickhouse/configmap.yaml.gotmpl", domain.FormatYAML)
+	clickhouseInstallationKustomization = domain.MustNewTemplateFromFS(templates, "templates/telemetrystore/clickhouse/kustomization.yaml.gotmpl", domain.FormatYAML)
 
 	// telemetrykeeper.
-	clickhouseKeeperInstallation  = types.MustNewTemplateFromFS(templates, "templates/telemetrykeeper/clickhousekeeper/clickhousekeeperinstallation.yaml.gotmpl", types.FormatYAML)
-	clickhouseKeeperKustomization = types.MustNewTemplateFromFS(templates, "templates/telemetrykeeper/clickhousekeeper/kustomization.yaml.gotmpl", types.FormatYAML)
+	clickhouseKeeperInstallation  = domain.MustNewTemplateFromFS(templates, "templates/telemetrykeeper/clickhousekeeper/clickhousekeeperinstallation.yaml.gotmpl", domain.FormatYAML)
+	clickhouseKeeperKustomization = domain.MustNewTemplateFromFS(templates, "templates/telemetrykeeper/clickhousekeeper/kustomization.yaml.gotmpl", domain.FormatYAML)
 
 	// signoz.
-	signozService        = types.MustNewTemplateFromFS(templates, "templates/signoz/service.yaml.gotmpl", types.FormatYAML)
-	signozServiceaccount = types.MustNewTemplateFromFS(templates, "templates/signoz/serviceaccount.yaml.gotmpl", types.FormatYAML)
-	signozStatefulset    = types.MustNewTemplateFromFS(templates, "templates/signoz/statefulset.yaml.gotmpl", types.FormatYAML)
-	signozKustomization  = types.MustNewTemplateFromFS(templates, "templates/signoz/kustomization.yaml.gotmpl", types.FormatYAML)
+	signozService        = domain.MustNewTemplateFromFS(templates, "templates/signoz/service.yaml.gotmpl", domain.FormatYAML)
+	signozServiceaccount = domain.MustNewTemplateFromFS(templates, "templates/signoz/serviceaccount.yaml.gotmpl", domain.FormatYAML)
+	signozStatefulset    = domain.MustNewTemplateFromFS(templates, "templates/signoz/statefulset.yaml.gotmpl", domain.FormatYAML)
+	signozKustomization  = domain.MustNewTemplateFromFS(templates, "templates/signoz/kustomization.yaml.gotmpl", domain.FormatYAML)
 
 	// ingester.
-	ingesterConfigmap      = types.MustNewTemplateFromFS(templates, "templates/ingester/configmap.yaml.gotmpl", types.FormatYAML)
-	ingesterDeployment     = types.MustNewTemplateFromFS(templates, "templates/ingester/deployment.yaml.gotmpl", types.FormatYAML)
-	ingesterService        = types.MustNewTemplateFromFS(templates, "templates/ingester/service.yaml.gotmpl", types.FormatYAML)
-	ingesterServiceaccount = types.MustNewTemplateFromFS(templates, "templates/ingester/serviceaccount.yaml.gotmpl", types.FormatYAML)
-	ingesterKustomization  = types.MustNewTemplateFromFS(templates, "templates/ingester/kustomization.yaml.gotmpl", types.FormatYAML)
+	ingesterConfigmap      = domain.MustNewTemplateFromFS(templates, "templates/ingester/configmap.yaml.gotmpl", domain.FormatYAML)
+	ingesterDeployment     = domain.MustNewTemplateFromFS(templates, "templates/ingester/deployment.yaml.gotmpl", domain.FormatYAML)
+	ingesterService        = domain.MustNewTemplateFromFS(templates, "templates/ingester/service.yaml.gotmpl", domain.FormatYAML)
+	ingesterServiceaccount = domain.MustNewTemplateFromFS(templates, "templates/ingester/serviceaccount.yaml.gotmpl", domain.FormatYAML)
+	ingesterKustomization  = domain.MustNewTemplateFromFS(templates, "templates/ingester/kustomization.yaml.gotmpl", domain.FormatYAML)
 
 	// metastore/postgres.
-	metastoreService        = types.MustNewTemplateFromFS(templates, "templates/metastore/postgres/service.yaml.gotmpl", types.FormatYAML)
-	metastoreServiceaccount = types.MustNewTemplateFromFS(templates, "templates/metastore/postgres/serviceaccount.yaml.gotmpl", types.FormatYAML)
-	metastoreStatefulset    = types.MustNewTemplateFromFS(templates, "templates/metastore/postgres/statefulset.yaml.gotmpl", types.FormatYAML)
-	metastoreKustomization  = types.MustNewTemplateFromFS(templates, "templates/metastore/postgres/kustomization.yaml.gotmpl", types.FormatYAML)
+	metastoreService        = domain.MustNewTemplateFromFS(templates, "templates/metastore/postgres/service.yaml.gotmpl", domain.FormatYAML)
+	metastoreServiceaccount = domain.MustNewTemplateFromFS(templates, "templates/metastore/postgres/serviceaccount.yaml.gotmpl", domain.FormatYAML)
+	metastoreStatefulset    = domain.MustNewTemplateFromFS(templates, "templates/metastore/postgres/statefulset.yaml.gotmpl", domain.FormatYAML)
+	metastoreKustomization  = domain.MustNewTemplateFromFS(templates, "templates/metastore/postgres/kustomization.yaml.gotmpl", domain.FormatYAML)
 
 	// telemetrystore-migrator.
-	telemetrystoreMigratorJob           = types.MustNewTemplateFromFS(templates, "templates/telemetrystore-migrator/job.yaml.gotmpl", types.FormatYAML)
-	telemetrystoreMigratorKustomization = types.MustNewTemplateFromFS(templates, "templates/telemetrystore-migrator/kustomization.yaml.gotmpl", types.FormatYAML)
+	telemetrystoreMigratorJob           = domain.MustNewTemplateFromFS(templates, "templates/telemetrystore-migrator/job.yaml.gotmpl", domain.FormatYAML)
+	telemetrystoreMigratorKustomization = domain.MustNewTemplateFromFS(templates, "templates/telemetrystore-migrator/kustomization.yaml.gotmpl", domain.FormatYAML)
 
 	// deployment.
-	deploymentNamespace     = types.MustNewTemplateFromFS(templates, "templates/namespace.yaml.gotmpl", types.FormatYAML)
-	deploymentKustomization = types.MustNewTemplateFromFS(templates, "templates/kustomization.yaml.gotmpl", types.FormatYAML)
+	deploymentNamespace     = domain.MustNewTemplateFromFS(templates, "templates/namespace.yaml.gotmpl", domain.FormatYAML)
+	deploymentKustomization = domain.MustNewTemplateFromFS(templates, "templates/kustomization.yaml.gotmpl", domain.FormatYAML)
 
 	// molding overrides.
-	telemetryStoreOverrideTemplate = types.MustNewTemplateFromFS(templates, "templates/overrides/telemetrystore.yaml.gotmpl", types.FormatYAML)
+	telemetryStoreOverrideTemplate = domain.MustNewTemplateFromFS(templates, "templates/overrides/telemetrystore.yaml.gotmpl", domain.FormatYAML)
 )

--- a/internal/casting/kuberneteskustomizecasting/enricher.go
+++ b/internal/casting/kuberneteskustomizecasting/enricher.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 const (
@@ -19,8 +19,8 @@ const (
 var _ molding.MoldingEnricher = (*kustomizeMoldingEnricher)(nil)
 
 type kustomizeMoldingEnricher struct {
-	materials         []types.Material
-	overrideMaterials []types.Material
+	materials         []domain.Material
+	overrideMaterials []domain.Material
 }
 
 func newKustomizeMoldingEnricher(config *v1alpha1.Casting) (*kustomizeMoldingEnricher, error) {
@@ -61,7 +61,7 @@ func (e *kustomizeMoldingEnricher) enrichTelemetryStore(config *v1alpha1.Casting
 	if err != nil {
 		return fmt.Errorf("failed to get telemetrystore service names: %w", err)
 	}
-	config.Spec.TelemetryStore.Status.Addresses.TCP = []string{types.FormatAddress("tcp", string(name), telemetryStorePort)}
+	config.Spec.TelemetryStore.Status.Addresses.TCP = []string{domain.FormatAddress("tcp", string(name), telemetryStorePort)}
 
 	if config.Spec.TelemetryStore.Status.Extras == nil {
 		config.Spec.TelemetryStore.Status.Extras = make(map[string]string)
@@ -85,8 +85,8 @@ func (e *kustomizeMoldingEnricher) enrichTelemetryKeeper(config *v1alpha1.Castin
 	base := config.Metadata.Name + "-clickhouse-keeper"
 	var client, raft []string
 	for i := 0; i < replicas; i++ {
-		client = append(client, types.FormatAddress("tcp", fmt.Sprintf("%s-%d", base, i), telemetryKeeperClientPort))
-		raft = append(raft, types.FormatAddress("tcp", fmt.Sprintf("%s-%d", base, i), telemetryKeeperRaftPort))
+		client = append(client, domain.FormatAddress("tcp", fmt.Sprintf("%s-%d", base, i), telemetryKeeperClientPort))
+		raft = append(raft, domain.FormatAddress("tcp", fmt.Sprintf("%s-%d", base, i), telemetryKeeperRaftPort))
 	}
 	config.Spec.TelemetryKeeper.Status.Addresses.Client = client
 	config.Spec.TelemetryKeeper.Status.Addresses.Raft = raft
@@ -106,7 +106,7 @@ func (e *kustomizeMoldingEnricher) enrichMetaStore(config *v1alpha1.Casting) err
 
 func (e *kustomizeMoldingEnricher) enrichSignoz(config *v1alpha1.Casting) error {
 	name := config.Metadata.Name + "-signoz"
-	config.Spec.Signoz.Status.Addresses.Opamp = []string{types.FormatAddress("ws", name, signozOpampPort)}
+	config.Spec.Signoz.Status.Addresses.Opamp = []string{domain.FormatAddress("ws", name, signozOpampPort)}
 	return nil
 }
 

--- a/internal/casting/railwaytemplatecasting/casting.go
+++ b/internal/casting/railwaytemplatecasting/casting.go
@@ -9,21 +9,21 @@ import (
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	"github.com/signoz/foundry/internal/casting"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ casting.Casting = (*railwayTemplateCasting)(nil)
 
 type railwayTemplateCasting struct {
 	logger   *slog.Logger
-	castings []*types.Template
+	castings []*domain.Template
 }
 
 func New(logger *slog.Logger) *railwayTemplateCasting {
 	return &railwayTemplateCasting{
 		logger: logger,
-		castings: []*types.Template{
+		castings: []*domain.Template{
 			telemetryKeeperDockerfileTemplate,
 			telemetryStoreDockerfileTemplate,
 			ingesterDockerfileTemplate,
@@ -44,8 +44,8 @@ func (c *railwayTemplateCasting) Enricher(ctx context.Context, config *v1alpha1.
 	return newRailwayTemplateMoldingEnricher(config)
 }
 
-func (c *railwayTemplateCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]types.Material, error) {
-	var materials []types.Material
+func (c *railwayTemplateCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]domain.Material, error) {
+	var materials []domain.Material
 
 	// TelemetryKeeper: Dockerfile + configs + railway.json
 	if config.Spec.TelemetryKeeper.Spec.IsEnabled() {
@@ -53,14 +53,14 @@ func (c *railwayTemplateCasting) Forge(ctx context.Context, config v1alpha1.Cast
 		if err := telemetryKeeperDockerfileTemplate.Execute(dockerfileBuf, config); err != nil {
 			return nil, fmt.Errorf("telemetrykeeper dockerfile: %w", err)
 		}
-		materials = append(materials, types.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrykeeper/Dockerfile")))
+		materials = append(materials, domain.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrykeeper/Dockerfile")))
 		railwayBuf := bytes.NewBuffer(nil)
 		if err := railwayTelemetryKeeperTemplate.Execute(railwayBuf, config); err != nil {
 			return nil, fmt.Errorf("telemetrykeeper railway.json: %w", err)
 		}
-		materials = append(materials, types.NewTextMaterial(railwayBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrykeeper/railway.json")))
+		materials = append(materials, domain.NewTextMaterial(railwayBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrykeeper/railway.json")))
 		for filename, content := range config.Spec.TelemetryKeeper.Spec.Config.Data {
-			m, err := types.NewYAMLMaterial([]byte(content), filepath.Join(casting.DeploymentDir, "telemetrykeeper/keeper.d/", filename))
+			m, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(casting.DeploymentDir, "telemetrykeeper/keeper.d/", filename))
 			if err != nil {
 				return nil, fmt.Errorf("telemetrykeeper config: %w", err)
 			}
@@ -74,14 +74,14 @@ func (c *railwayTemplateCasting) Forge(ctx context.Context, config v1alpha1.Cast
 		if err := telemetryStoreDockerfileTemplate.Execute(dockerfileBuf, config); err != nil {
 			return nil, fmt.Errorf("telemetrystore dockerfile: %w", err)
 		}
-		materials = append(materials, types.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrystore/Dockerfile")))
+		materials = append(materials, domain.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrystore/Dockerfile")))
 		railwayBuf := bytes.NewBuffer(nil)
 		if err := railwayTelemetryStoreTemplate.Execute(railwayBuf, config); err != nil {
 			return nil, fmt.Errorf("telemetrystore railway.json: %w", err)
 		}
-		materials = append(materials, types.NewTextMaterial(railwayBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrystore/railway.json")))
+		materials = append(materials, domain.NewTextMaterial(railwayBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrystore/railway.json")))
 		for filename, content := range config.Spec.TelemetryStore.Spec.Config.Data {
-			m, err := types.NewYAMLMaterial([]byte(content), filepath.Join(casting.DeploymentDir, "telemetrystore/config.d/", filename))
+			m, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(casting.DeploymentDir, "telemetrystore/config.d/", filename))
 			if err != nil {
 				return nil, fmt.Errorf("telemetrystore config: %w", err)
 			}
@@ -95,14 +95,14 @@ func (c *railwayTemplateCasting) Forge(ctx context.Context, config v1alpha1.Cast
 		if err := ingesterDockerfileTemplate.Execute(dockerfileBuf, config); err != nil {
 			return nil, fmt.Errorf("ingester dockerfile: %w", err)
 		}
-		materials = append(materials, types.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(casting.DeploymentDir, "ingester/Dockerfile")))
+		materials = append(materials, domain.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(casting.DeploymentDir, "ingester/Dockerfile")))
 		railwayBuf := bytes.NewBuffer(nil)
 		if err := railwayIngesterTemplate.Execute(railwayBuf, config); err != nil {
 			return nil, fmt.Errorf("ingester railway.json: %w", err)
 		}
-		materials = append(materials, types.NewTextMaterial(railwayBuf.Bytes(), filepath.Join(casting.DeploymentDir, "ingester/railway.json")))
+		materials = append(materials, domain.NewTextMaterial(railwayBuf.Bytes(), filepath.Join(casting.DeploymentDir, "ingester/railway.json")))
 		for filename, content := range config.Spec.Ingester.Spec.Config.Data {
-			m, err := types.NewYAMLMaterial([]byte(content), filepath.Join(casting.DeploymentDir, "ingester/", filename))
+			m, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(casting.DeploymentDir, "ingester/", filename))
 			if err != nil {
 				return nil, fmt.Errorf("ingester config: %w", err)
 			}
@@ -116,12 +116,12 @@ func (c *railwayTemplateCasting) Forge(ctx context.Context, config v1alpha1.Cast
 		if err := signozDockerfileTemplate.Execute(dockerfileBuf, config); err != nil {
 			return nil, fmt.Errorf("signoz dockerfile: %w", err)
 		}
-		materials = append(materials, types.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(casting.DeploymentDir, "signoz/Dockerfile")))
+		materials = append(materials, domain.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(casting.DeploymentDir, "signoz/Dockerfile")))
 		railwayBuf := bytes.NewBuffer(nil)
 		if err := railwaySignozTemplate.Execute(railwayBuf, config); err != nil {
 			return nil, fmt.Errorf("signoz railway.json: %w", err)
 		}
-		materials = append(materials, types.NewTextMaterial(railwayBuf.Bytes(), filepath.Join(casting.DeploymentDir, "signoz/railway.json")))
+		materials = append(materials, domain.NewTextMaterial(railwayBuf.Bytes(), filepath.Join(casting.DeploymentDir, "signoz/railway.json")))
 	}
 
 	// TelemetryStore migrator: Dockerfile + railway.json
@@ -130,12 +130,12 @@ func (c *railwayTemplateCasting) Forge(ctx context.Context, config v1alpha1.Cast
 		if err := telemetryStoreMigratorDockerfileTemplate.Execute(dockerfileBuf, config); err != nil {
 			return nil, fmt.Errorf("telemetrystore-migrator dockerfile: %w", err)
 		}
-		materials = append(materials, types.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrystore-migrator/Dockerfile")))
+		materials = append(materials, domain.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrystore-migrator/Dockerfile")))
 		railwayBuf := bytes.NewBuffer(nil)
 		if err := railwayTelemetryStoreMigratorTemplate.Execute(railwayBuf, config); err != nil {
 			return nil, fmt.Errorf("telemetrystore-migrator railway.json: %w", err)
 		}
-		materials = append(materials, types.NewTextMaterial(railwayBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrystore-migrator/railway.json")))
+		materials = append(materials, domain.NewTextMaterial(railwayBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrystore-migrator/railway.json")))
 	}
 
 	return materials, nil
@@ -146,14 +146,14 @@ func (c *railwayTemplateCasting) Cast(ctx context.Context, config v1alpha1.Casti
 	return nil
 }
 
-func getRailwayMaterial(config *v1alpha1.Casting) ([]types.Material, error) {
-	var materials []types.Material
+func getRailwayMaterial(config *v1alpha1.Casting) ([]domain.Material, error) {
+	var materials []domain.Material
 
 	keeperBuf := bytes.NewBuffer(nil)
 	if err := telemetryKeeperOverrideTemplate.Execute(keeperBuf, config); err != nil {
 		return nil, fmt.Errorf("failed to execute keeper override template: %w", err)
 	}
-	keeperMaterial, err := types.NewYAMLMaterial(keeperBuf.Bytes(), "keeper_overrides.yaml")
+	keeperMaterial, err := domain.NewYAMLMaterial(keeperBuf.Bytes(), "keeper_overrides.yaml")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create keeper override material: %w", err)
 	}
@@ -163,7 +163,7 @@ func getRailwayMaterial(config *v1alpha1.Casting) ([]types.Material, error) {
 	if err := telemetryStoreOverrideTemplate.Execute(storeBuf, config); err != nil {
 		return nil, fmt.Errorf("failed to execute keeper override template: %w", err)
 	}
-	storeMaterial, err := types.NewYAMLMaterial(storeBuf.Bytes(), "store_overrides.yaml")
+	storeMaterial, err := domain.NewYAMLMaterial(storeBuf.Bytes(), "store_overrides.yaml")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create keeper override material: %w", err)
 	}

--- a/internal/casting/railwaytemplatecasting/embed.go
+++ b/internal/casting/railwaytemplatecasting/embed.go
@@ -3,26 +3,26 @@ package railwaytemplatecasting
 import (
 	"embed"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/*.gotmpl
 var templates embed.FS
 
 var (
-	telemetryKeeperDockerfileTemplate        *types.Template = types.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v2556.gotmpl", types.FormatText)
-	telemetryStoreDockerfileTemplate         *types.Template = types.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v2556.gotmpl", types.FormatText)
-	ingesterDockerfileTemplate               *types.Template = types.MustNewTemplateFromFS(templates, "templates/Dockerfile.ingester.gotmpl", types.FormatText)
-	signozDockerfileTemplate                 *types.Template = types.MustNewTemplateFromFS(templates, "templates/Dockerfile.signoz.gotmpl", types.FormatText)
-	telemetryStoreMigratorDockerfileTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/Dockerfile.telemetrystore-migrator.gotmpl", types.FormatText)
+	telemetryKeeperDockerfileTemplate        *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v2556.gotmpl", domain.FormatText)
+	telemetryStoreDockerfileTemplate         *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v2556.gotmpl", domain.FormatText)
+	ingesterDockerfileTemplate               *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.ingester.gotmpl", domain.FormatText)
+	signozDockerfileTemplate                 *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.signoz.gotmpl", domain.FormatText)
+	telemetryStoreMigratorDockerfileTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.telemetrystore-migrator.gotmpl", domain.FormatText)
 
-	railwayTelemetryKeeperTemplate        *types.Template = types.MustNewTemplateFromFS(templates, "templates/railway.telemetrykeeper.json.gotmpl", types.FormatText)
-	railwayTelemetryStoreTemplate         *types.Template = types.MustNewTemplateFromFS(templates, "templates/railway.telemetrystore.json.gotmpl", types.FormatText)
-	railwayIngesterTemplate               *types.Template = types.MustNewTemplateFromFS(templates, "templates/railway.ingester.json.gotmpl", types.FormatText)
-	railwaySignozTemplate                 *types.Template = types.MustNewTemplateFromFS(templates, "templates/railway.signoz.json.gotmpl", types.FormatText)
-	railwayTelemetryStoreMigratorTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/railway.telemetrystore-migrator.json.gotmpl", types.FormatText)
+	railwayTelemetryKeeperTemplate        *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/railway.telemetrykeeper.json.gotmpl", domain.FormatText)
+	railwayTelemetryStoreTemplate         *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/railway.telemetrystore.json.gotmpl", domain.FormatText)
+	railwayIngesterTemplate               *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/railway.ingester.json.gotmpl", domain.FormatText)
+	railwaySignozTemplate                 *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/railway.signoz.json.gotmpl", domain.FormatText)
+	railwayTelemetryStoreMigratorTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/railway.telemetrystore-migrator.json.gotmpl", domain.FormatText)
 
 	// molding overrides.
-	telemetryKeeperOverrideTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/telemetrykeeper.yaml.gotmpl", types.FormatYAML)
-	telemetryStoreOverrideTemplate  *types.Template = types.MustNewTemplateFromFS(templates, "templates/telemetrystore.yaml.gotmpl", types.FormatYAML)
+	telemetryKeeperOverrideTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/telemetrykeeper.yaml.gotmpl", domain.FormatYAML)
+	telemetryStoreOverrideTemplate  *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/telemetrystore.yaml.gotmpl", domain.FormatYAML)
 )

--- a/internal/casting/railwaytemplatecasting/enricher.go
+++ b/internal/casting/railwaytemplatecasting/enricher.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ molding.MoldingEnricher = (*railwayTemplateMoldingEnricher)(nil)
 
 type railwayTemplateMoldingEnricher struct {
-	material []types.Material
+	material []domain.Material
 }
 
 func newRailwayTemplateMoldingEnricher(config *v1alpha1.Casting) (*railwayTemplateMoldingEnricher, error) {
@@ -40,7 +40,7 @@ func (enricher *railwayTemplateMoldingEnricher) EnrichStatus(ctx context.Context
 			return nil
 		}
 		svc := name + "-telemetrystore-" + config.Spec.TelemetryStore.Kind.String()
-		config.Spec.TelemetryStore.Status.Addresses.TCP = []string{types.FormatAddress("tcp", railwayInternalHost(svc), 9000)}
+		config.Spec.TelemetryStore.Status.Addresses.TCP = []string{domain.FormatAddress("tcp", railwayInternalHost(svc), 9000)}
 		if config.Spec.TelemetryStore.Status.Extras == nil {
 			config.Spec.TelemetryStore.Status.Extras = make(map[string]string)
 		}
@@ -52,16 +52,16 @@ func (enricher *railwayTemplateMoldingEnricher) EnrichStatus(ctx context.Context
 			return nil
 		}
 		svc := name + "-signoz"
-		config.Spec.Signoz.Status.Addresses.APIServer = []string{types.FormatAddress("tcp", railwayInternalHost(svc), 8080)}
-		config.Spec.Signoz.Status.Addresses.Opamp = []string{types.FormatAddress("ws", railwayInternalHost(svc), 4320)}
+		config.Spec.Signoz.Status.Addresses.APIServer = []string{domain.FormatAddress("tcp", railwayInternalHost(svc), 8080)}
+		config.Spec.Signoz.Status.Addresses.Opamp = []string{domain.FormatAddress("ws", railwayInternalHost(svc), 4320)}
 
 	case v1alpha1.MoldingKindTelemetryKeeper:
 		if !config.Spec.TelemetryKeeper.Spec.IsEnabled() {
 			return nil
 		}
 		svc := name + "-telemetrykeeper-" + config.Spec.TelemetryKeeper.Kind.String()
-		config.Spec.TelemetryKeeper.Status.Addresses.Client = []string{types.FormatAddress("tcp", railwayInternalHost(svc), 9181)}
-		config.Spec.TelemetryKeeper.Status.Addresses.Raft = []string{types.FormatAddress("tcp", railwayInternalHost(svc), 9234)}
+		config.Spec.TelemetryKeeper.Status.Addresses.Client = []string{domain.FormatAddress("tcp", railwayInternalHost(svc), 9181)}
+		config.Spec.TelemetryKeeper.Status.Addresses.Raft = []string{domain.FormatAddress("tcp", railwayInternalHost(svc), 9234)}
 		if config.Spec.TelemetryKeeper.Status.Extras == nil {
 			config.Spec.TelemetryKeeper.Status.Extras = make(map[string]string)
 		}
@@ -72,7 +72,7 @@ func (enricher *railwayTemplateMoldingEnricher) EnrichStatus(ctx context.Context
 			return nil
 		}
 		svc := name + "-ingester"
-		config.Spec.Ingester.Status.Addresses.OTLP = []string{types.FormatAddress("tcp", railwayInternalHost(svc), 4318)}
+		config.Spec.Ingester.Status.Addresses.OTLP = []string{domain.FormatAddress("tcp", railwayInternalHost(svc), 4318)}
 	}
 
 	return nil

--- a/internal/casting/rendercasting/casting.go
+++ b/internal/casting/rendercasting/casting.go
@@ -9,21 +9,21 @@ import (
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	"github.com/signoz/foundry/internal/casting"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ casting.Casting = (*renderCasting)(nil)
 
 type renderCasting struct {
 	logger   *slog.Logger
-	castings []*types.Template
+	castings []*domain.Template
 }
 
 func New(logger *slog.Logger) *renderCasting {
 	return &renderCasting{
 		logger: logger,
-		castings: []*types.Template{
+		castings: []*domain.Template{
 			renderYAMLTemplate,
 			telemetryKeeperDockerfileTemplate,
 			telemetryStoreDockerfileTemplate,
@@ -36,8 +36,8 @@ func (c *renderCasting) Enricher(ctx context.Context, config *v1alpha1.Casting) 
 	return newRenderMoldingEnricher(config)
 }
 
-func (c *renderCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]types.Material, error) {
-	var materials []types.Material
+func (c *renderCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPath string) ([]domain.Material, error) {
+	var materials []domain.Material
 
 	configsDir := filepath.Join(casting.DeploymentDir, "configs/")
 	// Generate render.yaml
@@ -54,12 +54,12 @@ func (c *renderCasting) Forge(ctx context.Context, config v1alpha1.Casting, pour
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute dockerfile keeper template: %w", err)
 		}
-		dockerfileMaterial := types.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(configsDir, "telemetrykeeper/Dockerfile"))
+		dockerfileMaterial := domain.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(configsDir, "telemetrykeeper/Dockerfile"))
 		materials = append(materials, dockerfileMaterial)
 
 		// Add telemetrykeeper config files (for dockerfile to copy)
 		for filename, content := range config.Spec.TelemetryKeeper.Spec.Config.Data {
-			material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(configsDir, fmt.Sprintf("telemetrykeeper/keeper.d/%s", filename)))
+			material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(configsDir, fmt.Sprintf("telemetrykeeper/keeper.d/%s", filename)))
 			if err != nil {
 				return nil, fmt.Errorf("failed to create telemetrykeeper config material: %w", err)
 			}
@@ -74,12 +74,12 @@ func (c *renderCasting) Forge(ctx context.Context, config v1alpha1.Casting, pour
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute dockerfile clickhouse template: %w", err)
 		}
-		dockerfileMaterial := types.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(configsDir, "telemetrystore/Dockerfile"))
+		dockerfileMaterial := domain.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(configsDir, "telemetrystore/Dockerfile"))
 		materials = append(materials, dockerfileMaterial)
 
 		// Add telemetrystore config files (for dockerfile to copy)
 		for filename, content := range config.Spec.TelemetryStore.Spec.Config.Data {
-			material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(configsDir, fmt.Sprintf("telemetrystore/config.d/%s", filename)))
+			material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(configsDir, fmt.Sprintf("telemetrystore/config.d/%s", filename)))
 			if err != nil {
 				return nil, fmt.Errorf("failed to create telemetrystore config material: %w", err)
 			}
@@ -94,11 +94,11 @@ func (c *renderCasting) Forge(ctx context.Context, config v1alpha1.Casting, pour
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute dockerfile otel template: %w", err)
 		}
-		dockerfileMaterial := types.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(configsDir, "ingester/Dockerfile"))
+		dockerfileMaterial := domain.NewTextMaterial(dockerfileBuf.Bytes(), filepath.Join(configsDir, "ingester/Dockerfile"))
 		materials = append(materials, dockerfileMaterial)
 
 		for filename, content := range config.Spec.Ingester.Spec.Config.Data {
-			material, err := types.NewYAMLMaterial([]byte(content), filepath.Join(configsDir, fmt.Sprintf("ingester/%s", filename)))
+			material, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(configsDir, fmt.Sprintf("ingester/%s", filename)))
 			if err != nil {
 				return nil, fmt.Errorf("failed to create ingester config material: %w", err)
 			}
@@ -117,11 +117,11 @@ func (c *renderCasting) Cast(ctx context.Context, config v1alpha1.Casting, pours
 	return nil
 }
 
-func getRenderMaterial(config *v1alpha1.Casting, path string) (types.Material, error) {
+func getRenderMaterial(config *v1alpha1.Casting, path string) (domain.Material, error) {
 	buf := bytes.NewBuffer(nil)
 	err := renderYAMLTemplate.Execute(buf, config)
 	if err != nil {
-		return types.Material{}, fmt.Errorf("failed to execute render yaml template: %w", err)
+		return domain.Material{}, fmt.Errorf("failed to execute render yaml template: %w", err)
 	}
-	return types.NewYAMLMaterial(buf.Bytes(), path)
+	return domain.NewYAMLMaterial(buf.Bytes(), path)
 }

--- a/internal/casting/rendercasting/embed.go
+++ b/internal/casting/rendercasting/embed.go
@@ -3,15 +3,15 @@ package rendercasting
 import (
 	"embed"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/*.gotmpl
 var templates embed.FS
 
 var (
-	renderYAMLTemplate                *types.Template = types.MustNewTemplateFromFS(templates, "templates/render.yaml.gotmpl", types.FormatYAML)
-	telemetryKeeperDockerfileTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v2556.gotmpl", types.FormatText)
-	telemetryStoreDockerfileTemplate  *types.Template = types.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v2556.gotmpl", types.FormatText)
-	ingesterDockerfileTemplate        *types.Template = types.MustNewTemplateFromFS(templates, "templates/Dockerfile.ingester.gotmpl", types.FormatText)
+	renderYAMLTemplate                *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/render.yaml.gotmpl", domain.FormatYAML)
+	telemetryKeeperDockerfileTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v2556.gotmpl", domain.FormatText)
+	telemetryStoreDockerfileTemplate  *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v2556.gotmpl", domain.FormatText)
+	ingesterDockerfileTemplate        *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.ingester.gotmpl", domain.FormatText)
 )

--- a/internal/casting/rendercasting/embed_test.go
+++ b/internal/casting/rendercasting/embed_test.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNotEmptyAndValid(t *testing.T) {
-	serviceTemplates := map[string]*types.Template{
+	serviceTemplates := map[string]*domain.Template{
 		"telemetryKeeperDockerfileTemplate": telemetryKeeperDockerfileTemplate,
 		"telemetryStoreDockerfileTemplate":  telemetryStoreDockerfileTemplate,
 		"ingesterDockerfileTemplate":        ingesterDockerfileTemplate,

--- a/internal/casting/rendercasting/enricher.go
+++ b/internal/casting/rendercasting/enricher.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ molding.MoldingEnricher = (*renderMoldingEnricher)(nil)
 
 type renderMoldingEnricher struct {
-	material types.Material
+	material domain.Material
 }
 
 func newRenderMoldingEnricher(config *v1alpha1.Casting) (*renderMoldingEnricher, error) {
@@ -38,7 +38,7 @@ func (enricher *renderMoldingEnricher) EnrichStatus(ctx context.Context, kind v1
 		var storeServiceNames []string
 		for _, serviceName := range serviceNames {
 			if strings.Contains(serviceName, "telemetrystore") && !strings.Contains(serviceName, "migrator") {
-				addrs = append(addrs, types.FormatAddress("tcp", serviceName, 9000))
+				addrs = append(addrs, domain.FormatAddress("tcp", serviceName, 9000))
 				storeServiceNames = append(storeServiceNames, serviceName)
 			}
 		}
@@ -61,8 +61,8 @@ func (enricher *renderMoldingEnricher) EnrichStatus(ctx context.Context, kind v1
 		var opampAddr []string
 		for _, serviceName := range serviceNames {
 			if strings.Contains(serviceName, "-signoz") {
-				apiServerAddr = append(apiServerAddr, types.FormatAddress("tcp", serviceName, 8080))
-				opampAddr = append(opampAddr, types.FormatAddress("ws", serviceName, 4320))
+				apiServerAddr = append(apiServerAddr, domain.FormatAddress("tcp", serviceName, 8080))
+				opampAddr = append(opampAddr, domain.FormatAddress("ws", serviceName, 4320))
 			}
 		}
 		config.Spec.Signoz.Status.Addresses.APIServer = apiServerAddr
@@ -80,8 +80,8 @@ func (enricher *renderMoldingEnricher) EnrichStatus(ctx context.Context, kind v1
 		var keeperServiceNames []string
 		for _, serviceName := range serviceNames {
 			if strings.Contains(serviceName, "telemetrykeeper") {
-				addrsClient = append(addrsClient, types.FormatAddress("tcp", serviceName, 9181))
-				addrsRaft = append(addrsRaft, types.FormatAddress("tcp", serviceName, 9234))
+				addrsClient = append(addrsClient, domain.FormatAddress("tcp", serviceName, 9181))
+				addrsRaft = append(addrsRaft, domain.FormatAddress("tcp", serviceName, 9234))
 				keeperServiceNames = append(keeperServiceNames, serviceName)
 			}
 		}
@@ -104,7 +104,7 @@ func (enricher *renderMoldingEnricher) EnrichStatus(ctx context.Context, kind v1
 		var addrs []string
 		for _, serviceName := range serviceNames {
 			if strings.Contains(serviceName, "ingester") {
-				addrs = append(addrs, types.FormatAddress("tcp", serviceName, 4318))
+				addrs = append(addrs, domain.FormatAddress("tcp", serviceName, 4318))
 			}
 		}
 		config.Spec.Ingester.Status.Addresses.OTLP = addrs

--- a/internal/casting/systemdcasting/casting.go
+++ b/internal/casting/systemdcasting/casting.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/signoz/foundry/api/v1alpha1"
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 const svcSuffix = ".service"
@@ -26,13 +26,13 @@ var _ rootcasting.Casting = (*systemdCasting)(nil)
 
 type systemdCasting struct {
 	logger   *slog.Logger
-	castings []*types.Template
+	castings []*domain.Template
 }
 
 func New(logger *slog.Logger) *systemdCasting {
 	return &systemdCasting{
 		logger: logger,
-		castings: []*types.Template{
+		castings: []*domain.Template{
 			telemetryKeeperServiceTemplate,
 			telemetryStoreServiceTemplate,
 			metaStoreServiceTemplate,
@@ -47,8 +47,8 @@ func (c *systemdCasting) Enricher(ctx context.Context, config *v1alpha1.Casting)
 	return newLinuxMoldingEnricher(config), nil
 }
 
-func (c *systemdCasting) Forge(ctx context.Context, cfg v1alpha1.Casting, poursPath string) ([]types.Material, error) {
-	var materials []types.Material
+func (c *systemdCasting) Forge(ctx context.Context, cfg v1alpha1.Casting, poursPath string) ([]domain.Material, error) {
+	var materials []domain.Material
 	for _, tmpl := range c.castings {
 		m, err := c.forgeCasting(tmpl, &cfg)
 		if err != nil {
@@ -103,7 +103,7 @@ func (c *systemdCasting) Cast(ctx context.Context, config v1alpha1.Casting, pour
 	return nil
 }
 
-func (c *systemdCasting) forgeCasting(tmpl *types.Template, cfg *v1alpha1.Casting) ([]types.Material, error) {
+func (c *systemdCasting) forgeCasting(tmpl *domain.Template, cfg *v1alpha1.Casting) ([]domain.Material, error) {
 	switch tmpl {
 	case signozServiceTemplate:
 		if !cfg.Spec.Signoz.Spec.IsEnabled() {
@@ -140,7 +140,7 @@ func (c *systemdCasting) forgeCasting(tmpl *types.Template, cfg *v1alpha1.Castin
 	}
 }
 
-func (c *systemdCasting) forgeIngester(tmpl *types.Template, cfg *v1alpha1.Casting) ([]types.Material, error) {
+func (c *systemdCasting) forgeIngester(tmpl *domain.Template, cfg *v1alpha1.Casting) ([]domain.Material, error) {
 	spec := &cfg.Spec.Ingester
 
 	if spec.Status.Extras == nil {
@@ -150,7 +150,7 @@ func (c *systemdCasting) forgeIngester(tmpl *types.Template, cfg *v1alpha1.Casti
 	spec.Status.Extras["cfgOpampPath"] = filepath.Join("ingester", "opamp.yaml")
 	spec.Status.Extras["workingDir"] = "/opt/ingester"
 
-	var materials []types.Material
+	var materials []domain.Material
 
 	svcMat, err := c.renderTemplate(tmpl, cfg, cfg.Metadata.Name+"-ingester"+svcSuffix)
 	if err != nil {
@@ -167,7 +167,7 @@ func (c *systemdCasting) forgeIngester(tmpl *types.Template, cfg *v1alpha1.Casti
 	return materials, nil
 }
 
-func (c *systemdCasting) forgeSignoz(tmpl *types.Template, cfg *v1alpha1.Casting) ([]types.Material, error) {
+func (c *systemdCasting) forgeSignoz(tmpl *domain.Template, cfg *v1alpha1.Casting) ([]domain.Material, error) {
 	spec := &cfg.Spec.Signoz
 
 	if spec.Status.Extras == nil {
@@ -175,7 +175,7 @@ func (c *systemdCasting) forgeSignoz(tmpl *types.Template, cfg *v1alpha1.Casting
 	}
 	spec.Status.Extras["workingDir"] = "/opt/signoz"
 
-	var materials []types.Material
+	var materials []domain.Material
 
 	svcMat, err := c.renderTemplate(tmpl, cfg, cfg.Metadata.Name+"-signoz"+svcSuffix)
 	if err != nil {
@@ -186,14 +186,14 @@ func (c *systemdCasting) forgeSignoz(tmpl *types.Template, cfg *v1alpha1.Casting
 	return materials, nil
 }
 
-func (c *systemdCasting) forgeMetaStore(tmpl *types.Template, cfg *v1alpha1.Casting) ([]types.Material, error) {
+func (c *systemdCasting) forgeMetaStore(tmpl *domain.Template, cfg *v1alpha1.Casting) ([]domain.Material, error) {
 	spec := &cfg.Spec.MetaStore
 
 	if spec.Status.Extras == nil {
 		spec.Status.Extras = make(map[string]string)
 	}
 
-	var materials []types.Material
+	var materials []domain.Material
 
 	switch spec.Kind {
 	case v1alpha1.MetaStoreKindPostgres:
@@ -207,7 +207,7 @@ func (c *systemdCasting) forgeMetaStore(tmpl *types.Template, cfg *v1alpha1.Cast
 	return materials, nil
 }
 
-func (c *systemdCasting) forgeTelemetryStore(tmpl *types.Template, cfg *v1alpha1.Casting) ([]types.Material, error) {
+func (c *systemdCasting) forgeTelemetryStore(tmpl *domain.Template, cfg *v1alpha1.Casting) ([]domain.Material, error) {
 	spec := &cfg.Spec.TelemetryStore
 
 	if spec.Status.Extras == nil {
@@ -218,7 +218,7 @@ func (c *systemdCasting) forgeTelemetryStore(tmpl *types.Template, cfg *v1alpha1
 	reps := max(1, *spec.Spec.Cluster.Replicas+1)
 	shards := max(1, *spec.Spec.Cluster.Shards)
 
-	var materials []types.Material
+	var materials []domain.Material
 
 	for s := range shards {
 		for r := range reps {
@@ -239,7 +239,7 @@ func (c *systemdCasting) forgeTelemetryStore(tmpl *types.Template, cfg *v1alpha1
 	return materials, nil
 }
 
-func (c *systemdCasting) forgeTelemetryKeeper(tmpl *types.Template, cfg *v1alpha1.Casting) ([]types.Material, error) {
+func (c *systemdCasting) forgeTelemetryKeeper(tmpl *domain.Template, cfg *v1alpha1.Casting) ([]domain.Material, error) {
 	spec := &cfg.Spec.TelemetryKeeper
 
 	if spec.Status.Extras == nil {
@@ -258,7 +258,7 @@ func (c *systemdCasting) forgeTelemetryKeeper(tmpl *types.Template, cfg *v1alpha
 		spec.Status.Extras["cfgPath"] = filepath.Join("/etc/clickhouse-keeper/", filepath.Base(cfgMats[0].Path()))
 	}
 
-	var materials []types.Material
+	var materials []domain.Material
 
 	for r := range reps {
 		svcMat, err := c.renderTemplate(tmpl, cfg, fmt.Sprintf("%s-telemetrykeeper-%s-%d%s", cfg.Metadata.Name, kind, r, svcSuffix))
@@ -273,8 +273,8 @@ func (c *systemdCasting) forgeTelemetryKeeper(tmpl *types.Template, cfg *v1alpha
 	return materials, nil
 }
 
-func (c *systemdCasting) forgeMigrator(tmpl *types.Template, cfg *v1alpha1.Casting) ([]types.Material, error) {
-	var materials []types.Material
+func (c *systemdCasting) forgeMigrator(tmpl *domain.Template, cfg *v1alpha1.Casting) ([]domain.Material, error) {
+	var materials []domain.Material
 
 	svcMat, err := c.renderTemplate(tmpl, cfg, cfg.Metadata.Name+"-telemetrystore-migrator"+svcSuffix)
 	if err != nil {
@@ -285,10 +285,10 @@ func (c *systemdCasting) forgeMigrator(tmpl *types.Template, cfg *v1alpha1.Casti
 	return materials, nil
 }
 
-func (c *systemdCasting) configMaterials(data map[string]string, component string, kind string) ([]types.Material, error) {
-	mats := make([]types.Material, 0, len(data))
+func (c *systemdCasting) configMaterials(data map[string]string, component string, kind string) ([]domain.Material, error) {
+	mats := make([]domain.Material, 0, len(data))
 	for filename, content := range data {
-		m, err := types.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, component, kind, filename))
+		m, err := domain.NewYAMLMaterial([]byte(content), filepath.Join(rootcasting.DeploymentDir, component, kind, filename))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create %s config material %s: %w", component, filename, err)
 		}
@@ -297,12 +297,12 @@ func (c *systemdCasting) configMaterials(data map[string]string, component strin
 	return mats, nil
 }
 
-func (c *systemdCasting) renderTemplate(tmpl *types.Template, cfg *v1alpha1.Casting, path string) (types.Material, error) {
+func (c *systemdCasting) renderTemplate(tmpl *domain.Template, cfg *v1alpha1.Casting, path string) (domain.Material, error) {
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, cfg); err != nil {
-		return types.Material{}, fmt.Errorf("execute template %s: %w", path, err)
+		return domain.Material{}, fmt.Errorf("execute template %s: %w", path, err)
 	}
-	return types.NewINIMaterial(buf.Bytes(), filepath.Join(rootcasting.DeploymentDir, path))
+	return domain.NewINIMaterial(buf.Bytes(), filepath.Join(rootcasting.DeploymentDir, path))
 }
 
 // execCommand executes a command and returns an error if it fails.

--- a/internal/casting/systemdcasting/embed.go
+++ b/internal/casting/systemdcasting/embed.go
@@ -3,17 +3,17 @@ package systemdcasting
 import (
 	"embed"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/*.gotmpl
 var templates embed.FS
 
 var (
-	signozServiceTemplate                 *types.Template = types.MustNewTemplateFromFS(templates, "templates/signoz.service.gotmpl", types.FormatINI)
-	ingesterServiceTemplate               *types.Template = types.MustNewTemplateFromFS(templates, "templates/ingester.service.gotmpl", types.FormatINI)
-	telemetryStoreServiceTemplate         *types.Template = types.MustNewTemplateFromFS(templates, "templates/clickhouse.telemetrystore.v2556.service.gotmpl", types.FormatINI)
-	telemetryKeeperServiceTemplate        *types.Template = types.MustNewTemplateFromFS(templates, "templates/clickhousekeeper.telemetrykeeper.v2556.service.gotmpl", types.FormatINI)
-	metaStoreServiceTemplate              *types.Template = types.MustNewTemplateFromFS(templates, "templates/postgres.metastore.service.gotmpl", types.FormatINI)
-	telemetryStoreMigratorServiceTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/migrator.telemetrystore.service.gotmpl", types.FormatINI)
+	signozServiceTemplate                 *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/signoz.service.gotmpl", domain.FormatINI)
+	ingesterServiceTemplate               *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/ingester.service.gotmpl", domain.FormatINI)
+	telemetryStoreServiceTemplate         *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhouse.telemetrystore.v2556.service.gotmpl", domain.FormatINI)
+	telemetryKeeperServiceTemplate        *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhousekeeper.telemetrykeeper.v2556.service.gotmpl", domain.FormatINI)
+	metaStoreServiceTemplate              *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/postgres.metastore.service.gotmpl", domain.FormatINI)
+	telemetryStoreMigratorServiceTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/migrator.telemetrystore.service.gotmpl", domain.FormatINI)
 )

--- a/internal/casting/systemdcasting/embed_test.go
+++ b/internal/casting/systemdcasting/embed_test.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNotEmptyAndValid(t *testing.T) {
-	serviceTemplates := map[string]*types.Template{
+	serviceTemplates := map[string]*domain.Template{
 		"telemetryStoreServiceTemplate":  telemetryStoreServiceTemplate,
 		"telemetryKeeperServiceTemplate": telemetryKeeperServiceTemplate,
 		"metaStoreServiceTemplate":       metaStoreServiceTemplate,

--- a/internal/casting/systemdcasting/enricher.go
+++ b/internal/casting/systemdcasting/enricher.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ molding.MoldingEnricher = (*linuxMoldingEnricher)(nil)
@@ -19,11 +19,11 @@ const (
 )
 
 type linuxMoldingEnricher struct {
-	materials []types.Material
+	materials []domain.Material
 }
 
 func newLinuxMoldingEnricher(_ *v1alpha1.Casting) *linuxMoldingEnricher {
-	return &linuxMoldingEnricher{materials: []types.Material{}}
+	return &linuxMoldingEnricher{materials: []domain.Material{}}
 }
 
 func (e *linuxMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alpha1.MoldingKind, config *v1alpha1.Casting) error {
@@ -64,7 +64,7 @@ func (e *linuxMoldingEnricher) enrichTelemetryStore(config *v1alpha1.Casting) er
 	for shard := 0; shard < shards; shard++ {
 		for replica := 0; replica < replicas; replica++ {
 			port := baseTelemetryStoreClusterPort + (shard * replicas) + replica
-			addresses = append(addresses, types.FormatAddress("tcp", "localhost", port))
+			addresses = append(addresses, domain.FormatAddress("tcp", "localhost", port))
 		}
 	}
 
@@ -87,8 +87,8 @@ func (e *linuxMoldingEnricher) enrichTelemetryKeeper(config *v1alpha1.Casting) e
 
 	var clientAddresses, raftAddresses []string
 	for r := 0; r < replicas; r++ {
-		clientAddresses = append(clientAddresses, types.FormatAddress("tcp", "localhost", baseTelemetryKeeperClientPort+r))
-		raftAddresses = append(raftAddresses, types.FormatAddress("tcp", "localhost", baseTelemetryKeeperRaftPort+r))
+		clientAddresses = append(clientAddresses, domain.FormatAddress("tcp", "localhost", baseTelemetryKeeperClientPort+r))
+		raftAddresses = append(raftAddresses, domain.FormatAddress("tcp", "localhost", baseTelemetryKeeperRaftPort+r))
 	}
 
 	config.Spec.TelemetryKeeper.Status.Addresses.Client = clientAddresses
@@ -101,7 +101,7 @@ func (e *linuxMoldingEnricher) enrichMetaStore(config *v1alpha1.Casting) error {
 	case v1alpha1.MetaStoreKindSQLite:
 		// SQLite — no addresses or binaries to enrich.
 	case v1alpha1.MetaStoreKindPostgres:
-		dsn := types.FormatAddress("postgres", "localhost", baseMetaStorePostgresPort)
+		dsn := domain.FormatAddress("postgres", "localhost", baseMetaStorePostgresPort)
 		config.Spec.MetaStore.Status.Addresses.DSN = []string{dsn}
 
 		// Get the annotation value
@@ -122,10 +122,10 @@ func (e *linuxMoldingEnricher) enrichMetaStore(config *v1alpha1.Casting) error {
 
 func (e *linuxMoldingEnricher) enrichSignoz(config *v1alpha1.Casting) error {
 	config.Spec.Signoz.Status.Addresses.Opamp = []string{
-		types.FormatAddress("ws", "localhost", 4320),
+		domain.FormatAddress("ws", "localhost", 4320),
 	}
 	config.Spec.Signoz.Status.Addresses.APIServer = []string{
-		types.FormatAddress("tcp", "localhost", 8080),
+		domain.FormatAddress("tcp", "localhost", 8080),
 	}
 
 	// Get the annotation value
@@ -146,7 +146,7 @@ func (e *linuxMoldingEnricher) enrichSignoz(config *v1alpha1.Casting) error {
 
 func (e *linuxMoldingEnricher) enrichIngester(config *v1alpha1.Casting) error {
 	config.Spec.Ingester.Status.Addresses.OTLP = []string{
-		types.FormatAddress("tcp", "localhost", 4317),
+		domain.FormatAddress("tcp", "localhost", 4317),
 	}
 
 	// Get the annotation value

--- a/internal/config/yamlconfig/config.go
+++ b/internal/config/yamlconfig/config.go
@@ -10,8 +10,8 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/signoz/foundry/api/v1alpha1"
 	"github.com/signoz/foundry/internal/config"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/errors"
-	"github.com/signoz/foundry/internal/types"
 )
 
 type yamlConfig struct {
@@ -32,7 +32,7 @@ func (config *yamlConfig) GetV1Alpha1(ctx context.Context, path string) (v1alpha
 
 	var casting v1alpha1.Casting
 
-	err = types.UnmarshalYAML(bytes, &casting)
+	err = domain.UnmarshalYAML(bytes, &casting)
 	if err != nil {
 		return v1alpha1.Casting{}, fmt.Errorf("failed to unmarshal yaml: %w", err)
 	}
@@ -62,7 +62,7 @@ func (config *yamlConfig) GetV1Alpha1(ctx context.Context, path string) (v1alpha
 }
 
 func (*yamlConfig) CreateV1Alpha1Lock(ctx context.Context, config v1alpha1.Casting, path string) error {
-	contents, err := types.MarshalYAML(config)
+	contents, err := domain.MarshalYAML(config)
 	if err != nil {
 		return fmt.Errorf("failed to marshal yaml: %w", err)
 	}
@@ -83,7 +83,7 @@ func (*yamlConfig) GetV1Alpha1Lock(ctx context.Context, path string) (v1alpha1.C
 
 	var casting v1alpha1.Casting
 
-	err = types.UnmarshalYAML(bytes, &casting)
+	err = domain.UnmarshalYAML(bytes, &casting)
 	if err != nil {
 		return v1alpha1.Casting{}, fmt.Errorf("failed to unmarshal yaml: %w", err)
 	}

--- a/internal/config/yamlconfig/config_test.go
+++ b/internal/config/yamlconfig/config_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/signoz/foundry/api/v1alpha1"
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -295,7 +295,7 @@ func TestGetV1Alpha1Merge(t *testing.T) {
 				Spec: v1alpha1.CastingSpec{
 					MetaStore: v1alpha1.MetaStore{
 						Spec: v1alpha1.MoldingSpec{
-							Enabled: types.NewBoolPtr(false),
+							Enabled: domain.NewBoolPtr(false),
 						},
 					},
 				},

--- a/internal/domain/address.go
+++ b/internal/domain/address.go
@@ -1,4 +1,4 @@
-package types
+package domain
 
 import (
 	"fmt"

--- a/internal/domain/doc.go
+++ b/internal/domain/doc.go
@@ -1,0 +1,16 @@
+// Package domain contains Foundry's shared domain primitives.
+//
+// This package is for value objects and pure helpers that are used across
+// configuration loading, molding, casting, patching, and writing. Examples
+// include generated materials, template wrappers, addresses, formats, pointer
+// helpers, and serialization helpers.
+//
+// Keep this package free of orchestration and side effects. It must not decide
+// which pipeline phase runs, select deployment implementations, execute tools,
+// write files, read user configuration, or contain platform-specific rendering
+// behavior. Put that logic in the package that owns the behavior instead.
+//
+// The only Foundry package this package may import is internal/errors. Do not
+// import api/v1alpha1 or any internal orchestration, casting, molding,
+// infrastructure, writer, tooler, config, or ledger package from here.
+package domain

--- a/internal/domain/file.go
+++ b/internal/domain/file.go
@@ -1,4 +1,4 @@
-package types
+package domain
 
 import "embed"
 

--- a/internal/domain/format.go
+++ b/internal/domain/format.go
@@ -1,4 +1,4 @@
-package types
+package domain
 
 var (
 	FormatYAML Format = Format{s: "yaml"}

--- a/internal/domain/ini.go
+++ b/internal/domain/ini.go
@@ -1,4 +1,4 @@
-package types
+package domain
 
 import (
 	"bytes"

--- a/internal/domain/material.go
+++ b/internal/domain/material.go
@@ -1,4 +1,4 @@
-package types
+package domain
 
 import (
 	"bytes"

--- a/internal/domain/pointer.go
+++ b/internal/domain/pointer.go
@@ -1,4 +1,4 @@
-package types
+package domain
 
 func NewIntPtr(i int) *int {
 	return &i

--- a/internal/domain/template.go
+++ b/internal/domain/template.go
@@ -1,4 +1,4 @@
-package types
+package domain
 
 import (
 	"embed"

--- a/internal/domain/yaml.go
+++ b/internal/domain/yaml.go
@@ -1,4 +1,4 @@
-package types
+package domain
 
 import (
 	"fmt"

--- a/internal/foundry/forge.go
+++ b/internal/foundry/forge.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	foundryerrors "github.com/signoz/foundry/internal/errors"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 	"github.com/signoz/foundry/internal/writer"
 )
 
@@ -76,7 +76,7 @@ func (foundry *Foundry) Forge(ctx context.Context, config v1alpha1.Casting, path
 
 	// Generate infrastructure-as-code manifests if enabled, before writing the lock file
 	// so that the generated file contents are captured in the lock's infrastructure.status.
-	var infraMaterials []types.Material
+	var infraMaterials []domain.Material
 	if config.Spec.Infrastructure.Enabled {
 		foundry.Logger.InfoContext(ctx, "generating infrastructure manifests",
 			slog.String("casting.metadata.name", config.Metadata.Name),

--- a/internal/infrastructure/generator.go
+++ b/internal/infrastructure/generator.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/signoz/foundry/api/v1alpha1"
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 // Generator is the interface for infrastructure-as-code generators.
@@ -12,7 +12,7 @@ import (
 // and can validate the generated output using the underlying tool.
 type Generator interface {
 	// Generate produces IaC materials from the casting configuration.
-	Generate(ctx context.Context, config v1alpha1.Casting) ([]types.Material, error)
+	Generate(ctx context.Context, config v1alpha1.Casting) ([]domain.Material, error)
 
 	// Validate runs the IaC tool's built-in validation (e.g., terraform validate)
 	// against the manifests written to poursPath.

--- a/internal/infrastructure/terraform/embed.go
+++ b/internal/infrastructure/terraform/embed.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"embed"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/*.gotmpl templates/aws/ec2/*.gotmpl templates/aws/eks/*.gotmpl templates/gcp/gce/*.gotmpl templates/gcp/gke/*.gotmpl templates/azure/vm/*.gotmpl templates/azure/aks/*.gotmpl
@@ -11,47 +11,47 @@ var templates embed.FS
 
 // Common templates.
 var (
-	providersTFTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/providers.tf.json.gotmpl", types.FormatJSON)
+	providersTFTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/providers.tf.json.gotmpl", domain.FormatJSON)
 )
 
 // AWS EC2 templates.
 var (
-	awsEC2MainTFTemplate      *types.Template = types.MustNewTemplateFromFS(templates, "templates/aws/ec2/main.tf.json.gotmpl", types.FormatJSON)
-	awsEC2VariablesTFTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/aws/ec2/variables.tf.json.gotmpl", types.FormatJSON)
-	awsEC2OutputsTFTemplate   *types.Template = types.MustNewTemplateFromFS(templates, "templates/aws/ec2/outputs.tf.json.gotmpl", types.FormatJSON)
+	awsEC2MainTFTemplate      *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/aws/ec2/main.tf.json.gotmpl", domain.FormatJSON)
+	awsEC2VariablesTFTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/aws/ec2/variables.tf.json.gotmpl", domain.FormatJSON)
+	awsEC2OutputsTFTemplate   *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/aws/ec2/outputs.tf.json.gotmpl", domain.FormatJSON)
 )
 
 // AWS EKS templates.
 var (
-	awsEKSMainTFTemplate      *types.Template = types.MustNewTemplateFromFS(templates, "templates/aws/eks/main.tf.json.gotmpl", types.FormatJSON)
-	awsEKSVariablesTFTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/aws/eks/variables.tf.json.gotmpl", types.FormatJSON)
-	awsEKSOutputsTFTemplate   *types.Template = types.MustNewTemplateFromFS(templates, "templates/aws/eks/outputs.tf.json.gotmpl", types.FormatJSON)
+	awsEKSMainTFTemplate      *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/aws/eks/main.tf.json.gotmpl", domain.FormatJSON)
+	awsEKSVariablesTFTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/aws/eks/variables.tf.json.gotmpl", domain.FormatJSON)
+	awsEKSOutputsTFTemplate   *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/aws/eks/outputs.tf.json.gotmpl", domain.FormatJSON)
 )
 
 // GCP GCE templates.
 var (
-	gcpGCEMainTFTemplate      *types.Template = types.MustNewTemplateFromFS(templates, "templates/gcp/gce/main.tf.json.gotmpl", types.FormatJSON)
-	gcpGCEVariablesTFTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/gcp/gce/variables.tf.json.gotmpl", types.FormatJSON)
-	gcpGCEOutputsTFTemplate   *types.Template = types.MustNewTemplateFromFS(templates, "templates/gcp/gce/outputs.tf.json.gotmpl", types.FormatJSON)
+	gcpGCEMainTFTemplate      *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/gcp/gce/main.tf.json.gotmpl", domain.FormatJSON)
+	gcpGCEVariablesTFTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/gcp/gce/variables.tf.json.gotmpl", domain.FormatJSON)
+	gcpGCEOutputsTFTemplate   *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/gcp/gce/outputs.tf.json.gotmpl", domain.FormatJSON)
 )
 
 // GCP GKE templates.
 var (
-	gcpGKEMainTFTemplate      *types.Template = types.MustNewTemplateFromFS(templates, "templates/gcp/gke/main.tf.json.gotmpl", types.FormatJSON)
-	gcpGKEVariablesTFTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/gcp/gke/variables.tf.json.gotmpl", types.FormatJSON)
-	gcpGKEOutputsTFTemplate   *types.Template = types.MustNewTemplateFromFS(templates, "templates/gcp/gke/outputs.tf.json.gotmpl", types.FormatJSON)
+	gcpGKEMainTFTemplate      *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/gcp/gke/main.tf.json.gotmpl", domain.FormatJSON)
+	gcpGKEVariablesTFTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/gcp/gke/variables.tf.json.gotmpl", domain.FormatJSON)
+	gcpGKEOutputsTFTemplate   *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/gcp/gke/outputs.tf.json.gotmpl", domain.FormatJSON)
 )
 
 // Azure VM templates.
 var (
-	azureVMMainTFTemplate      *types.Template = types.MustNewTemplateFromFS(templates, "templates/azure/vm/main.tf.json.gotmpl", types.FormatJSON)
-	azureVMVariablesTFTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/azure/vm/variables.tf.json.gotmpl", types.FormatJSON)
-	azureVMOutputsTFTemplate   *types.Template = types.MustNewTemplateFromFS(templates, "templates/azure/vm/outputs.tf.json.gotmpl", types.FormatJSON)
+	azureVMMainTFTemplate      *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/azure/vm/main.tf.json.gotmpl", domain.FormatJSON)
+	azureVMVariablesTFTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/azure/vm/variables.tf.json.gotmpl", domain.FormatJSON)
+	azureVMOutputsTFTemplate   *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/azure/vm/outputs.tf.json.gotmpl", domain.FormatJSON)
 )
 
 // Azure AKS templates.
 var (
-	azureAKSMainTFTemplate      *types.Template = types.MustNewTemplateFromFS(templates, "templates/azure/aks/main.tf.json.gotmpl", types.FormatJSON)
-	azureAKSVariablesTFTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/azure/aks/variables.tf.json.gotmpl", types.FormatJSON)
-	azureAKSOutputsTFTemplate   *types.Template = types.MustNewTemplateFromFS(templates, "templates/azure/aks/outputs.tf.json.gotmpl", types.FormatJSON)
+	azureAKSMainTFTemplate      *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/azure/aks/main.tf.json.gotmpl", domain.FormatJSON)
+	azureAKSVariablesTFTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/azure/aks/variables.tf.json.gotmpl", domain.FormatJSON)
+	azureAKSOutputsTFTemplate   *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/azure/aks/outputs.tf.json.gotmpl", domain.FormatJSON)
 )

--- a/internal/infrastructure/terraform/generator.go
+++ b/internal/infrastructure/terraform/generator.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/infrastructure"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ infrastructure.Generator = (*Generator)(nil)
@@ -37,7 +37,7 @@ func New(logger *slog.Logger) *Generator {
 
 // Generate creates Terraform manifests based on the casting configuration.
 // The compute type is resolved automatically from the provider and deployment mode.
-func (g *Generator) Generate(ctx context.Context, config v1alpha1.Casting) ([]types.Material, error) {
+func (g *Generator) Generate(ctx context.Context, config v1alpha1.Casting) ([]domain.Material, error) {
 	if !config.Spec.Infrastructure.Enabled {
 		return nil, nil
 	}
@@ -67,14 +67,14 @@ func (g *Generator) Generate(ctx context.Context, config v1alpha1.Casting) ([]ty
 		return nil, err
 	}
 
-	var materials []types.Material
+	var materials []domain.Material
 
 	// main.tf.json
 	mainBuf := bytes.NewBuffer(nil)
 	if err := mainTemplate.Execute(mainBuf, data); err != nil {
 		return nil, fmt.Errorf("failed to execute main.tf.json template: %w", err)
 	}
-	mainMaterial, err := types.NewJSONMaterial(mainBuf.Bytes(), filepath.Join(infrastructureDir, "main.tf.json"))
+	mainMaterial, err := domain.NewJSONMaterial(mainBuf.Bytes(), filepath.Join(infrastructureDir, "main.tf.json"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create main.tf.json material: %w", err)
 	}
@@ -85,7 +85,7 @@ func (g *Generator) Generate(ctx context.Context, config v1alpha1.Casting) ([]ty
 	if err := varsTemplate.Execute(varsBuf, data); err != nil {
 		return nil, fmt.Errorf("failed to execute variables.tf.json template: %w", err)
 	}
-	varsMaterial, err := types.NewJSONMaterial(varsBuf.Bytes(), filepath.Join(infrastructureDir, "variables.tf.json"))
+	varsMaterial, err := domain.NewJSONMaterial(varsBuf.Bytes(), filepath.Join(infrastructureDir, "variables.tf.json"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create variables.tf.json material: %w", err)
 	}
@@ -96,7 +96,7 @@ func (g *Generator) Generate(ctx context.Context, config v1alpha1.Casting) ([]ty
 	if err := providersTFTemplate.Execute(providersBuf, data); err != nil {
 		return nil, fmt.Errorf("failed to execute providers.tf.json template: %w", err)
 	}
-	providersMaterial, err := types.NewJSONMaterial(providersBuf.Bytes(), filepath.Join(infrastructureDir, "providers.tf.json"))
+	providersMaterial, err := domain.NewJSONMaterial(providersBuf.Bytes(), filepath.Join(infrastructureDir, "providers.tf.json"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create providers.tf.json material: %w", err)
 	}
@@ -107,7 +107,7 @@ func (g *Generator) Generate(ctx context.Context, config v1alpha1.Casting) ([]ty
 	if err := outputsTemplate.Execute(outputsBuf, data); err != nil {
 		return nil, fmt.Errorf("failed to execute outputs.tf.json template: %w", err)
 	}
-	outputsMaterial, err := types.NewJSONMaterial(outputsBuf.Bytes(), filepath.Join(infrastructureDir, "outputs.tf.json"))
+	outputsMaterial, err := domain.NewJSONMaterial(outputsBuf.Bytes(), filepath.Join(infrastructureDir, "outputs.tf.json"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create outputs.tf.json material: %w", err)
 	}
@@ -131,7 +131,7 @@ func (g *Generator) Validate(ctx context.Context, poursPath string) error {
 }
 
 // templatesFor returns the provider+compute-type specific templates.
-func (g *Generator) templatesFor(provider v1alpha1.Platform, computeType infrastructure.ComputeType) (main, vars, outputs *types.Template, err error) {
+func (g *Generator) templatesFor(provider v1alpha1.Platform, computeType infrastructure.ComputeType) (main, vars, outputs *domain.Template, err error) {
 	switch provider {
 	case v1alpha1.PlatformAWS:
 		switch computeType {

--- a/internal/molding/ingestermolding/template.go
+++ b/internal/molding/ingestermolding/template.go
@@ -3,15 +3,15 @@ package ingestermolding
 import (
 	"embed"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/*.gotmpl
 var templates embed.FS
 
 var (
-	ConfigV0129xTemplate *types.Template = types.MustNewTemplateFromFS(templates, "templates/config.v0129x.yaml.gotmpl", types.FormatYAML)
-	OpampV0129xTemplate  *types.Template = types.MustNewTemplateFromFS(templates, "templates/opamp.v0129x.yaml.gotmpl", types.FormatYAML)
+	ConfigV0129xTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/config.v0129x.yaml.gotmpl", domain.FormatYAML)
+	OpampV0129xTemplate  *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/opamp.v0129x.yaml.gotmpl", domain.FormatYAML)
 )
 
 type Data struct {

--- a/internal/molding/signozmolding/signoz.go
+++ b/internal/molding/signozmolding/signoz.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ molding.Molding = (*signoz)(nil)
@@ -57,7 +57,7 @@ func (molding *signoz) MoldV1Alpha1(ctx context.Context, config *v1alpha1.Castin
 				molding.logger.WarnContext(ctx, "SIGNOZ_SQLSTORE_POSTGRES_DSN is going to be overridden", slog.String("value", val))
 			}
 			// construct postgres dsn with user, password, host, port, and db
-			addrs, err := types.NewAddresses(config.Spec.MetaStore.Status.Addresses.DSN)
+			addrs, err := domain.NewAddresses(config.Spec.MetaStore.Status.Addresses.DSN)
 			if err != nil {
 				return fmt.Errorf("failed to parse addresses: %w", err)
 			}

--- a/internal/molding/telemetrykeepermolding/telemetrykeeper.go
+++ b/internal/molding/telemetrykeepermolding/telemetrykeeper.go
@@ -7,9 +7,9 @@ import (
 	"log/slog"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	foundryerrors "github.com/signoz/foundry/internal/errors"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ molding.Molding = (*telemetrykeeper)(nil)
@@ -51,7 +51,7 @@ func (molding *telemetrykeeper) MoldV1Alpha1(ctx context.Context, config *v1alph
 		base := configBuf.String()
 
 		if overrides != "" {
-			merged, err := types.MergeYAML(base, overrides)
+			merged, err := domain.MergeYAML(base, overrides)
 			if err != nil {
 				return fmt.Errorf("failed to merge config overrides for %s: %w", key, err)
 			}

--- a/internal/molding/telemetrykeepermolding/template.go
+++ b/internal/molding/telemetrykeepermolding/template.go
@@ -5,20 +5,20 @@ import (
 	"fmt"
 
 	"github.com/signoz/foundry/api/v1alpha1"
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/*.gotmpl
 var templates embed.FS
 
 var (
-	KeeperClickhousev2556YAML *types.Template = types.MustNewTemplateFromFS(templates, "templates/keeper.clickhouse.v2556.yaml.gotmpl", types.FormatYAML)
+	KeeperClickhousev2556YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/keeper.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
 )
 
 // Data is the template data for rendering ClickHouse Keeper configs.
 type Data struct {
-	RaftAddresses   []types.Address // Inter-keeper consensus addresses
-	ClientAddresses []types.Address // Client-facing addresses
+	RaftAddresses   []domain.Address // Inter-keeper consensus addresses
+	ClientAddresses []domain.Address // Client-facing addresses
 	ServerCount     int
 	ServerID        int // Current server ID for per-node config generation
 }
@@ -42,13 +42,13 @@ func newData(config *v1alpha1.Casting) (Data, error) {
 		return Data{}, fmt.Errorf("insufficient client addresses: have %d, need %d servers", len(clientAddresses), data.ServerCount)
 	}
 
-	newRaftAddrs, err := types.NewAddresses(raftAddresses[:data.ServerCount])
+	newRaftAddrs, err := domain.NewAddresses(raftAddresses[:data.ServerCount])
 	if err != nil {
 		return Data{}, fmt.Errorf("failed to parse raft addresses: %w", err)
 	}
 	data.RaftAddresses = newRaftAddrs
 
-	newClientAddrs, err := types.NewAddresses(clientAddresses[:data.ServerCount])
+	newClientAddrs, err := domain.NewAddresses(clientAddresses[:data.ServerCount])
 	if err != nil {
 		return Data{}, fmt.Errorf("failed to parse client addresses: %w", err)
 	}

--- a/internal/molding/telemetrystoremolding/telemetrystore.go
+++ b/internal/molding/telemetrystoremolding/telemetrystore.go
@@ -7,9 +7,9 @@ import (
 	"log/slog"
 
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	foundryerrors "github.com/signoz/foundry/internal/errors"
 	"github.com/signoz/foundry/internal/molding"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ molding.Molding = (*telemetrystore)(nil)
@@ -51,7 +51,7 @@ func (molding *telemetrystore) MoldV1Alpha1(ctx context.Context, config *v1alpha
 	base := configBuf.String()
 
 	if overrides != "" {
-		merged, err := types.MergeYAML(base, overrides)
+		merged, err := domain.MergeYAML(base, overrides)
 		if err != nil {
 			return fmt.Errorf("failed to merge config overrides for config.yaml: %w", err)
 		}
@@ -92,7 +92,7 @@ func (molding *telemetrystore) getData(config *v1alpha1.Casting) (Data, error) {
 		)
 	}
 
-	newStoreAddrs, err := types.NewAddresses(storeAddresses[:expectedNodes])
+	newStoreAddrs, err := domain.NewAddresses(storeAddresses[:expectedNodes])
 	if err != nil {
 		return Data{}, fmt.Errorf("failed to parse addresses: %w", err)
 	}
@@ -102,7 +102,7 @@ func (molding *telemetrystore) getData(config *v1alpha1.Casting) (Data, error) {
 		return Data{}, fmt.Errorf("telemetry keeper addresses not set in status")
 	}
 
-	newKeeperAddrs, err := types.NewAddresses(keeperAddresses)
+	newKeeperAddrs, err := domain.NewAddresses(keeperAddresses)
 	if err != nil {
 		return Data{}, fmt.Errorf("failed to parse addresses: %w", err)
 	}

--- a/internal/molding/telemetrystoremolding/template.go
+++ b/internal/molding/telemetrystoremolding/template.go
@@ -3,21 +3,21 @@ package telemetrystoremolding
 import (
 	"embed"
 
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 //go:embed templates/*.gotmpl
 var templates embed.FS
 
 var (
-	ConfigClickhousev2556YAML    *types.Template = types.MustNewTemplateFromFS(templates, "templates/config.clickhouse.v2556.yaml.gotmpl", types.FormatYAML)
-	FunctionsClickhousev2556YAML *types.Template = types.MustNewTemplateFromFS(templates, "templates/functions.clickhouse.v2556.yaml.gotmpl", types.FormatYAML)
+	ConfigClickhousev2556YAML    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/config.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
+	FunctionsClickhousev2556YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/functions.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
 )
 
 // Data is the template data for rendering ClickHouse telemetry store configs.
 type Data struct {
-	StoreAddresses  []types.Address
-	KeeperAddresses []types.Address
+	StoreAddresses  []domain.Address
+	KeeperAddresses []domain.Address
 	ShardCount      int
 	ReplicaCount    int
 }

--- a/internal/patch/jsonpatch/patch.go
+++ b/internal/patch/jsonpatch/patch.go
@@ -7,8 +7,8 @@ import (
 
 	jsonpatchv5 "github.com/evanphx/json-patch/v5"
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/patch"
-	"github.com/signoz/foundry/internal/types"
 )
 
 var _ patch.Patch = (*jsonPatch)(nil)
@@ -19,13 +19,13 @@ func New() patch.Patch {
 	return &jsonPatch{}
 }
 
-func (p *jsonPatch) Apply(ctx context.Context, materials []types.Material, pe v1alpha1.PatchEntry) ([]types.Material, error) {
+func (p *jsonPatch) Apply(ctx context.Context, materials []domain.Material, pe v1alpha1.PatchEntry) ([]domain.Material, error) {
 	patchDoc, err := json.Marshal(pe.Operations)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal patch operations for target %q: %w", pe.Target, err)
 	}
 
-	result := make([]types.Material, len(materials))
+	result := make([]domain.Material, len(materials))
 	copy(result, materials)
 
 	matched := false
@@ -57,15 +57,15 @@ func (p *jsonPatch) Apply(ctx context.Context, materials []types.Material, pe v1
 	return result, nil
 }
 
-func applyToMaterial(mat types.Material, patchDoc []byte) (types.Material, error) {
+func applyToMaterial(mat domain.Material, patchDoc []byte) (domain.Material, error) {
 	decoded, err := jsonpatchv5.DecodePatch(patchDoc)
 	if err != nil {
-		return types.Material{}, fmt.Errorf("failed to decode json patch: %w", err)
+		return domain.Material{}, fmt.Errorf("failed to decode json patch: %w", err)
 	}
 
 	patched, err := decoded.Apply(mat.Contents())
 	if err != nil {
-		return types.Material{}, fmt.Errorf("failed to apply json patch: %w", err)
+		return domain.Material{}, fmt.Errorf("failed to apply json patch: %w", err)
 	}
 
 	return mat.WithContents(patched), nil

--- a/internal/patch/jsonpatch/patch_test.go
+++ b/internal/patch/jsonpatch/patch_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"github.com/signoz/foundry/api/v1alpha1"
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func newYAMLMaterial(t *testing.T, yamlContent string, path string) types.Material {
+func newYAMLMaterial(t *testing.T, yamlContent string, path string) domain.Material {
 	t.Helper()
-	mat, err := types.NewYAMLMaterial([]byte(yamlContent), path)
+	mat, err := domain.NewYAMLMaterial([]byte(yamlContent), path)
 	require.NoError(t, err)
 	return mat
 }
@@ -32,7 +32,7 @@ services:
 		},
 	}
 
-	result, err := p.Apply(context.Background(), []types.Material{mat}, pe)
+	result, err := p.Apply(context.Background(), []domain.Material{mat}, pe)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
@@ -58,7 +58,7 @@ services:
 		},
 	}
 
-	result, err := p.Apply(context.Background(), []types.Material{mat}, pe)
+	result, err := p.Apply(context.Background(), []domain.Material{mat}, pe)
 	require.NoError(t, err)
 
 	contents, err := result[0].ToYaml()
@@ -83,7 +83,7 @@ services:
 		},
 	}
 
-	result, err := p.Apply(context.Background(), []types.Material{mat}, pe)
+	result, err := p.Apply(context.Background(), []domain.Material{mat}, pe)
 	require.NoError(t, err)
 
 	contents, err := result[0].ToYaml()
@@ -105,7 +105,7 @@ func TestApply_GlobTarget(t *testing.T) {
 		},
 	}
 
-	result, err := p.Apply(context.Background(), []types.Material{mat1, mat2, mat3}, pe)
+	result, err := p.Apply(context.Background(), []domain.Material{mat1, mat2, mat3}, pe)
 	require.NoError(t, err)
 	require.Len(t, result, 3)
 
@@ -131,7 +131,7 @@ func TestApply_FullPathMatch(t *testing.T) {
 		},
 	}
 
-	result, err := p.Apply(context.Background(), []types.Material{mat}, pe)
+	result, err := p.Apply(context.Background(), []domain.Material{mat}, pe)
 	require.NoError(t, err)
 
 	contents, err := result[0].ToYaml()
@@ -150,7 +150,7 @@ func TestApply_UnmatchedTargetReturnsError(t *testing.T) {
 		},
 	}
 
-	_, err := p.Apply(context.Background(), []types.Material{mat}, pe)
+	_, err := p.Apply(context.Background(), []domain.Material{mat}, pe)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "did not match any generated material")
 }
@@ -166,7 +166,7 @@ func TestApply_InvalidPathReturnsError(t *testing.T) {
 		},
 	}
 
-	_, err := p.Apply(context.Background(), []types.Material{mat}, pe)
+	_, err := p.Apply(context.Background(), []domain.Material{mat}, pe)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to apply")
 }
@@ -193,7 +193,7 @@ spec:
 		},
 	}
 
-	result, err := p.Apply(context.Background(), []types.Material{mat}, pe)
+	result, err := p.Apply(context.Background(), []domain.Material{mat}, pe)
 	require.NoError(t, err)
 
 	contents, err := result[0].ToYaml()

--- a/internal/patch/patch.go
+++ b/internal/patch/patch.go
@@ -5,13 +5,13 @@ import (
 	"path/filepath"
 
 	"github.com/signoz/foundry/api/v1alpha1"
-	"github.com/signoz/foundry/internal/types"
+	"github.com/signoz/foundry/internal/domain"
 )
 
 // Patch applies a single patch entry to generated materials.
 type Patch interface {
 	// Apply applies a single patch entry to matching materials and returns the patched materials.
-	Apply(ctx context.Context, materials []types.Material, patch v1alpha1.PatchEntry) ([]types.Material, error)
+	Apply(ctx context.Context, materials []domain.Material, patch v1alpha1.PatchEntry) ([]domain.Material, error)
 }
 
 // MatchTarget checks if a material path matches a target pattern.

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/signoz/foundry/internal/domain"
 	foundryerrors "github.com/signoz/foundry/internal/errors"
-	"github.com/signoz/foundry/internal/types"
 )
 
 type Options struct {
@@ -46,7 +46,7 @@ func New(logger *slog.Logger, options *Options) (*Writer, error) {
 	}, nil
 }
 
-func (w *Writer) Write(ctx context.Context, material types.Material) error {
+func (w *Writer) Write(ctx context.Context, material domain.Material) error {
 	if _, ok := w.options.Output.(*os.File); ok {
 		path := filepath.Join(w.options.TargetDirectory, material.Path())
 
@@ -75,7 +75,7 @@ func (w *Writer) Write(ctx context.Context, material types.Material) error {
 	return nil
 }
 
-func (w *Writer) WriteMany(ctx context.Context, materials ...types.Material) error {
+func (w *Writer) WriteMany(ctx context.Context, materials ...domain.Material) error {
 	for _, material := range materials {
 		if err := w.Write(ctx, material); err != nil {
 			return err


### PR DESCRIPTION
## Summary
- Rename internal/types to internal/domain
- Update imports and call sites to use the domain package
- Document the domain package boundaries
- Remove api/v1alpha1 dependency on internal/domain

## Tests
- GOCACHE=/private/tmp/foundry-go-cache go test ./...