### PR TITLE
refactor(domain): make Address a scheme-aware value object

### DIFF
--- a/internal/casting/coolifycasting/enricher.go
+++ b/internal/casting/coolifycasting/enricher.go
@@ -37,7 +37,7 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		var telemetrystoreContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "telemetrystore-clickhouse") && !strings.Contains(containerName, "user-scripts") {
-				telemetrystoreContainerNames = append(telemetrystoreContainerNames, domain.FormatAddress("tcp", containerName, 9000))
+				telemetrystoreContainerNames = append(telemetrystoreContainerNames, domain.MustNewAddress("tcp", containerName, 9000).String())
 			}
 		}
 		config.Spec.TelemetryStore.Status.Addresses.TCP = telemetrystoreContainerNames
@@ -52,8 +52,8 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		var opampAddr []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "-signoz") {
-				apiServerAddr = append(apiServerAddr, domain.FormatAddress("tcp", containerName, 8080))
-				opampAddr = append(opampAddr, domain.FormatAddress("ws", containerName, 4320))
+				apiServerAddr = append(apiServerAddr, domain.MustNewAddress("tcp", containerName, 8080).String())
+				opampAddr = append(opampAddr, domain.MustNewAddress("ws", containerName, 4320).String())
 			}
 		}
 		config.Spec.Signoz.Status.Addresses.APIServer = apiServerAddr
@@ -68,7 +68,7 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		var telemetrykeeperContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "telemetrykeeper") {
-				telemetrykeeperContainerNames = append(telemetrykeeperContainerNames, domain.FormatAddress("tcp", containerName, 9181))
+				telemetrykeeperContainerNames = append(telemetrykeeperContainerNames, domain.MustNewAddress("tcp", containerName, 9181).String())
 			}
 		}
 		config.Spec.TelemetryKeeper.Status.Addresses.Client = telemetrykeeperContainerNames
@@ -76,7 +76,7 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		var telemetryRaftaddress []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "telemetrykeeper") {
-				telemetryRaftaddress = append(telemetryRaftaddress, domain.FormatAddress("tcp", containerName, 9234))
+				telemetryRaftaddress = append(telemetryRaftaddress, domain.MustNewAddress("tcp", containerName, 9234).String())
 			}
 		}
 		config.Spec.TelemetryKeeper.Status.Addresses.Raft = telemetryRaftaddress
@@ -90,7 +90,7 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		var metastoreContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "metastore") {
-				metastoreContainerNames = append(metastoreContainerNames, domain.FormatAddress("tcp", containerName, 5432))
+				metastoreContainerNames = append(metastoreContainerNames, domain.MustNewAddress("tcp", containerName, 5432).String())
 			}
 		}
 		config.Spec.MetaStore.Status.Addresses.DSN = metastoreContainerNames
@@ -104,7 +104,7 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		var ingesterContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "ingester") {
-				ingesterContainerNames = append(ingesterContainerNames, domain.FormatAddress("tcp", containerName, 4318))
+				ingesterContainerNames = append(ingesterContainerNames, domain.MustNewAddress("tcp", containerName, 4318).String())
 			}
 		}
 		config.Spec.Ingester.Status.Addresses.OTLP = ingesterContainerNames

--- a/internal/casting/dockercomposecasting/enricher.go
+++ b/internal/casting/dockercomposecasting/enricher.go
@@ -39,7 +39,7 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		var telemetrystoreContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "telemetrystore-clickhouse") && !strings.Contains(containerName, "user-scripts") {
-				telemetrystoreContainerNames = append(telemetrystoreContainerNames, domain.FormatAddress("tcp", containerName, 9000))
+				telemetrystoreContainerNames = append(telemetrystoreContainerNames, domain.MustNewAddress("tcp", containerName, 9000).String())
 			}
 		}
 
@@ -56,8 +56,8 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		var opampAddr []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "-signoz") {
-				apiServerAddr = append(apiServerAddr, domain.FormatAddress("tcp", containerName, 8080))
-				opampAddr = append(opampAddr, domain.FormatAddress("ws", containerName, 4320))
+				apiServerAddr = append(apiServerAddr, domain.MustNewAddress("tcp", containerName, 8080).String())
+				opampAddr = append(opampAddr, domain.MustNewAddress("ws", containerName, 4320).String())
 			}
 		}
 		config.Spec.Signoz.Status.Addresses.APIServer = apiServerAddr
@@ -73,7 +73,7 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		var telemetrykeeperContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "telemetrykeeper") {
-				telemetrykeeperContainerNames = append(telemetrykeeperContainerNames, domain.FormatAddress("tcp", containerName, 9181))
+				telemetrykeeperContainerNames = append(telemetrykeeperContainerNames, domain.MustNewAddress("tcp", containerName, 9181).String())
 			}
 		}
 
