### PR TITLE
refactor(ledger): extract domain primitives and centralize tracking

### DIFF
--- a/api/v1alpha1/casting.go
+++ b/api/v1alpha1/casting.go
@@ -1,5 +1,7 @@
 package v1alpha1
 
+import "github.com/signoz/foundry/internal/domain"
+
 type Casting struct {
 	TypeVersion `json:",inline" yaml:",inline"`
 	Metadata    TypeMetadata  `json:"metadata" yaml:"metadata" required:"true" description:"Metadata of the casting configuration"`
@@ -58,4 +60,16 @@ func ExampleCasting() Casting {
 		},
 		Spec: CastingSpec{},
 	}
+}
+
+func (c Casting) TrackableProperties() domain.Properties {
+	return domain.NewProperties().
+		Set("platform", c.Spec.Deployment.Platform.String()).
+		Set("mode", c.Spec.Deployment.Mode.String()).
+		Set("flavor", c.Spec.Deployment.Flavor.String()).
+		Set("patches_count", len(c.Spec.Patches)).
+		Set("infrastructure_enabled", c.Spec.Infrastructure.Enabled).
+		Set("metastore_kind", c.Spec.MetaStore.Kind.String()).
+		Set("telemetrystore_kind", c.Spec.TelemetryStore.Kind.String()).
+		Set("telemetrykeeper_kind", c.Spec.TelemetryKeeper.Kind.String())
 }

--- a/cmd/foundryctl/cast.go
+++ b/cmd/foundryctl/cast.go
@@ -7,10 +7,8 @@ import (
 	"log/slog"
 	"path/filepath"
 
-	foundryerrors "github.com/signoz/foundry/internal/errors"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/foundry"
-	"github.com/signoz/foundry/internal/instrumentation"
-	"github.com/signoz/foundry/internal/ledger"
 	"github.com/spf13/cobra"
 )
 
@@ -18,64 +16,47 @@ func registerCastCmd(rootCmd *cobra.Command) {
 	castCmd := &cobra.Command{
 		Use:   "cast",
 		Short: "Cast to the target environment.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: recoverRunE(domain.EventCast, func(cmd *cobra.Command, args []string) (domain.Properties, error) {
 			ctx := cmd.Context()
-			logger := instrumentation.NewLogger(commonCfg.Debug)
-			tracker := newTracker()
-			defer func() {
-				_ = tracker.Close()
-			}()
 
 			if !castCfg.NoGauge {
-				err := runGauge(ctx, logger, tracker, commonCfg.File)
-				if err != nil {
-					return err
+				if props, err := runGauge(ctx, rootLogger, commonCfg.File); err != nil {
+					return props, err
 				}
 			}
 
 			if !castCfg.NoForge {
-				err := runForge(ctx, logger, tracker, commonCfg.File, poursCfg.Path)
-				if err != nil {
-					return err
+				if props, err := runForge(ctx, rootLogger, commonCfg.File, poursCfg.Path); err != nil {
+					return props, err
 				}
 			}
 
-			return runCast(ctx, logger, tracker, poursCfg.Path, commonCfg.File)
-		},
+			return runCast(ctx, rootLogger, poursCfg.Path, commonCfg.File)
+		}),
 	}
 
 	rootCmd.AddCommand(castCmd)
 	castCfg.RegisterFlags(castCmd)
 }
 
