### PR TITLE
refactor(domain): make Template a format-aware value object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ pours/
 
 ### VSCode ###
 !.vscode/settings.json
+
+### Claude ###
+CLAUDE.local.md

--- a/internal/casting/ecsterraformcasting/casting.go
+++ b/internal/casting/ecsterraformcasting/casting.go
@@ -1,7 +1,6 @@
 package ecsterraformcasting
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -46,7 +45,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 		"terraform.tfvars.json": tfarsTF,
 	}
 	for filename, tmpl := range rootTemplates {
-		m, err := executeTemplate(tmpl, config, filepath.Join(deployDir, filename))
+		m, err := tmpl.Render(config, filepath.Join(deployDir, filename))
 		if err != nil {
 			return nil, err
 		}
@@ -60,7 +59,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 		"outputs.tf.json":   moduleOutputsTF,
 	}
 	for filename, tmpl := range moduleTemplates {
-		m, err := executeTemplate(tmpl, config, filepath.Join(moduleDir, filename))
+		m, err := tmpl.Render(config, filepath.Join(moduleDir, filename))
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +68,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 
 	// TelemetryKeeper
 	if config.Spec.TelemetryKeeper.Spec.IsEnabled() {
-		m, err := executeTemplate(moduleTelemetryKeeperTF, config, filepath.Join(moduleDir, "telemetrykeeper.tf.json"))
+		m, err := moduleTelemetryKeeperTF.Render(config, filepath.Join(moduleDir, "telemetrykeeper.tf.json"))
 		if err != nil {
 			return nil, err
 		}
@@ -86,7 +85,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 
 	// TelemetryStore
 	if config.Spec.TelemetryStore.Spec.IsEnabled() {
-		m, err := executeTemplate(moduleTelemetryStoreTF, config, filepath.Join(moduleDir, "telemetrystore.tf.json"))
+		m, err := moduleTelemetryStoreTF.Render(config, filepath.Join(moduleDir, "telemetrystore.tf.json"))
 		if err != nil {
 			return nil, err
 		}
@@ -103,7 +102,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 
 	// TelemetryStore migrator
 	if config.Spec.TelemetryStore.Spec.IsEnabled() {
-		m, err := executeTemplate(moduleMigratorTF, config, filepath.Join(moduleDir, "telemetrystore_migrator.tf.json"))
+		m, err := moduleMigratorTF.Render(config, filepath.Join(moduleDir, "telemetrystore_migrator.tf.json"))
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +111,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 
 	// MetaStore
 	if config.Spec.MetaStore.Spec.IsEnabled() {
-		m, err := executeTemplate(moduleMetaStoreTF, config, filepath.Join(moduleDir, "metastore.tf.json"))
+		m, err := moduleMetaStoreTF.Render(config, filepath.Join(moduleDir, "metastore.tf.json"))
 		if err != nil {
 			return nil, err
 		}
@@ -129,7 +128,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 
 	// Signoz
 	if config.Spec.Signoz.Spec.IsEnabled() {
-		m, err := executeTemplate(moduleSignozTF, config, filepath.Join(moduleDir, "signoz.tf.json"))
+		m, err := moduleSignozTF.Render(config, filepath.Join(moduleDir, "signoz.tf.json"))
 		if err != nil {
 			return nil, err
 		}
@@ -138,7 +137,7 @@ func (c *ecsCasting) Forge(ctx context.Context, config v1alpha1.Casting, poursPa
 
 	// Ingester
 	if config.Spec.Ingester.Spec.IsEnabled() {
-		m, err := executeTemplate(moduleIngesterTF, config, filepath.Join(moduleDir, "ingester.tf.json"))
+		m, err := moduleIngesterTF.Render(config, filepath.Join(moduleDir, "ingester.tf.json"))
 		if err != nil {
 			return nil, err
 		}
@@ -197,15 +196,6 @@ func (c *ecsCasting) Cast(ctx context.Context, config v1alpha1.Casting, outputPa
 	return nil
 }
 
-// executeTemplate renders a template and returns a JSONMaterial at the given path.
-func executeTemplate(tmpl *domain.Template, config v1alpha1.Casting, path string) (domain.StructuredMaterial, error) {
-	buf := bytes.NewBuffer(nil)
-	if err := tmpl.Execute(buf, config); err != nil {
-		return nil, fmt.Errorf("failed to execute template for %s: %w", path, err)
-	}
-	return domain.NewJSONMaterial(buf.Bytes(), path)
-}
-
 // getMaterials renders all module templates and returns them as JSONMaterials.
 func getMaterials(config *v1alpha1.Casting) ([]domain.StructuredMaterial, error) {
 	var materials []domain.StructuredMaterial
@@ -218,11 +208,15 @@ func getMaterials(config *v1alpha1.Casting) ([]domain.StructuredMaterial, error)
 		moduleSignozTF,
 		moduleIngesterTF,
 	} {
-		m, err := executeTemplate(tmpl, *config, tmpl.GetPath())
+		m, err := tmpl.Render(*config, tmpl.Path())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create material: %w", err)
 		}
-		materials = append(materials, m)
+		sm, ok := m.(domain.StructuredMaterial)
+		if !ok {
+			return nil, fmt.Errorf("template %s does not produce a structured material", tmpl.Path())
+		}
+		materials = append(materials, sm)
 	}
 
 	return materials, nil

--- a/internal/casting/kuberneteskustomizecasting/casting.go
+++ b/internal/casting/kuberneteskustomizecasting/casting.go
@@ -1,7 +1,6 @@
 package kuberneteskustomizecasting
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -142,58 +141,47 @@ func (c *kustomizeCasting) applyCRDs(ctx context.Context) error {
 }
 
 func (c *kustomizeCasting) forgeCasting(tmpl *domain.Template, cfg *v1alpha1.Casting, poursPath string) ([]domain.Material, error) {
-	templatePath := tmpl.GetPath()
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, cfg); err != nil {
-		return nil, fmt.Errorf("execute template %s: %w", templatePath, err)
-	}
+	templatePath := tmpl.Path()
 	relPath := strings.TrimPrefix(templatePath, "templates/")
 	relPath = strings.TrimSuffix(relPath, filepath.Ext(relPath))
 	path := filepath.Join(rootcasting.DeploymentDir, relPath)
-	material, err := domain.NewYAMLMaterial(buf.Bytes(), path)
+	material, err := tmpl.Render(cfg, path)
 	if err != nil {
-		return nil, fmt.Errorf("create material %s: %w", templatePath, err)
+		return nil, fmt.Errorf("render template %s: %w", templatePath, err)
 	}
 	return []domain.Material{material}, nil
 }
 
 func getOverrideMaterials(config *v1alpha1.Casting) ([]domain.StructuredMaterial, error) {
-	var materials []domain.StructuredMaterial
-
-	storeBuf := bytes.NewBuffer(nil)
-	if err := telemetryStoreOverrideTemplate.Execute(storeBuf, config); err != nil {
-		return nil, fmt.Errorf("failed to execute store override template: %w", err)
-	}
-	storeMaterial, err := domain.NewYAMLMaterial(storeBuf.Bytes(), "store_overrides.yaml")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create store override material: %w", err)
-	}
-	materials = append(materials, storeMaterial)
-
-	return materials, nil
+	return renderStructured(config, []templateAt{
+		{telemetryStoreOverrideTemplate, "store_overrides.yaml"},
+	})
 }
 
 func getServiceMaterials(config *v1alpha1.Casting) ([]domain.StructuredMaterial, error) {
-	var materials []domain.StructuredMaterial
+	return renderStructured(config, []templateAt{
+		{clickhouseInstanceInstallation, "clickhouseInstallation.yaml"},
+		{metastoreService, "metastoreServie.yaml"},
+	})
+}
 
-	telemetryStoreInstallationBuf := bytes.NewBuffer(nil)
-	if err := clickhouseInstanceInstallation.Execute(telemetryStoreInstallationBuf, config); err != nil {
-		return nil, fmt.Errorf("failed to execute store installation template: %w", err)
-	}
-	telemetryStoreInstallationMaterial, err := domain.NewYAMLMaterial(telemetryStoreInstallationBuf.Bytes(), "clickhouseInstallation.yaml")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create keeper override material: %w", err)
-	}
-	materials = append(materials, telemetryStoreInstallationMaterial)
+type templateAt struct {
+	tmpl *domain.Template
+	path string
+}
 
-	metaStoreServiceBuf := bytes.NewBuffer(nil)
-	if err := metastoreService.Execute(metaStoreServiceBuf, config); err != nil {
-		return nil, fmt.Errorf("failed to execute store installation template: %w", err)
+func renderStructured(config *v1alpha1.Casting, items []templateAt) ([]domain.StructuredMaterial, error) {
+	materials := make([]domain.StructuredMaterial, 0, len(items))
+	for _, item := range items {
+		m, err := item.tmpl.Render(config, item.path)
+		if err != nil {
+			return nil, fmt.Errorf("render template %s: %w", item.tmpl.Path(), err)
+		}
+		sm, ok := m.(domain.StructuredMaterial)
+		if !ok {
+			return nil, fmt.Errorf("template %s does not produce a structured material", item.tmpl.Path())
+		}
+		materials = append(materials, sm)
 	}
-	metaStoreServiceMaterial, err := domain.NewYAMLMaterial(metaStoreServiceBuf.Bytes(), "metastoreServie.yaml")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create metastore service material: %w", err)
-	}
-	materials = append(materials, metaStoreServiceMaterial)
 	return materials, nil
 }

--- a/internal/casting/systemdcasting/casting.go
+++ b/internal/casting/systemdcasting/casting.go
@@ -1,7 +1,6 @@
 package systemdcasting
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -298,11 +297,7 @@ func (c *systemdCasting) configMaterials(data map[string]string, component strin
 }
 
 func (c *systemdCasting) renderTemplate(tmpl *domain.Template, cfg *v1alpha1.Casting, path string) (domain.Material, error) {
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, cfg); err != nil {
-		return nil, fmt.Errorf("execute template %s: %w", path, err)
-	}
-	return domain.NewINIMaterial(buf.Bytes(), filepath.Join(rootcasting.DeploymentDir, path))
+	return tmpl.Render(cfg, filepath.Join(rootcasting.DeploymentDir, path))
 }
 
 // execCommand executes a command and returns an error if it fails.

--- a/internal/domain/material.go
+++ b/internal/domain/material.go
@@ -6,14 +6,32 @@ import (
 )
 
 var (
-	FormatYAML Format = Format{s: "yaml"}
-	FormatJSON Format = Format{s: "json"}
-	FormatINI  Format = Format{s: "ini"}
-	FormatText Format = Format{s: "text"}
+	FormatYAML = Format{s: "yaml", new: func(c []byte, p string) (Material, error) { return NewYAMLMaterial(c, p) }}
+	FormatJSON = Format{s: "json", new: func(c []byte, p string) (Material, error) { return NewJSONMaterial(c, p) }}
+	FormatINI  = Format{s: "ini", new: func(c []byte, p string) (Material, error) { return NewINIMaterial(c, p) }}
+	FormatText = Format{s: "text", new: func(c []byte, p string) (Material, error) { return NewBlobMaterial(c, p), nil }}
 )
 
-// Format identifies the syntax of a Material's contents.
-type Format struct{ s string }
+// Format identifies the syntax of a Material's contents and carries the
+// constructor that wraps a rendered byte stream in the matching concrete
+// Material type. To register a new format, add a single entry above with its
+// New* constructor — Template.Render picks it up automatically.
+type Format struct {
+	s   string
+	new func(contents []byte, path string) (Material, error)
+}
+
+func (f Format) String() string {
+	return f.s
+}
+
+// NewMaterial wraps contents in the concrete Material type for this format.
+func (f Format) NewMaterial(contents []byte, path string) (Material, error) {
+	if f.new == nil {
+		return nil, errors.Newf(errors.TypeUnsupported, "failed to create material for path %q: unsupported format %q", path, f.s)
+	}
+	return f.new(contents, path)
+}
 
 // Material is a unit of output that Foundry produces. It carries the path it
 // should be written to and the bytes to write there.

--- a/internal/domain/template.go
+++ b/internal/domain/template.go
@@ -1,15 +1,20 @@
 package domain
 
 import (
+	"bytes"
 	"embed"
 	"io"
 	"path/filepath"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/signoz/foundry/internal/errors"
 	"sigs.k8s.io/yaml"
 )
 
+// Template is a parsed text/template paired with the on-disk path it was loaded
+// from and the Format its rendered output is expected to take. Format drives
+// Render's choice of concrete Material type.
 type Template struct {
 	name   string
 	path   string
@@ -17,7 +22,91 @@ type Template struct {
 	tmpl   *template.Template
 }
 
-// templateFuncMap returns the function map for templates (sprig + toYaml).
+func NewTemplateFromFS(fs embed.FS, path string, format Format) (*Template, error) {
+	name := filepath.Base(path)
+	tmpl, err := template.New(name).Funcs(templateFuncMap()).ParseFS(fs, path)
+	if err != nil {
+		return nil, errors.Wrapf(err, errors.TypeInvalidInput, "failed to create template from %q: contents are not a valid template", path)
+	}
+
+	return &Template{name: name, path: path, format: format, tmpl: tmpl}, nil
+}
+
+func NewTemplate(name string, contents []byte, format Format) (*Template, error) {
+	tmpl, err := template.New(name).Funcs(templateFuncMap()).Parse(string(contents))
+	if err != nil {
+		return nil, errors.Wrapf(err, errors.TypeInvalidInput, "failed to create template from %q: contents are not a valid template", name)
+	}
+
+	return &Template{name: name, format: format, tmpl: tmpl}, nil
+}
+
+func MustNewTemplateFromFS(fs embed.FS, path string, format Format) *Template {
+	tmpl, err := NewTemplateFromFS(fs, path, format)
+	if err != nil {
+		panic(err)
+	}
+
+	return tmpl
+}
+
+func MustNewTemplate(name string, contents []byte, format Format) *Template {
+	tmpl, err := NewTemplate(name, contents, format)
+	if err != nil {
+		panic(err)
+	}
+
+	return tmpl
+}
+
+// Execute renders the template into w. Each call clones the underlying
+// *template.Template so concurrent calls don't share parse state.
+func (t *Template) Execute(w io.Writer, data any) error {
+	newtmpl, err := t.tmpl.Clone()
+	if err != nil {
+		return errors.Wrapf(err, errors.TypeInternal, "failed to execute template %q", t.name)
+	}
+
+	if err := newtmpl.ExecuteTemplate(w, t.name, data); err != nil {
+		return errors.Wrapf(err, errors.TypeInternal, "failed to execute template %q", t.name)
+	}
+
+	return nil
+}
+
+// Render executes the template against data and wraps the output in the
+// concrete Material type indicated by the template's Format.
+func (t *Template) Render(data any, path string) (Material, error) {
+	buf := bytes.NewBuffer(nil)
+	if err := t.Execute(buf, data); err != nil {
+		return nil, err
+	}
+
+	m, err := t.format.NewMaterial(buf.Bytes(), path)
+	if err != nil {
+		return nil, errors.Wrapf(err, errors.TypeInternal, "failed to render template %q", t.name)
+	}
+	return m, nil
+}
+
+func (t *Template) Name() string {
+	return t.name
+}
+
+func (t *Template) Path() string {
+	return t.path
+}
+
+func (t *Template) Format() Format {
+	return t.format
+}
+
+// templateFuncMap layers the project's helpers on top of sprig:
+//   - derefInt / derefIntDefault: nil-safe int pointer access for spec fields
+//     that distinguish "unset" from zero.
+//   - toYaml / fromYaml: round-trip a value through YAML inside templates.
+//   - flattenKeys: flatten a nested map into "/"-joined leaf keys (used to
+//     project hierarchical config into flat env-var-style maps).
 func templateFuncMap() template.FuncMap {
 	fm := template.FuncMap(sprig.FuncMap())
 	fm["derefInt"] = func(p *int) int {
@@ -64,58 +153,4 @@ func flattenMapKeys(prefix string, m map[string]any, result map[string]any) {
 			result[key] = v
 		}
 	}
-}
-
-func NewTemplateFromFS(fs embed.FS, path string, format Format) (*Template, error) {
-	name := filepath.Base(path)
-	tmpl, err := template.New(name).Funcs(templateFuncMap()).ParseFS(fs, path)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Template{name: name, path: path, tmpl: tmpl, format: format}, nil
-}
-
-func MustNewTemplateFromFS(fs embed.FS, path string, format Format) *Template {
-	tmpl, err := NewTemplateFromFS(fs, path, format)
-	if err != nil {
-		panic(err)
-	}
-
-	return tmpl
-}
-
-func NewTemplate(name string, contents []byte) (*Template, error) {
-	tmpl, err := template.New(name).Funcs(templateFuncMap()).Parse(string(contents))
-	if err != nil {
-		return nil, err
-	}
-
-	return &Template{name: name, tmpl: tmpl}, nil
-}
-
-func MustNewTemplate(name string, contents []byte) *Template {
-	tmpl, err := NewTemplate(name, contents)
-	if err != nil {
-		panic(err)
-	}
-
-	return tmpl
-}
-
-func (t *Template) Execute(w io.Writer, data any) error {
-	newtmpl, err := t.tmpl.Clone()
-	if err != nil {
-		return err
-	}
-
-	return newtmpl.ExecuteTemplate(w, t.name, data)
-}
-
-func (t *Template) GetName() string {
-	return t.name
-}
-
-func (t *Template) GetPath() string {
-	return t.path
 }

--- a/internal/domain/template_test.go
+++ b/internal/domain/template_test.go
@@ -1,0 +1,88 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplateRender(t *testing.T) {
+	tests := []struct {
+		name        string
+		contents    []byte
+		format      Format
+		path        string
+		data        any
+		pass        bool
+		expectedFmt []byte
+	}{
+		{
+			name:        "YAML_Valid",
+			contents:    []byte("greeting: hello {{ .Name }}\n"),
+			format:      FormatYAML,
+			path:        "out.yaml",
+			data:        map[string]string{"Name": "world"},
+			pass:        true,
+			expectedFmt: []byte("greeting: hello world\n"),
+		},
+		{
+			name:        "JSON_Valid",
+			contents:    []byte(`{"greeting":"hello {{ .Name }}"}`),
+			format:      FormatJSON,
+			path:        "out.json",
+			data:        map[string]string{"Name": "world"},
+			pass:        true,
+			expectedFmt: []byte(`{"greeting":"hello world"}`),
+		},
+		{
+			name:        "INI_Valid",
+			contents:    []byte("[greeting]\nname = {{ .Name }}\n"),
+			format:      FormatINI,
+			path:        "out.ini",
+			data:        map[string]string{"Name": "world"},
+			pass:        true,
+			expectedFmt: []byte("[greeting]\nname=world\n"),
+		},
+		{
+			name:        "Text_Valid",
+			contents:    []byte("hello {{ .Name }}"),
+			format:      FormatText,
+			path:        "out.txt",
+			data:        map[string]string{"Name": "world"},
+			pass:        true,
+			expectedFmt: []byte("hello world"),
+		},
+		{
+			name:     "UnsupportedFormat_Invalid",
+			contents: []byte("hello"),
+			format:   Format{s: "bogus"},
+			path:     "out",
+			data:     nil,
+			pass:     false,
+		},
+		{
+			name:     "JSON_InvalidOutput",
+			contents: []byte(`{"greeting": hello {{ .Name }}}`),
+			format:   FormatJSON,
+			path:     "out.json",
+			data:     map[string]string{"Name": "world"},
+			pass:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl := MustNewTemplate(tt.name, tt.contents, tt.format)
+
+			material, err := tmpl.Render(tt.data, tt.path)
+			if !tt.pass {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.path, material.Path())
+			assert.Equal(t, tt.expectedFmt, material.FmtContents())
+		})
+	}
+}

--- a/internal/infrastructure/terraform/generator.go
+++ b/internal/infrastructure/terraform/generator.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -67,51 +66,22 @@ func (g *Generator) Generate(ctx context.Context, config v1alpha1.Casting) ([]do
 		return nil, err
 	}
 
-	var materials []domain.Material
-
-	// main.tf.json
-	mainBuf := bytes.NewBuffer(nil)
-	if err := mainTemplate.Execute(mainBuf, data); err != nil {
-		return nil, fmt.Errorf("failed to execute main.tf.json template: %w", err)
+	materials := make([]domain.Material, 0, 4)
+	for _, item := range []struct {
+		tmpl *domain.Template
+		path string
+	}{
+		{mainTemplate, "main.tf.json"},
+		{varsTemplate, "variables.tf.json"},
+		{providersTFTemplate, "providers.tf.json"},
+		{outputsTemplate, "outputs.tf.json"},
+	} {
+		m, err := item.tmpl.Render(data, filepath.Join(infrastructureDir, item.path))
+		if err != nil {
+			return nil, fmt.Errorf("failed to render %s: %w", item.path, err)
+		}
+		materials = append(materials, m)
 	}
-	mainMaterial, err := domain.NewJSONMaterial(mainBuf.Bytes(), filepath.Join(infrastructureDir, "main.tf.json"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create main.tf.json material: %w", err)
-	}
-	materials = append(materials, mainMaterial)
-
-	// variables.tf.json
-	varsBuf := bytes.NewBuffer(nil)
-	if err := varsTemplate.Execute(varsBuf, data); err != nil {
-		return nil, fmt.Errorf("failed to execute variables.tf.json template: %w", err)
-	}
-	varsMaterial, err := domain.NewJSONMaterial(varsBuf.Bytes(), filepath.Join(infrastructureDir, "variables.tf.json"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create variables.tf.json material: %w", err)
-	}
-	materials = append(materials, varsMaterial)
-
-	// providers.tf.json
-	providersBuf := bytes.NewBuffer(nil)
-	if err := providersTFTemplate.Execute(providersBuf, data); err != nil {
-		return nil, fmt.Errorf("failed to execute providers.tf.json template: %w", err)
-	}
-	providersMaterial, err := domain.NewJSONMaterial(providersBuf.Bytes(), filepath.Join(infrastructureDir, "providers.tf.json"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create providers.tf.json material: %w", err)
-	}
-	materials = append(materials, providersMaterial)
-
-	// outputs.tf.json
-	outputsBuf := bytes.NewBuffer(nil)
-	if err := outputsTemplate.Execute(outputsBuf, data); err != nil {
-		return nil, fmt.Errorf("failed to execute outputs.tf.json template: %w", err)
-	}
-	outputsMaterial, err := domain.NewJSONMaterial(outputsBuf.Bytes(), filepath.Join(infrastructureDir, "outputs.tf.json"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create outputs.tf.json material: %w", err)
-	}
-	materials = append(materials, outputsMaterial)
 
 	return materials, nil
 }


### PR DESCRIPTION
## Summary
- `Template` now carries its `Format` end-to-end. Each format declares its `Material` constructor inline (`FormatYAML = Format{s: "yaml", new: ...}`), so adding a format is one `var` entry — no switch in `Render`, no per-callsite dispatch.
- New `Template.Render(data, path) (Material, error)` replaces the `Execute` → `bytes.Buffer` → `NewXMaterial` trio duplicated across `ecsterraformcasting`, `kuberneteskustomizecasting`, `systemdcasting`, and `infrastructure/terraform/generator`. Net −165/+259, but most of the +s are the new test file.
- Errors flow through `internal/errors` (`TypeInvalidInput` / `TypeInternal` / `TypeUnsupported`) using the project's `failed to create <X> from %q: <reason>` wording, matching the recent `Material` and `Address` refactors.
- Drop `Get` prefix on accessors: `Name()`, `Path()`, `Format()`.
- `internal/domain/template_test.go` covers `Render` across every format plus the unsupported-format and invalid-output paths.