@@ -82,7 +82,7 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		var telemetryRaftaddress []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "telemetrykeeper") {
-				telemetryRaftaddress = append(telemetryRaftaddress, domain.FormatAddress("tcp", containerName, 9234))
+				telemetryRaftaddress = append(telemetryRaftaddress, domain.MustNewAddress("tcp", containerName, 9234).String())
 			}
 		}
 
@@ -98,7 +98,7 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		var metastoreContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "metastore") {
-				metastoreContainerNames = append(metastoreContainerNames, domain.FormatAddress("tcp", containerName, 5432))
+				metastoreContainerNames = append(metastoreContainerNames, domain.MustNewAddress("tcp", containerName, 5432).String())
 			}
 		}
 
@@ -114,7 +114,7 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		var ingesterContainerNames []string
 		for _, containerName := range containerNames {
 			if strings.Contains(containerName, "ingester") {
-				ingesterContainerNames = append(ingesterContainerNames, domain.FormatAddress("tcp", containerName, 4317))
+				ingesterContainerNames = append(ingesterContainerNames, domain.MustNewAddress("tcp", containerName, 4317).String())
 			}
 		}
 

--- a/internal/casting/dockerswarmcasting/enricher.go
+++ b/internal/casting/dockerswarmcasting/enricher.go
@@ -38,7 +38,7 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		var telemetrystoreAddresses []string
 		for _, name := range containerNames {
 			if strings.Contains(name, "telemetrystore-clickhouse") && !strings.Contains(name, "user-scripts") {
-				telemetrystoreAddresses = append(telemetrystoreAddresses, domain.FormatAddress("tcp", name, 9000))
+				telemetrystoreAddresses = append(telemetrystoreAddresses, domain.MustNewAddress("tcp", name, 9000).String())
 			}
 		}
 
@@ -54,8 +54,8 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		var opampAddr []string
 		for _, name := range containerNames {
 			if strings.Contains(name, "-signoz") {
-				apiServerAddr = append(apiServerAddr, domain.FormatAddress("tcp", name, 8080))
-				opampAddr = append(opampAddr, domain.FormatAddress("ws", name, 4320))
+				apiServerAddr = append(apiServerAddr, domain.MustNewAddress("tcp", name, 8080).String())
+				opampAddr = append(opampAddr, domain.MustNewAddress("ws", name, 4320).String())
 			}
 		}
 		config.Spec.Signoz.Status.Addresses.APIServer = apiServerAddr
@@ -70,7 +70,7 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		var clientAddresses []string
 		for _, name := range containerNames {
 			if strings.Contains(name, "telemetrykeeper") {
-				clientAddresses = append(clientAddresses, domain.FormatAddress("tcp", name, 9181))
+				clientAddresses = append(clientAddresses, domain.MustNewAddress("tcp", name, 9181).String())
 			}
 		}
 		config.Spec.TelemetryKeeper.Status.Addresses.Client = clientAddresses
@@ -78,7 +78,7 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		var raftAddresses []string
 		for _, name := range containerNames {
 			if strings.Contains(name, "telemetrykeeper") {
-				raftAddresses = append(raftAddresses, domain.FormatAddress("tcp", name, 9234))
+				raftAddresses = append(raftAddresses, domain.MustNewAddress("tcp", name, 9234).String())
 			}
 		}
 		config.Spec.TelemetryKeeper.Status.Addresses.Raft = raftAddresses
@@ -92,7 +92,7 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		var metastoreAddresses []string
 		for _, name := range containerNames {
 			if strings.Contains(name, "metastore") {
-				metastoreAddresses = append(metastoreAddresses, domain.FormatAddress("tcp", name, 5432))
+				metastoreAddresses = append(metastoreAddresses, domain.MustNewAddress("tcp", name, 5432).String())
 			}
 		}
 		config.Spec.MetaStore.Status.Addresses.DSN = metastoreAddresses
@@ -106,7 +106,7 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		var ingesterAddresses []string
 		for _, name := range containerNames {
 			if strings.Contains(name, "ingester") {
-				ingesterAddresses = append(ingesterAddresses, domain.FormatAddress("tcp", name, 9000))
+				ingesterAddresses = append(ingesterAddresses, domain.MustNewAddress("tcp", name, 9000).String())
 			}
 		}
 		config.Spec.Ingester.Status.Addresses.OTLP = ingesterAddresses

--- a/internal/casting/ecsterraformcasting/enricher.go
+++ b/internal/casting/ecsterraformcasting/enricher.go
@@ -47,7 +47,7 @@ func (enricher *ecsMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alp
 			return fmt.Errorf("failed to get telemetrystore service discovery name: %w", err)
 		}
 		fqdn := fmt.Sprintf("%s.%s", string(sdName), namespace)