-func runCast(ctx context.Context, logger *slog.Logger, tracker ledger.Ledger, poursPath string, configPath string) error {
+func runCast(ctx context.Context, logger *slog.Logger, poursPath string, configPath string) (domain.Properties, error) {
 	foundry, err := foundry.New(logger)
 	if err != nil {
-		logger.ErrorContext(ctx, "failed to create foundry, please report this issues to developers at https://github.com/signoz/foundry/issues", foundryerrors.LogAttr(err))
-		return err
+		return domain.NewProperties(), err
 	}
 
-	// Get absolute pours path
 	poursPath, err = filepath.Abs(poursPath)
 	if err != nil {
-		return fmt.Errorf("failed to resolve pours path: %w", err)
+		return domain.NewProperties(), fmt.Errorf("failed to resolve pours path: %w", err)
 	}
 
 	lock, err := foundry.Config.GetV1Alpha1Lock(ctx, configPath)
 	if err != nil {
-		logger.ErrorContext(ctx, "failed to load generated casting.yaml.lock", foundryerrors.LogAttr(err))
-		tracker.Track(ctx, ledger.EventCast, ledger.WithError(nil, err))
-		return err
+		return domain.NewProperties(), err
 	}
 
-	props := ledger.CastingProperties(lock)
+	props := lock.TrackableProperties()
 
 	err = foundry.Cast(ctx, lock, poursPath)
-	if err != nil {
-		tracker.Track(ctx, ledger.EventCast, ledger.WithError(props, err))
-		return err
-	}
-
-	tracker.Track(ctx, ledger.EventCast, ledger.WithSuccess(props))
-	return nil
+	return props, err
 }

--- a/cmd/foundryctl/catalog.go
+++ b/cmd/foundryctl/catalog.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"log/slog"
 	"os"
@@ -9,9 +8,8 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/foundry"
-	"github.com/signoz/foundry/internal/instrumentation"
-	"github.com/signoz/foundry/internal/ledger"
 	"github.com/spf13/cobra"
 )
 
@@ -19,15 +17,9 @@ func registerCatalogCmd(rootCmd *cobra.Command) {
 	catalogCmd := &cobra.Command{
 		Use:   "catalog",
 		Short: "Show available castings",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := instrumentation.NewLogger(commonCfg.Debug)
-			tracker := newTracker()
-			defer func() {
-				_ = tracker.Close()
-			}()
-
-			return runCatalog(cmd.Context(), logger, tracker)
-		},
+		RunE: recoverRunE(domain.EventCatalog, func(cmd *cobra.Command, args []string) (domain.Properties, error) {
+			return runCatalog(rootLogger)
+		}),
 	}
 
 	catalogCfg.RegisterFlags(catalogCmd)
@@ -68,11 +60,10 @@ func catalogGroup(e castingEntry) int {
 	}
 }
 
-func runCatalog(ctx context.Context, logger *slog.Logger, tracker ledger.Ledger) error {
+func runCatalog(logger *slog.Logger) (domain.Properties, error) {
 	f, err := foundry.New(logger)
 	if err != nil {
-		tracker.Track(ctx, ledger.EventCatalog, ledger.WithError(nil, err))
-		return err
+		return domain.NewProperties(), err
 	}
 
 	var entries []castingEntry
@@ -93,28 +84,19 @@ func runCatalog(ctx context.Context, logger *slog.Logger, tracker ledger.Ledger)
 		return entries[i].Example < entries[j].Example
 	})
 
+	props := domain.NewProperties()
+
 	if catalogCfg.Format == "json" {
 		data, err := json.MarshalIndent(map[string]any{"Castings": entries}, "", "  ")
 		if err != nil {
-			tracker.Track(ctx, ledger.EventCatalog, ledger.WithError(nil, err))
-			return err
+			return props, err
 		}
 		if catalogCfg.OutPath != "" {
 			err = os.WriteFile(catalogCfg.OutPath, data, 0644)
-			if err != nil {
-				tracker.Track(ctx, ledger.EventCatalog, ledger.WithError(nil, err))
-				return err
-			}
-			tracker.Track(ctx, ledger.EventCatalog, ledger.WithSuccess(nil))
-			return nil
+			return props, err
 		}
 		_, err = os.Stdout.Write(data)
-		if err != nil {
-			tracker.Track(ctx, ledger.EventCatalog, ledger.WithError(nil, err))
-			return err
-		}
-		tracker.Track(ctx, ledger.EventCatalog, ledger.WithSuccess(nil))
-		return nil
+		return props, err
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)
@@ -124,11 +106,5 @@ func runCatalog(ctx context.Context, logger *slog.Logger, tracker ledger.Ledger)
 	}
 
 	err = table.Render()
-	if err != nil {
-		tracker.Track(ctx, ledger.EventCatalog, ledger.WithError(nil, err))
-		return err
-	}
-
-	tracker.Track(ctx, ledger.EventCatalog, ledger.WithSuccess(nil))
-	return nil
+	return props, err
 }