-		config.Spec.TelemetryStore.Status.Addresses.TCP = []string{domain.FormatAddress("tcp", fqdn, telemetryStorePort)}
+		config.Spec.TelemetryStore.Status.Addresses.TCP = []string{domain.MustNewAddress("tcp", fqdn, telemetryStorePort).String()}
 
 	case v1alpha1.MoldingKindTelemetryKeeper:
 		sdName, err := enricher.materials[2].GetBytes("resource.aws_service_discovery_service.telemetrykeeper.name")
@@ -55,8 +55,8 @@ func (enricher *ecsMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alp
 			return fmt.Errorf("failed to get telemetrykeeper service discovery name: %w", err)
 		}
 		fqdn := fmt.Sprintf("%s.%s", string(sdName), namespace)
-		config.Spec.TelemetryKeeper.Status.Addresses.Client = []string{domain.FormatAddress("tcp", fqdn, telemetryKeeperClientPort)}
-		config.Spec.TelemetryKeeper.Status.Addresses.Raft = []string{domain.FormatAddress("tcp", fqdn, telemetryKeeperRaftPort)}
+		config.Spec.TelemetryKeeper.Status.Addresses.Client = []string{domain.MustNewAddress("tcp", fqdn, telemetryKeeperClientPort).String()}
+		config.Spec.TelemetryKeeper.Status.Addresses.Raft = []string{domain.MustNewAddress("tcp", fqdn, telemetryKeeperRaftPort).String()}
 
 	case v1alpha1.MoldingKindMetaStore:
 		sdName, err := enricher.materials[3].GetBytes("resource.aws_service_discovery_service.metastore.name")
@@ -64,7 +64,7 @@ func (enricher *ecsMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alp
 			return fmt.Errorf("failed to get metastore service discovery name: %w", err)
 		}
 		fqdn := fmt.Sprintf("%s.%s", string(sdName), namespace)
-		config.Spec.MetaStore.Status.Addresses.DSN = []string{domain.FormatAddress("tcp", fqdn, metaStorePort)}
+		config.Spec.MetaStore.Status.Addresses.DSN = []string{domain.MustNewAddress("tcp", fqdn, metaStorePort).String()}
 
 	case v1alpha1.MoldingKindSignoz:
 		sdName, err := enricher.materials[4].GetBytes("resource.aws_service_discovery_service.signoz.name")
@@ -72,8 +72,8 @@ func (enricher *ecsMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alp
 			return fmt.Errorf("failed to get signoz service discovery name: %w", err)
 		}
 		fqdn := fmt.Sprintf("%s.%s", string(sdName), namespace)
-		config.Spec.Signoz.Status.Addresses.APIServer = []string{domain.FormatAddress("tcp", fqdn, signozAPIPort)}
-		config.Spec.Signoz.Status.Addresses.Opamp = []string{domain.FormatAddress("ws", fqdn, signozOpampPort)}
+		config.Spec.Signoz.Status.Addresses.APIServer = []string{domain.MustNewAddress("tcp", fqdn, signozAPIPort).String()}
+		config.Spec.Signoz.Status.Addresses.Opamp = []string{domain.MustNewAddress("ws", fqdn, signozOpampPort).String()}
 	}
 
 	return nil