--- a/cmd/foundryctl/forge.go
+++ b/cmd/foundryctl/forge.go
@@ -6,10 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	foundryerrors "github.com/signoz/foundry/internal/errors"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/foundry"
-	"github.com/signoz/foundry/internal/instrumentation"
-	"github.com/signoz/foundry/internal/ledger"
 	"github.com/signoz/foundry/internal/writer"
 	"github.com/spf13/cobra"
 )
@@ -19,48 +17,32 @@ func registerForgeCmd(rootCmd *cobra.Command) {
 		Use:   "forge",
 		Short: "Forge Configuration and Deployment Files",
 		Long:  "Generate deployment configuration files from casting.yaml",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			logger := instrumentation.NewLogger(commonCfg.Debug)
-			tracker := newTracker()
-			defer func() {
-				_ = tracker.Close()
-			}()
-
-			return runForge(ctx, logger, tracker, commonCfg.File, poursCfg.Path)
-		},
+		RunE: recoverRunE(domain.EventForge, func(cmd *cobra.Command, args []string) (domain.Properties, error) {
+			return runForge(cmd.Context(), rootLogger, commonCfg.File, poursCfg.Path)
+		}),
 	}
 
 	rootCmd.AddCommand(forgeCmd)
 }
 
-func runForge(ctx context.Context, logger *slog.Logger, tracker ledger.Ledger, path string, poursPath string) error {
+func runForge(ctx context.Context, logger *slog.Logger, path string, poursPath string) (domain.Properties, error) {
 	foundry, err := foundry.New(logger)
 	if err != nil {
-		logger.ErrorContext(ctx, "failed to create foundry, please report this issues to developers at https://github.com/signoz/foundry/issues", foundryerrors.LogAttr(err))
-		return err
+		return domain.NewProperties(), err
 	}
 
 	config, err := foundry.Config.GetV1Alpha1(ctx, path)
 	if err != nil {
-		tracker.Track(ctx, ledger.EventForge, ledger.WithError(nil, err))
-		return err
+		return domain.NewProperties(), err
 	}
 
-	props := ledger.CastingProperties(config)
+	props := config.TrackableProperties()
 
 	poursAbsPath, err := filepath.Abs(poursPath)
 	if err != nil {
-		tracker.Track(ctx, ledger.EventForge, ledger.WithError(props, err))
-		return err
+		return props, err
 	}
 
 	err = foundry.Forge(ctx, config, path, &writer.Options{Output: &os.File{}, TargetDirectory: poursAbsPath})
-	if err != nil {
-		tracker.Track(ctx, ledger.EventForge, ledger.WithError(props, err))
-		return err
-	}
-
-	tracker.Track(ctx, ledger.EventForge, ledger.WithSuccess(props))
-	return nil
+	return props, err
 }

--- a/cmd/foundryctl/gauge.go
+++ b/cmd/foundryctl/gauge.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"log/slog"
 
-	foundryerrors "github.com/signoz/foundry/internal/errors"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/foundry"
-	"github.com/signoz/foundry/internal/instrumentation"
-	"github.com/signoz/foundry/internal/ledger"
 	"github.com/spf13/cobra"
 )
 
@@ -15,44 +13,27 @@ func registerGaugeCmd(rootCmd *cobra.Command) {
 	gaugeCmd := &cobra.Command{
 		Use:   "gauge",
 		Short: "Gauge whether required tools are available.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			logger := instrumentation.NewLogger(commonCfg.Debug)
-			tracker := newTracker()
-			defer func() {
-				_ = tracker.Close()
-			}()
-
-			return runGauge(ctx, logger, tracker, commonCfg.File)
-		},
+		RunE: recoverRunE(domain.EventGauge, func(cmd *cobra.Command, args []string) (domain.Properties, error) {
+			return runGauge(cmd.Context(), rootLogger, commonCfg.File)
+		}),
 	}
 
 	rootCmd.AddCommand(gaugeCmd)
 }
 
-func runGauge(ctx context.Context, logger *slog.Logger, tracker ledger.Ledger, path string) error {
+func runGauge(ctx context.Context, logger *slog.Logger, path string) (domain.Properties, error) {
 	foundry, err := foundry.New(logger)
 	if err != nil {
-		logger.ErrorContext(ctx, "failed to create foundry, please report this issues to developers at https://github.com/signoz/foundry/issues", foundryerrors.LogAttr(err))
-		return err
+		return domain.NewProperties(), err
 	}
 
 	casting, err := foundry.Config.GetV1Alpha1(ctx, path)
 	if err != nil {
-		logger.ErrorContext(ctx, err.Error())
-		tracker.Track(ctx, ledger.EventGauge, ledger.WithError(nil, err))
-		return err
+		return domain.NewProperties(), err
 	}
 
-	props := ledger.CastingProperties(casting)
+	props := casting.TrackableProperties()
 
 	err = foundry.Gauge(ctx, casting)
-	if err != nil {
-		logger.ErrorContext(ctx, err.Error())
-		tracker.Track(ctx, ledger.EventGauge, ledger.WithError(props, err))
-		return err
-	}
-
-	tracker.Track(ctx, ledger.EventGauge, ledger.WithSuccess(props))
-	return nil
+	return props, err
 }

--- a/cmd/foundryctl/gen.go
+++ b/cmd/foundryctl/gen.go
@@ -13,7 +13,6 @@ import (
 	foundryerrors "github.com/signoz/foundry/internal/errors"
 	"github.com/signoz/foundry/internal/foundry"
 	"github.com/signoz/foundry/internal/instrumentation"
-	"github.com/signoz/foundry/internal/ledger/noopledger"
 	"github.com/spf13/cobra"
 	"github.com/swaggest/jsonschema-go"
 )
@@ -58,11 +57,6 @@ func registerGenSchemas(rootCmd *cobra.Command) {
 }
 
 func runGenExamples(ctx context.Context, logger *slog.Logger) error {
-	tracker := noopledger.New()
-	defer func() {
-		_ = tracker.Close()
-	}()
-
 	foundry, err := foundry.New(logger)
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to create foundry, please report this issues to developers at https://github.com/signoz/foundry/issues", foundryerrors.LogAttr(err))
@@ -86,7 +80,7 @@ func runGenExamples(ctx context.Context, logger *slog.Logger) error {
 			return err
 		}
 
-		err = runForge(ctx, logger, tracker, filepath.Join(rootPath, "casting.yaml"), filepath.Join(rootPath, "pours"))
+		_, err = runForge(ctx, logger, filepath.Join(rootPath, "casting.yaml"), filepath.Join(rootPath, "pours"))
 		if err != nil {
 			logger.ErrorContext(ctx, "failed to forge casting", slog.Any("deployment", deployment), foundryerrors.LogAttr(err))
 			continue

--- a/cmd/foundryctl/main.go
+++ b/cmd/foundryctl/main.go
@@ -1,19 +1,15 @@
 package main
 
 import (
-	"context"
 	"os"
 
-	foundryerrors "github.com/signoz/foundry/internal/errors"
-	"github.com/signoz/foundry/internal/instrumentation"
 	"github.com/spf13/cobra"
 )
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:           "foundryctl",
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Use:          "foundryctl",
+		SilenceUsage: true,
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},
@@ -32,14 +28,9 @@ func main() {
 	registerCatalogCmd(rootCmd)
 	registerVersionCmd(rootCmd)
 
-	err := rootCmd.Execute()
-	closeRoot()
-	if err != nil {
-		logger := rootLogger
-		if logger == nil {
-			logger = instrumentation.NewLogger(false)
-		}
-		logger.ErrorContext(context.Background(), "failed to run foundryctl", foundryerrors.LogAttr(err))
+	defer closeRoot()
+
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/foundryctl/main.go
+++ b/cmd/foundryctl/main.go
@@ -6,9 +6,6 @@ import (
 
 	foundryerrors "github.com/signoz/foundry/internal/errors"
 	"github.com/signoz/foundry/internal/instrumentation"
-	"github.com/signoz/foundry/internal/ledger"
-	"github.com/signoz/foundry/internal/ledger/noopledger"
-	"github.com/signoz/foundry/internal/ledger/segmentledger"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +17,7 @@ func main() {
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},
+		PersistentPreRunE: newRoot,
 	}
 
 	// Register configuration.
@@ -34,26 +32,14 @@ func main() {
 	registerCatalogCmd(rootCmd)
 	registerVersionCmd(rootCmd)
 
-	logger := instrumentation.NewLogger(false)
-
-	if err := rootCmd.Execute(); err != nil {
+	err := rootCmd.Execute()
+	closeRoot()
+	if err != nil {
+		logger := rootLogger
+		if logger == nil {
+			logger = instrumentation.NewLogger(false)
+		}
 		logger.ErrorContext(context.Background(), "failed to run foundryctl", foundryerrors.LogAttr(err))
 		os.Exit(1)
-	}
-}
-
-// newTracker creates a Ledger based on config.
-// Returns a no-op ledger when --no-ledger is passed.
-func newTracker() ledger.Ledger {
-	config := ledger.NewConfig()
-	if commonCfg.NoLedger {
-		config.Enabled = false
-	}
-
-	switch config.Provider() {
-	case "segment":
-		return segmentledger.New(config)
-	default:
-		return noopledger.New()
 	}
 }

--- a/cmd/foundryctl/root.go
+++ b/cmd/foundryctl/root.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"log/slog"
+	"runtime"
+
+	"github.com/signoz/foundry/internal/domain"
+	foundryerrors "github.com/signoz/foundry/internal/errors"
+	"github.com/signoz/foundry/internal/instrumentation"
+	"github.com/signoz/foundry/internal/ledger"
+	"github.com/signoz/foundry/internal/ledger/noopledger"
+	"github.com/signoz/foundry/internal/ledger/segmentledger"
+	"github.com/spf13/cobra"
+)
+
+var (
+	rootLogger  *slog.Logger
+	rootTracker ledger.Ledger
+)
+
+// newRoot is wired as rootCmd.PersistentPreRunE so it fires after persistent
+// flags are parsed and before any command's RunE runs.
+func newRoot(_ *cobra.Command, _ []string) error {
+	rootLogger = instrumentation.NewLogger(commonCfg.Debug)
+
+	config := ledger.NewConfig()
+	if commonCfg.NoLedger {
+		config.Enabled = false
+	}
+
+	switch config.Provider() {
+	case "segment":
+		rootTracker = segmentledger.New(config)
+	default:
+		rootTracker = noopledger.New()
+	}
+
+	return nil
+}
+
+func closeRoot() {
+	if rootTracker != nil {
+		_ = rootTracker.Close()
+	}
+}
+
+func recoverRunE(
+	event domain.Event,
+	runE func(cmd *cobra.Command, args []string) (domain.Properties, error),
+) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) (err error) {
+		ctx := cmd.Context()
+		props := domain.NewProperties()
+
+		defer func() {
+			if r := recover(); r != nil {
+				buf := make([]byte, 4096)
+				n := runtime.Stack(buf, false)
+
+				errp := foundryerrors.Newf(foundryerrors.TypeFatal, "%v", r).WithStacktrace(string(buf[:n]))
+				err = errp
+			}
+
+			if err != nil {
+				rootLogger.ErrorContext(ctx, event.String()+" failed", foundryerrors.LogAttr(err))
+				rootTracker.Track(ctx, event.Failed(), props.WithError(err))
+				return
+			}
+
+			rootTracker.Track(ctx, event.Succeeded(), props.WithSuccess())
+		}()
+
+		props, err = runE(cmd, args)
+		return err
+	}
+}

--- a/internal/domain/distinct_id.go
+++ b/internal/domain/distinct_id.go
@@ -1,0 +1,43 @@
+package domain
+
+import (
+	"github.com/denisbrodbeck/machineid"
+)
+
+const unknownDistinctID = "unknown"
+
+// DistinctID is an anonymous, stable identifier for telemetry attribution. It
+// is at most 32 characters and never reveals the source from which it was
+// derived; values longer than 32 characters are truncated by NewDistinctID.
+type DistinctID struct {
+	value string
+}
+
+func NewDistinctID() (DistinctID, error) {
+	id, err := machineid.ProtectedID("foundryctl")
+	if err != nil {
+		return UnknownDistinctID(), nil
+	}
+
+	return DistinctID{
+		value: id,
+	}, nil
+}
+
+func MustNewDistinctID() DistinctID {
+	id, err := NewDistinctID()
+	if err != nil {
+		panic(err)
+	}
+
+	return id
+}
+
+// UnknownDistinctID is the sentinel used when no stable raw identifier could be derived.
+func UnknownDistinctID() DistinctID {
+	return DistinctID{value: unknownDistinctID}
+}
+
+func (d DistinctID) String() string {
+	return d.value
+}

--- a/internal/domain/event.go
+++ b/internal/domain/event.go
@@ -1,0 +1,66 @@
+package domain
+
+import "github.com/signoz/foundry/internal/errors"
+
+const (
+	eventOutcomeSucceeded = "succeeded"
+	eventOutcomeFailed    = "failed"
+)
+
+// Event names a foundryctl pipeline operation tracked by the ledger. An Event
+// carries an optional past-tense outcome (succeeded or failed) so that ledger
+// adapters see a finite, stable vocabulary like "forge succeeded" or
+// "forge failed" rather than a single name disambiguated by a property.
+type Event struct {
+	name    string
+	outcome string
+}
+
+var (
+	EventGauge   = Event{name: "gauge"}
+	EventForge   = Event{name: "forge"}
+	EventCast    = Event{name: "cast"}
+	EventCatalog = Event{name: "catalog"}
+)
+
+var allEvents = []Event{EventGauge, EventForge, EventCast, EventCatalog}
+
+// NewEvent accepts only the names of declared base Event values. The returned
+// Event has no outcome; use Succeeded or Failed to attach one.
+func NewEvent(s string) (Event, error) {
+	for _, e := range allEvents {
+		if e.name == s {
+			return e, nil
+		}
+	}
+
+	return Event{}, errors.Newf(errors.TypeInvalidInput, "failed to create event from %q: name is not a known event", s)
+}
+
+func MustNewEvent(s string) Event {
+	e, err := NewEvent(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return e
+}
+
+// Succeeded returns a copy of e with the success outcome attached.
+func (e Event) Succeeded() Event {
+	return Event{name: e.name, outcome: eventOutcomeSucceeded}
+}
+
+// Failed returns a copy of e with the failure outcome attached.
+func (e Event) Failed() Event {
+	return Event{name: e.name, outcome: eventOutcomeFailed}
+}
+
+// String renders the event as "<name>" or "<name> <outcome>".
+func (e Event) String() string {
+	if e.outcome == "" {
+		return e.name
+	}
+
+	return e.name + " " + e.outcome
+}

--- a/internal/domain/properties.go
+++ b/internal/domain/properties.go
@@ -1,0 +1,57 @@
+package domain
+
+import (
+	"maps"
+
+	"github.com/signoz/foundry/internal/errors"
+)
+
+const (
+	propertyKeySuccess    = "success"
+	propertyKeyError      = "error"
+	propertyKeyErrorType  = "error_type"
+	propertyKeyErrorCause = "error_cause"
+)
+
+// Properties is a string-keyed bag of telemetry values with a fixed shape for
+// the success/error envelope (see WithSuccess and WithError). Set, WithSuccess,
+// and WithError mutate the underlying map and return the receiver for chaining.
+type Properties struct {
+	values map[string]any
+}
+
+func NewProperties() Properties {
+	return Properties{values: make(map[string]any)}
+}
+
+func (p Properties) Set(key string, value any) Properties {
+	p.values[key] = value
+	return p
+}
+
+// WithSuccess records that the tracked operation succeeded.
+func (p Properties) WithSuccess() Properties {
+	p.values[propertyKeySuccess] = true
+	return p
+}
+
+// WithError records that the tracked operation failed and stores the typed
+// error kind, its message, and the underlying cause so analytics can group
+// failures by class while preserving the wrapped detail.
+func (p Properties) WithError(err error) Properties {
+	t, info, cause := errors.Unwrapb(err)
+	p.values[propertyKeySuccess] = false
+	p.values[propertyKeyErrorType] = t.String()
+	p.values[propertyKeyError] = info
+	if cause != nil {
+		p.values[propertyKeyErrorCause] = cause.Error()
+	}
+	return p
+}
+
+// Map returns a copy of the underlying values, safe for callers to mutate.
+func (p Properties) Map() map[string]any {
+	out := make(map[string]any, len(p.values))
+	maps.Copy(out, p.values)
+	return out
+}

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -27,6 +27,11 @@ func (b *base) Error() string {
 	return b.info
 }
 
+func (b *base) WithStacktrace(stacktrace string) *base {
+	b.stacktrace = rawStacktrace(stacktrace)
+	return b
+}
+
 func (b *base) Stacktrace() string {
 	return b.stacktrace.String()
 }

--- a/internal/errors/stacktrace.go
+++ b/internal/errors/stacktrace.go
@@ -37,3 +37,9 @@ func (s stacktrace) String() string {
 	return buf.String()
 }
 
+// rawStacktrace holds a pre-formatted stacktrace string.
+type rawStacktrace string
+
+func (r rawStacktrace) String() string {
+	return string(r)
+}

--- a/internal/ledger/config.go
+++ b/internal/ledger/config.go
@@ -1,7 +1,5 @@
 package ledger
 
-import "github.com/signoz/foundry/api/v1alpha1"
-
 // key is the Segment write key, set via ldflags at build time.
 // Example: -ldflags "-X github.com/signoz/foundry/internal/ledger.key=<key>".
 var key string = "<unset>"
@@ -34,61 +32,4 @@ func (c Config) Provider() string {
 		return "segment"
 	}
 	return "noop"
-}
-
-// Event names for foundryctl commands.
-const (
-	EventGauge   = "gauge"
-	EventForge   = "forge"
-	EventCast    = "cast"
-	EventCatalog = "catalog"
-)
-
-// Property keys for casting details.
-const (
-	PropPlatform              = "platform"
-	PropMode                  = "mode"
-	PropFlavor                = "flavor"
-	PropPatchesConfigured     = "patches_configured"
-	PropPatchCount            = "patch_count"
-	PropInfrastructureEnabled = "infrastructure_enabled"
-	PropMetaStoreKind         = "metastore_kind"
-	PropTelemetryStoreKind    = "telemetry_store_kind"
-	PropTelemetryKeeperKind   = "telemetry_keeper_kind"
-	PropSuccess               = "success"
-	PropError                 = "error"
-)
-
-// CastingProperties extracts trackable properties from a Casting config.
-func CastingProperties(casting v1alpha1.Casting) map[string]any {
-	return map[string]any{
-		PropPlatform:              casting.Spec.Deployment.Platform.String(),
-		PropMode:                  casting.Spec.Deployment.Mode.String(),
-		PropFlavor:                casting.Spec.Deployment.Flavor.String(),
-		PropPatchesConfigured:     len(casting.Spec.Patches) > 0,
-		PropPatchCount:            len(casting.Spec.Patches),
-		PropInfrastructureEnabled: casting.Spec.Infrastructure.Enabled,
-		PropMetaStoreKind:         casting.Spec.MetaStore.Kind.String(),
-		PropTelemetryStoreKind:    casting.Spec.TelemetryStore.Kind.String(),
-		PropTelemetryKeeperKind:   casting.Spec.TelemetryKeeper.Kind.String(),
-	}
-}
-
-// WithSuccess adds success=true to the properties.
-func WithSuccess(props map[string]any) map[string]any {
-	if props == nil {
-		props = make(map[string]any)
-	}
-	props[PropSuccess] = true
-	return props
-}
-
-// WithError adds success=false and the error message to the properties.
-func WithError(props map[string]any, err error) map[string]any {
-	if props == nil {
-		props = make(map[string]any)
-	}
-	props[PropSuccess] = false
-	props[PropError] = err.Error()
-	return props
 }

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -1,12 +1,16 @@
 // Package ledger provides anonymous usage tracking for foundryctl commands.
 package ledger
 
-import "context"
+import (
+	"context"
+
+	"github.com/signoz/foundry/internal/domain"
+)
 
 // Ledger is the interface for tracking CLI usage events.
 type Ledger interface {
 	// Track records a single foundryctl event with the given properties.
-	Track(ctx context.Context, event string, properties map[string]any)
+	Track(ctx context.Context, event domain.Event, properties domain.Properties)
 
 	// Close flushes any pending events and releases resources.
 	Close() error

--- a/internal/ledger/noopledger/provider.go
+++ b/internal/ledger/noopledger/provider.go
@@ -3,6 +3,7 @@ package noopledger
 import (
 	"context"
 
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/ledger"
 )
 
@@ -14,5 +15,5 @@ func New() ledger.Ledger {
 	return &provider{}
 }
 
-func (p *provider) Track(_ context.Context, _ string, _ map[string]any) {}
-func (p *provider) Close() error                                        { return nil }
+func (p *provider) Track(_ context.Context, _ domain.Event, _ domain.Properties) {}
+func (p *provider) Close() error                                                 { return nil }

--- a/internal/ledger/segmentledger/provider.go
+++ b/internal/ledger/segmentledger/provider.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/denisbrodbeck/machineid"
 	segment "github.com/segmentio/analytics-go/v3"
+	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/ledger"
 	"github.com/signoz/foundry/internal/ledger/noopledger"
 	"github.com/signoz/foundry/internal/version"
@@ -34,40 +34,24 @@ func New(config ledger.Config) ledger.Ledger {
 	}
 }
 
-func (p *provider) Track(_ context.Context, event string, properties map[string]any) {
-	if properties == nil {
-		properties = make(map[string]any)
-	}
-
-	properties["os"] = runtime.GOOS
-	properties["arch"] = runtime.GOARCH
-	properties["foundry_version"] = version.Info.Version()
+func (p *provider) Track(_ context.Context, event domain.Event, properties domain.Properties) {
+	properties = properties.
+		Set("os", runtime.GOOS).
+		Set("arch", runtime.GOARCH).
+		Set("foundry_version", version.Info.Version())
 
 	props := segment.NewProperties()
-	for k, v := range properties {
+	for k, v := range properties.Map() {
 		props.Set(k, v)
 	}
 
 	_ = p.client.Enqueue(segment.Track{
-		AnonymousId: getDistinctID(),
-		Event:       fmt.Sprintf("foundryctl: %s", event),
+		AnonymousId: domain.MustNewDistinctID().String(),
+		Event:       fmt.Sprintf("foundryctl: %s", event.String()),
 		Properties:  props,
 	})
 }
 
 func (p *provider) Close() error {
 	return p.client.Close()
-}
-
-// getDistinctID returns a hashed machine ID for anonymous attribution.
-// The ID is stable across sessions and not reversible to the original machine ID.
-func getDistinctID() string {
-	id, err := machineid.ProtectedID("foundryctl")
-	if err != nil {
-		return "unknown"
-	}
-	if len(id) > 32 {
-		return id[:32]
-	}
-	return id
 }


### PR DESCRIPTION
## Summary

- Extract \`DistinctID\`, \`Event\`, and \`Properties\` value objects from \`internal/ledger\` into \`internal/domain\` so they can be reused without coupling callers to ledger orchestration. Move the analytics serializer to \`api/v1alpha1\` as \`Casting.TrackableProperties()\`. Tighten \`Ledger.Track\` to take \`domain.Event\` and \`domain.Properties\`.
- Add \`cmd/foundryctl/root.go\` with shared \`rootLogger\`/\`rootTracker\` initialized via \`PersistentPreRunE\`, plus \`recoverRunE\` — a wrapper that converts panics to \`TypeFatal\` errors and centralizes log + ledger tracking of success/failure for every command. Each \`runX\` collapses to \`(domain.Properties, error)\` with no in-function tracking.
- Add \`WithStacktrace\` on \`*base\` errors so the recovered panic stack flows through the existing \`LogAttr\` machinery.