--- a/internal/casting/kuberneteshelmcasting/enricher.go
+++ b/internal/casting/kuberneteshelmcasting/enricher.go
@@ -37,7 +37,7 @@ func (e *helmMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alpha1.Mo
 
 func (e *helmMoldingEnricher) enrichTelemetryStore(config *v1alpha1.Casting) error {
 	name := fmt.Sprintf("%s-telemetrystore-%s", config.Metadata.Name, config.Spec.TelemetryStore.Kind)
-	config.Spec.TelemetryStore.Status.Addresses.TCP = []string{domain.FormatAddress("tcp", name, 9000)}
+	config.Spec.TelemetryStore.Status.Addresses.TCP = []string{domain.MustNewAddress("tcp", name, 9000).String()}
 	return nil
 }
 
@@ -54,8 +54,8 @@ func (e *helmMoldingEnricher) enrichTelemetryKeeper(config *v1alpha1.Casting) er
 	base := fmt.Sprintf("%s-telemetrykeeper-zookeeper", config.Metadata.Name)
 	var client, raft []string
 	for i := 0; i < replicas; i++ {
-		client = append(client, domain.FormatAddress("tcp", fmt.Sprintf("%s-%d", base, i), 9181))
-		raft = append(raft, domain.FormatAddress("tcp", fmt.Sprintf("%s-%d", base, i), 9234))
+		client = append(client, domain.MustNewAddress("tcp", fmt.Sprintf("%s-%d", base, i), 9181).String())
+		raft = append(raft, domain.MustNewAddress("tcp", fmt.Sprintf("%s-%d", base, i), 9234).String())
 	}
 	config.Spec.TelemetryKeeper.Status.Addresses.Client = client
 	config.Spec.TelemetryKeeper.Status.Addresses.Raft = raft
@@ -73,7 +73,7 @@ func (e *helmMoldingEnricher) enrichMetaStore(config *v1alpha1.Casting) error {
 func (e *helmMoldingEnricher) enrichSignoz(config *v1alpha1.Casting) error {
 	// Chart uses signoz.fullname which resolves to fullnameOverride directly.
 	name := config.Metadata.Name
-	config.Spec.Signoz.Status.Addresses.Opamp = []string{domain.FormatAddress("tcp", name, 4320)}
+	config.Spec.Signoz.Status.Addresses.Opamp = []string{domain.MustNewAddress("tcp", name, 4320).String()}
 	return nil
 }
 

--- a/internal/casting/kuberneteskustomizecasting/enricher.go
+++ b/internal/casting/kuberneteskustomizecasting/enricher.go
@@ -61,7 +61,7 @@ func (e *kustomizeMoldingEnricher) enrichTelemetryStore(config *v1alpha1.Casting
 	if err != nil {
 		return fmt.Errorf("failed to get telemetrystore service names: %w", err)
 	}
-	config.Spec.TelemetryStore.Status.Addresses.TCP = []string{domain.FormatAddress("tcp", string(name), telemetryStorePort)}
+	config.Spec.TelemetryStore.Status.Addresses.TCP = []string{domain.MustNewAddress("tcp", string(name), telemetryStorePort).String()}
 
 	if config.Spec.TelemetryStore.Status.Extras == nil {
 		config.Spec.TelemetryStore.Status.Extras = make(map[string]string)
@@ -85,8 +85,8 @@ func (e *kustomizeMoldingEnricher) enrichTelemetryKeeper(config *v1alpha1.Castin
 	base := config.Metadata.Name + "-clickhouse-keeper"
 	var client, raft []string
 	for i := 0; i < replicas; i++ {
-		client = append(client, domain.FormatAddress("tcp", fmt.Sprintf("%s-%d", base, i), telemetryKeeperClientPort))
-		raft = append(raft, domain.FormatAddress("tcp", fmt.Sprintf("%s-%d", base, i), telemetryKeeperRaftPort))
+		client = append(client, domain.MustNewAddress("tcp", fmt.Sprintf("%s-%d", base, i), telemetryKeeperClientPort).String())
+		raft = append(raft, domain.MustNewAddress("tcp", fmt.Sprintf("%s-%d", base, i), telemetryKeeperRaftPort).String())
 	}
 	config.Spec.TelemetryKeeper.Status.Addresses.Client = client
 	config.Spec.TelemetryKeeper.Status.Addresses.Raft = raft
@@ -106,7 +106,7 @@ func (e *kustomizeMoldingEnricher) enrichMetaStore(config *v1alpha1.Casting) err
 
 func (e *kustomizeMoldingEnricher) enrichSignoz(config *v1alpha1.Casting) error {
 	name := config.Metadata.Name + "-signoz"
-	config.Spec.Signoz.Status.Addresses.Opamp = []string{domain.FormatAddress("ws", name, signozOpampPort)}
+	config.Spec.Signoz.Status.Addresses.Opamp = []string{domain.MustNewAddress("ws", name, signozOpampPort).String()}
 	return nil
 }
 

--- a/internal/casting/railwaytemplatecasting/enricher.go
+++ b/internal/casting/railwaytemplatecasting/enricher.go
@@ -40,7 +40,7 @@ func (enricher *railwayTemplateMoldingEnricher) EnrichStatus(ctx context.Context
 			return nil
 		}
 		svc := name + "-telemetrystore-" + config.Spec.TelemetryStore.Kind.String()
-		config.Spec.TelemetryStore.Status.Addresses.TCP = []string{domain.FormatAddress("tcp", railwayInternalHost(svc), 9000)}
+		config.Spec.TelemetryStore.Status.Addresses.TCP = []string{domain.MustNewAddress("tcp", railwayInternalHost(svc), 9000).String()}
 		if config.Spec.TelemetryStore.Status.Extras == nil {
 			config.Spec.TelemetryStore.Status.Extras = make(map[string]string)
 		}
@@ -52,16 +52,16 @@ func (enricher *railwayTemplateMoldingEnricher) EnrichStatus(ctx context.Context
 			return nil
 		}
 		svc := name + "-signoz"
-		config.Spec.Signoz.Status.Addresses.APIServer = []string{domain.FormatAddress("tcp", railwayInternalHost(svc), 8080)}
-		config.Spec.Signoz.Status.Addresses.Opamp = []string{domain.FormatAddress("ws", railwayInternalHost(svc), 4320)}
+		config.Spec.Signoz.Status.Addresses.APIServer = []string{domain.MustNewAddress("tcp", railwayInternalHost(svc), 8080).String()}
+		config.Spec.Signoz.Status.Addresses.Opamp = []string{domain.MustNewAddress("ws", railwayInternalHost(svc), 4320).String()}
 
 	case v1alpha1.MoldingKindTelemetryKeeper:
 		if !config.Spec.TelemetryKeeper.Spec.IsEnabled() {
 			return nil
 		}
 		svc := name + "-telemetrykeeper-" + config.Spec.TelemetryKeeper.Kind.String()
-		config.Spec.TelemetryKeeper.Status.Addresses.Client = []string{domain.FormatAddress("tcp", railwayInternalHost(svc), 9181)}
-		config.Spec.TelemetryKeeper.Status.Addresses.Raft = []string{domain.FormatAddress("tcp", railwayInternalHost(svc), 9234)}
+		config.Spec.TelemetryKeeper.Status.Addresses.Client = []string{domain.MustNewAddress("tcp", railwayInternalHost(svc), 9181).String()}
+		config.Spec.TelemetryKeeper.Status.Addresses.Raft = []string{domain.MustNewAddress("tcp", railwayInternalHost(svc), 9234).String()}
 		if config.Spec.TelemetryKeeper.Status.Extras == nil {
 			config.Spec.TelemetryKeeper.Status.Extras = make(map[string]string)
 		}
@@ -72,7 +72,7 @@ func (enricher *railwayTemplateMoldingEnricher) EnrichStatus(ctx context.Context
 			return nil
 		}
 		svc := name + "-ingester"
-		config.Spec.Ingester.Status.Addresses.OTLP = []string{domain.FormatAddress("tcp", railwayInternalHost(svc), 4318)}
+		config.Spec.Ingester.Status.Addresses.OTLP = []string{domain.MustNewAddress("tcp", railwayInternalHost(svc), 4318).String()}
 	}
 
 	return nil

--- a/internal/casting/rendercasting/enricher.go
+++ b/internal/casting/rendercasting/enricher.go
@@ -38,7 +38,7 @@ func (enricher *renderMoldingEnricher) EnrichStatus(ctx context.Context, kind v1
 		var storeServiceNames []string
 		for _, serviceName := range serviceNames {
 			if strings.Contains(serviceName, "telemetrystore") && !strings.Contains(serviceName, "migrator") {
-				addrs = append(addrs, domain.FormatAddress("tcp", serviceName, 9000))
+				addrs = append(addrs, domain.MustNewAddress("tcp", serviceName, 9000).String())
 				storeServiceNames = append(storeServiceNames, serviceName)
 			}
 		}
@@ -61,8 +61,8 @@ func (enricher *renderMoldingEnricher) EnrichStatus(ctx context.Context, kind v1
 		var opampAddr []string
 		for _, serviceName := range serviceNames {
 			if strings.Contains(serviceName, "-signoz") {
-				apiServerAddr = append(apiServerAddr, domain.FormatAddress("tcp", serviceName, 8080))
-				opampAddr = append(opampAddr, domain.FormatAddress("ws", serviceName, 4320))
+				apiServerAddr = append(apiServerAddr, domain.MustNewAddress("tcp", serviceName, 8080).String())
+				opampAddr = append(opampAddr, domain.MustNewAddress("ws", serviceName, 4320).String())
 			}
 		}
 		config.Spec.Signoz.Status.Addresses.APIServer = apiServerAddr
@@ -80,8 +80,8 @@ func (enricher *renderMoldingEnricher) EnrichStatus(ctx context.Context, kind v1
 		var keeperServiceNames []string
 		for _, serviceName := range serviceNames {
 			if strings.Contains(serviceName, "telemetrykeeper") {
-				addrsClient = append(addrsClient, domain.FormatAddress("tcp", serviceName, 9181))
-				addrsRaft = append(addrsRaft, domain.FormatAddress("tcp", serviceName, 9234))
+				addrsClient = append(addrsClient, domain.MustNewAddress("tcp", serviceName, 9181).String())
+				addrsRaft = append(addrsRaft, domain.MustNewAddress("tcp", serviceName, 9234).String())
 				keeperServiceNames = append(keeperServiceNames, serviceName)
 			}
 		}
@@ -104,7 +104,7 @@ func (enricher *renderMoldingEnricher) EnrichStatus(ctx context.Context, kind v1
 		var addrs []string
 		for _, serviceName := range serviceNames {
 			if strings.Contains(serviceName, "ingester") {
-				addrs = append(addrs, domain.FormatAddress("tcp", serviceName, 4318))
+				addrs = append(addrs, domain.MustNewAddress("tcp", serviceName, 4318).String())
 			}
 		}
 		config.Spec.Ingester.Status.Addresses.OTLP = addrs

--- a/internal/casting/systemdcasting/enricher.go
+++ b/internal/casting/systemdcasting/enricher.go
@@ -64,7 +64,7 @@ func (e *linuxMoldingEnricher) enrichTelemetryStore(config *v1alpha1.Casting) er
 	for shard := 0; shard < shards; shard++ {
 		for replica := 0; replica < replicas; replica++ {
 			port := baseTelemetryStoreClusterPort + (shard * replicas) + replica
-			addresses = append(addresses, domain.FormatAddress("tcp", "localhost", port))
+			addresses = append(addresses, domain.MustNewAddress("tcp", "localhost", port).String())
 		}
 	}
 
@@ -87,8 +87,8 @@ func (e *linuxMoldingEnricher) enrichTelemetryKeeper(config *v1alpha1.Casting) e
 
 	var clientAddresses, raftAddresses []string
 	for r := 0; r < replicas; r++ {
-		clientAddresses = append(clientAddresses, domain.FormatAddress("tcp", "localhost", baseTelemetryKeeperClientPort+r))
-		raftAddresses = append(raftAddresses, domain.FormatAddress("tcp", "localhost", baseTelemetryKeeperRaftPort+r))
+		clientAddresses = append(clientAddresses, domain.MustNewAddress("tcp", "localhost", baseTelemetryKeeperClientPort+r).String())
+		raftAddresses = append(raftAddresses, domain.MustNewAddress("tcp", "localhost", baseTelemetryKeeperRaftPort+r).String())
 	}
 
 	config.Spec.TelemetryKeeper.Status.Addresses.Client = clientAddresses
@@ -101,7 +101,7 @@ func (e *linuxMoldingEnricher) enrichMetaStore(config *v1alpha1.Casting) error {
 	case v1alpha1.MetaStoreKindSQLite:
 		// SQLite — no addresses or binaries to enrich.
 	case v1alpha1.MetaStoreKindPostgres:
-		dsn := domain.FormatAddress("postgres", "localhost", baseMetaStorePostgresPort)
+		dsn := domain.MustNewAddress("postgres", "localhost", baseMetaStorePostgresPort).String()
 		config.Spec.MetaStore.Status.Addresses.DSN = []string{dsn}
 
 		// Get the annotation value
@@ -122,10 +122,10 @@ func (e *linuxMoldingEnricher) enrichMetaStore(config *v1alpha1.Casting) error {
 
 func (e *linuxMoldingEnricher) enrichSignoz(config *v1alpha1.Casting) error {
 	config.Spec.Signoz.Status.Addresses.Opamp = []string{
-		domain.FormatAddress("ws", "localhost", 4320),
+		domain.MustNewAddress("ws", "localhost", 4320).String(),
 	}
 	config.Spec.Signoz.Status.Addresses.APIServer = []string{
-		domain.FormatAddress("tcp", "localhost", 8080),
+		domain.MustNewAddress("tcp", "localhost", 8080).String(),
 	}
 
 	// Get the annotation value
@@ -146,7 +146,7 @@ func (e *linuxMoldingEnricher) enrichSignoz(config *v1alpha1.Casting) error {
 
 func (e *linuxMoldingEnricher) enrichIngester(config *v1alpha1.Casting) error {
 	config.Spec.Ingester.Status.Addresses.OTLP = []string{
-		domain.FormatAddress("tcp", "localhost", 4317),
+		domain.MustNewAddress("tcp", "localhost", 4317).String(),
 	}
 
 	// Get the annotation value

--- a/internal/domain/address.go
+++ b/internal/domain/address.go
@@ -1,63 +1,101 @@
 package domain
 
 import (
-	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
+
+	"github.com/signoz/foundry/internal/errors"
 )
 
 type Address struct {
-	host string
-	port int
+	scheme string
+	host   string
+	port   int
 }
 
-func (address *Address) Host() string {
-	return address.host
-}
-
-func (address *Address) Port() int {
-	return address.port
-}
-
-// FormatAddress creates a formatted address string from scheme, host, and port.
-func FormatAddress(scheme, host string, port int) string {
-	return fmt.Sprintf("%s://%s:%d", scheme, host, port)
-}
-
-// NewAddress parses a URL-formatted address string into host and port components.
-func NewAddress(address string) (Address, error) {
-	u, err := url.Parse(address)
-	if err != nil {
-		return Address{}, fmt.Errorf("invalid address %q: %w", address, err)
+// NewAddress requires a non-empty scheme and host, and a port in [0, 65535] where 0 means no port.
+func NewAddress(scheme, host string, port int) (Address, error) {
+	if scheme == "" {
+		return Address{}, errors.Newf(errors.TypeInvalidInput, "failed to create address: scheme is empty")
 	}
 
-	host := u.Hostname()
-	portStr := u.Port()
-
 	if host == "" {
-		return Address{}, fmt.Errorf("address %q has no host", address)
+		return Address{}, errors.Newf(errors.TypeInvalidInput, "failed to create address: host is empty")
+	}
+
+	if port < 0 || port > 65535 {
+		return Address{}, errors.Newf(errors.TypeInvalidInput, "failed to create address: port %d is out of range", port)
+	}
+
+	return Address{scheme: scheme, host: host, port: port}, nil
+}
+
+func MustNewAddress(scheme, host string, port int) Address {
+	address, err := NewAddress(scheme, host, port)
+	if err != nil {
+		panic(err)
+	}
+
+	return address
+}
+
+// ParseAddress accepts "scheme://host[:port]"; IPv6 literals must be bracketed
+// (e.g. "tcp://[::1]:9000" or "tcp://[::1]").
+func ParseAddress(raw string) (Address, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return Address{}, errors.Wrapf(err, errors.TypeInvalidInput, "failed to create address from %q: contents are not a valid URL", raw)
 	}
 
 	var port int
-	if portStr != "" {
+	if portStr := u.Port(); portStr != "" {
 		port, err = strconv.Atoi(portStr)
 		if err != nil {
-			return Address{}, fmt.Errorf("address %q has invalid port: %w", address, err)
+			return Address{}, errors.Wrapf(err, errors.TypeInvalidInput, "failed to create address from %q: port is not a valid integer", raw)
 		}
 	}
 
-	return Address{host: host, port: port}, nil
+	return NewAddress(u.Scheme, u.Hostname(), port)
 }
 
-// NewAddresses parses multiple address strings and returns the parsed results.
-func NewAddresses(addresses []string) ([]Address, error) {
-	result := make([]Address, 0, len(addresses))
-	for i, addr := range addresses {
-		parsed, err := NewAddress(addr)
+func ParseAddresses(raws []string) ([]Address, error) {
+	result := make([]Address, 0, len(raws))
+
+	for i, raw := range raws {
+		address, err := ParseAddress(raw)
 		if err != nil {
-			return nil, fmt.Errorf("address[%d]: %w", i, err)
+			return nil, errors.Wrapf(err, errors.TypeInvalidInput, "addresses[%d]", i)
 		}
-		result = append(result, parsed)
+
+		result = append(result, address)
 	}
+
 	return result, nil
+}
+
+func (a Address) Scheme() string {
+	return a.scheme
+}
+
+func (a Address) Host() string {
+	return a.host
+}
+
+func (a Address) Port() int {
+	return a.port
+}
+
+// String renders the address as "scheme://host[:port]", bracketing IPv6 hosts and omitting the port suffix when port is zero.
+func (a Address) String() string {
+	host := a.host
+	if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+
+	if a.port == 0 {
+		return a.scheme + "://" + host
+	}
+
+	return a.scheme + "://" + host + ":" + strconv.Itoa(a.port)
 }

--- a/internal/domain/address_test.go
+++ b/internal/domain/address_test.go
@@ -1,0 +1,85 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseAddress(t *testing.T) {
+	tests := []struct {
+		name           string
+		raw            string
+		pass           bool
+		expectedScheme string
+		expectedHost   string
+		expectedPort   int
+	}{
+		{
+			name:           "Hostname_Valid",
+			raw:            "tcp://query-service:9000",
+			pass:           true,
+			expectedScheme: "tcp",
+			expectedHost:   "query-service",
+			expectedPort:   9000,
+		},
+		{
+			name:           "IPv4_Valid",
+			raw:            "postgres://127.0.0.1:5432",
+			pass:           true,
+			expectedScheme: "postgres",
+			expectedHost:   "127.0.0.1",
+			expectedPort:   5432,
+		},
+		{
+			name:           "IPv6_Valid",
+			raw:            "tcp://[::1]:9000",
+			pass:           true,
+			expectedScheme: "tcp",
+			expectedHost:   "::1",
+			expectedPort:   9000,
+		},
+		{
+			name:           "Hostname_NoPort_Valid",
+			raw:            "tcp://signoz",
+			pass:           true,
+			expectedScheme: "tcp",
+			expectedHost:   "signoz",
+			expectedPort:   0,
+		},
+		{
+			name:           "IPv6_NoPort_Valid",
+			raw:            "tcp://[::1]",
+			pass:           true,
+			expectedScheme: "tcp",
+			expectedHost:   "::1",
+			expectedPort:   0,
+		},
+		{
+			name: "MissingScheme_Invalid",
+			raw:  "localhost:9000",
+			pass: false,
+		},
+		{
+			name: "Malformed_Invalid",
+			raw:  "://bad",
+			pass: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address, err := ParseAddress(tt.raw)
+			if !tt.pass {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedScheme, address.Scheme())
+			assert.Equal(t, tt.expectedHost, address.Host())
+			assert.Equal(t, tt.expectedPort, address.Port())
+			assert.Equal(t, tt.raw, address.String())
+		})
+	}
+}

--- a/internal/molding/signozmolding/signoz.go
+++ b/internal/molding/signozmolding/signoz.go
@@ -57,7 +57,7 @@ func (molding *signoz) MoldV1Alpha1(ctx context.Context, config *v1alpha1.Castin
 				molding.logger.WarnContext(ctx, "SIGNOZ_SQLSTORE_POSTGRES_DSN is going to be overridden", slog.String("value", val))
 			}
 			// construct postgres dsn with user, password, host, port, and db
-			addrs, err := domain.NewAddresses(config.Spec.MetaStore.Status.Addresses.DSN)
+			addrs, err := domain.ParseAddresses(config.Spec.MetaStore.Status.Addresses.DSN)
 			if err != nil {
 				return fmt.Errorf("failed to parse addresses: %w", err)
 			}

--- a/internal/molding/telemetrykeepermolding/template.go
+++ b/internal/molding/telemetrykeepermolding/template.go
@@ -42,13 +42,13 @@ func newData(config *v1alpha1.Casting) (Data, error) {
 		return Data{}, fmt.Errorf("insufficient client addresses: have %d, need %d servers", len(clientAddresses), data.ServerCount)
 	}
 
-	newRaftAddrs, err := domain.NewAddresses(raftAddresses[:data.ServerCount])
+	newRaftAddrs, err := domain.ParseAddresses(raftAddresses[:data.ServerCount])
 	if err != nil {
 		return Data{}, fmt.Errorf("failed to parse raft addresses: %w", err)
 	}
 	data.RaftAddresses = newRaftAddrs
 
-	newClientAddrs, err := domain.NewAddresses(clientAddresses[:data.ServerCount])
+	newClientAddrs, err := domain.ParseAddresses(clientAddresses[:data.ServerCount])
 	if err != nil {
 		return Data{}, fmt.Errorf("failed to parse client addresses: %w", err)
 	}

--- a/internal/molding/telemetrystoremolding/telemetrystore.go
+++ b/internal/molding/telemetrystoremolding/telemetrystore.go
@@ -92,7 +92,7 @@ func (molding *telemetrystore) getData(config *v1alpha1.Casting) (Data, error) {
 		)
 	}
 
-	newStoreAddrs, err := domain.NewAddresses(storeAddresses[:expectedNodes])
+	newStoreAddrs, err := domain.ParseAddresses(storeAddresses[:expectedNodes])
 	if err != nil {
 		return Data{}, fmt.Errorf("failed to parse addresses: %w", err)
 	}
@@ -102,7 +102,7 @@ func (molding *telemetrystore) getData(config *v1alpha1.Casting) (Data, error) {
 		return Data{}, fmt.Errorf("telemetry keeper addresses not set in status")
 	}
 
-	newKeeperAddrs, err := domain.NewAddresses(keeperAddresses)
+	newKeeperAddrs, err := domain.ParseAddresses(keeperAddresses)
 	if err != nil {
 		return Data{}, fmt.Errorf("failed to parse addresses: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Carry scheme on `domain.Address` so the round-trip `Parse → String` is lossless; bracket IPv6 hosts on render.
- Single construction path: `ParseAddress` delegates field validation to `NewAddress`. Add `MustNewAddress` and rename the slice constructor `NewAddresses` → `ParseAddresses` (it parses strings).
- Port is optional — `0` means unset and is dropped from `String`, so `tcp://signoz` and `tcp://[::1]` round-trip cleanly.
- Drop `FormatAddress`; casting enrichers now use `domain.MustNewAddress(...).String()`.
- Error messages aligned with the material-domain wording (`failed to create address[ from %q]: <reason>`).
- Adds `internal/domain/address_test.go` covering hostname / IPv4 / IPv6, port-less variants, parse round-trip, and slice error propagation.