### PR TITLE
fix(foundryctl): metastore support for sqlite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CASTINGS_JSON = $$(cat docs/examples/castings.json)
 NO_LEDGER	:= "--no-ledger"
 
 clean:
-	cd pours/deployment && docker compose -p dev down --remove-orphans --volumes
+	cd pours/deployment && docker compose down --remove-orphans --volumes
 	cd ../..
 	rm -rf ./pours
 

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -178,7 +178,7 @@ services:
       - CMD-SHELL
       - pg_isready -U signoz -d signoz
       timeout: 5s
-    image: docker.io/postgres:16
+    image: postgres:16
     logging:
       options:
         max-file: "3"

--- a/docs/examples/docker/compose/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose/pours/deployment/compose.yaml
@@ -41,7 +41,7 @@ services:
       - CMD-SHELL
       - pg_isready -U signoz -d signoz
       timeout: 10s
-    image: docker.io/postgres:16
+    image: postgres:16
     networks:
     - signoz-network
     volumes:

--- a/docs/examples/docker/compose/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose/pours/deployment/compose.yaml
@@ -45,7 +45,7 @@ services:
     networks:
     - signoz-network
     volumes:
-    - signoz-metastore-0-data:/var/lib/postgresql/data
+    - signoz-metastore-postgres-0-data:/var/lib/postgresql/data
   signoz-signoz:
     container_name: signoz-signoz
     deploy:
@@ -163,8 +163,8 @@ services:
     networks:
     - signoz-network
 volumes:
-  signoz-metastore-0-data:
-    name: signoz-metastore-0-data
+  signoz-metastore-postgres-0-data:
+    name: signoz-metastore-postgres-0-data
   signoz-telemetrykeeper-0-data:
     name: signoz-telemetrykeeper-0-data
   signoz-telemetrystore-0-0-data:

--- a/docs/examples/docker/swarm/pours/deployment/compose.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/compose.yaml
@@ -53,7 +53,7 @@ services:
       - CMD-SHELL
       - pg_isready -U signoz -d signoz
       timeout: 10s
-    image: docker.io/postgres:16
+    image: postgres:16
     networks:
     - signoz-network
     volumes:

--- a/docs/examples/docker/swarm/pours/deployment/compose.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/compose.yaml
@@ -57,7 +57,7 @@ services:
     networks:
     - signoz-network
     volumes:
-    - signoz-metastore-0-data:/var/lib/postgresql/data
+    - signoz-metastore-postgres-0-data:/var/lib/postgresql/data
   signoz-signoz:
     deploy:
       replicas: 1
@@ -188,7 +188,7 @@ services:
     - signoz-network
 version: "3"
 volumes:
-  signoz-metastore-0-data: null
+  signoz-metastore-postgres-0-data: null
   signoz-telemetrykeeper-0-data: null
   signoz-telemetrystore-0-0-data: null
   signoz-telemetrystore-user-scripts: null

--- a/internal/casting/coolifycasting/enricher.go
+++ b/internal/casting/coolifycasting/enricher.go
@@ -82,6 +82,10 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		config.Spec.TelemetryKeeper.Status.Addresses.Raft = telemetryRaftaddress
 
 	case v1alpha1.MoldingKindMetaStore:
+		// Skip molding enrichment if sqlite
+		if config.Spec.MetaStore.Kind == v1alpha1.MetaStoreKindSQLite {
+			return nil
+		}
 		containerNames, err := enricher.material.GetStringSlice("services|@keys")
 		if err != nil {
 			return fmt.Errorf("failed to get metastore container names: %w", err)

--- a/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
+++ b/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
@@ -111,6 +111,7 @@ services:
         max-file: "3"
   {{- end }}
   {{- end }}
+  {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}:
     image: docker.io/{{ $.Spec.MetaStore.Kind }}:{{ $.Spec.MetaStore.Spec.Version }}
@@ -134,13 +135,16 @@ services:
         max-size: 50m
         max-file: "3"
   {{- end }}
+  {{- end }}
   {{ $.Metadata.Name }}-signoz:
     container_name: {{ $.Metadata.Name }}-signoz
     image: {{ $.Spec.Signoz.Spec.Image }}
     depends_on:
+      {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
       {{- range $metaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
       {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $metaIdx }}:
         condition: service_healthy
+      {{- end }}
       {{- end }}
       {{- range $shardIdx := $.Spec.TelemetryStore.Spec.Cluster.Shards }}
       {{- range $storeReplicaIdx := add $.Spec.TelemetryStore.Spec.Cluster.Replicas 1 }}
@@ -260,9 +264,11 @@ volumes:
   {{- end }}
   {{ $.Metadata.Name }}-telemetrystore-user-scripts:
     name: {{ $.Metadata.Name }}-telemetrystore-user-scripts
+  {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data:
     name: {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data
+  {{- end }}
   {{- end }}
   {{ $.Metadata.Name }}-signoz-data:
     name: {{ $.Metadata.Name }}-signoz-data

--- a/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
+++ b/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
@@ -114,7 +114,7 @@ services:
   {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}:
-    image: docker.io/{{ $.Spec.MetaStore.Kind }}:{{ $.Spec.MetaStore.Spec.Version }}
+    image: {{ $.Spec.MetaStore.Spec.Image }}
     environment:
       - POSTGRES_USER=signoz
       - POSTGRES_PASSWORD=signoz

--- a/internal/casting/dockercomposecasting/enricher.go
+++ b/internal/casting/dockercomposecasting/enricher.go
@@ -89,6 +89,10 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		config.Spec.TelemetryKeeper.Status.Addresses.Raft = telemetryRaftaddress
 
 	case v1alpha1.MoldingKindMetaStore:
+		// Skip molding enrichment if sqlite
+		if config.Spec.MetaStore.Kind == v1alpha1.MetaStoreKindSQLite {
+			return nil
+		}
 		// Get metastore container names
 		containerNames, err := enricher.material.GetStringSlice("services|@keys")
 		if err != nil {

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -95,7 +95,7 @@ services:
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}:
     container_name: {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}
-    image: docker.io/{{ $.Spec.MetaStore.Kind }}:{{ $.Spec.MetaStore.Spec.Version }}
+    image: {{ $.Spec.MetaStore.Spec.Image }}
     networks:
       - {{ $.Metadata.Name }}-network
     {{- if $.Spec.MetaStore.Spec.Env }}

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -105,7 +105,7 @@ services:
       {{- end }}
     {{- end }}
     volumes:
-      - {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data:/var/lib/postgresql/data
+      - {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data:/var/lib/postgresql/data
     healthcheck:
       test:
       - "CMD-SHELL"
@@ -162,7 +162,7 @@ services:
       - "8080:8080"
     {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
     volumes:
-      - {{ $.Metadata.Name }}-metastore-data:{{ dir (index $.Spec.Signoz.Spec.Env "SIGNOZ_SQLSTORE_SQLITE_PATH") }}
+      - {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-data:{{ dir (index $.Spec.Signoz.Spec.Env "SIGNOZ_SQLSTORE_SQLITE_PATH") }}
     {{- end }}
     healthcheck:
       test:
@@ -219,11 +219,11 @@ volumes:
     name: {{ $.Metadata.Name }}-telemetrystore-user-scripts
   {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
-  {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data:
-    name: {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data
+  {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data:
+    name: {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data
   {{- end }}
   {{- end }}
   {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
-  {{ $.Metadata.Name }}-metastore-data:
-    name: {{ $.Metadata.Name }}-metastore-data
+  {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-data:
+    name: {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-data
   {{- end }}

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -91,6 +91,7 @@ services:
       wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F$${version}/histogram-quantile_$${node_os}_$${node_arch}.tar.gz"
       tar -xvzf histogram-quantile.tar.gz
       mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
+  {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}:
     container_name: {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}
@@ -113,6 +114,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+  {{- end }}
   {{- end }}
   {{ $.Metadata.Name }}-ingester:
     container_name: {{ $.Metadata.Name }}-ingester
@@ -158,6 +160,10 @@ services:
     {{- end }}
     ports:
       - "8080:8080"
+    {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
+    volumes:
+      - {{ $.Metadata.Name }}-signoz-sqlite-data:/var/lib/signoz
+    {{- end }}
     healthcheck:
       test:
       - "CMD"
@@ -211,7 +217,13 @@ volumes:
   {{- end }}
   {{ $.Metadata.Name }}-telemetrystore-user-scripts:
     name: {{ $.Metadata.Name }}-telemetrystore-user-scripts
+  {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data:
     name: {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data
+  {{- end }}
+  {{- end }}
+  {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
+  {{ $.Metadata.Name }}-signoz-sqlite-data:
+    name: {{ $.Metadata.Name }}-signoz-sqlite-data
   {{- end }}

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -162,7 +162,7 @@ services:
       - "8080:8080"
     {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
     volumes:
-      - {{ $.Metadata.Name }}-metastore-data:/var/lib/signoz
+      - {{ $.Metadata.Name }}-metastore-data:{{ dir (index $.Spec.Signoz.Spec.Env "SIGNOZ_SQLSTORE_SQLITE_PATH") }}
     {{- end }}
     healthcheck:
       test:

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -162,7 +162,7 @@ services:
       - "8080:8080"
     {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
     volumes:
-      - {{ $.Metadata.Name }}-signoz-sqlite-data:/var/lib/signoz
+      - {{ $.Metadata.Name }}-metastore-data:/var/lib/signoz
     {{- end }}
     healthcheck:
       test:
@@ -224,6 +224,6 @@ volumes:
   {{- end }}
   {{- end }}
   {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
-  {{ $.Metadata.Name }}-signoz-sqlite-data:
-    name: {{ $.Metadata.Name }}-signoz-sqlite-data
+  {{ $.Metadata.Name }}-metastore-data:
+    name: {{ $.Metadata.Name }}-metastore-data
   {{- end }}

--- a/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
@@ -111,7 +111,7 @@ services:
       {{- end }}
     {{- end }}
     volumes:
-      - {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data:/var/lib/postgresql/data
+      - {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data:/var/lib/postgresql/data
     deploy:
       restart_policy:
         condition: on-failure
@@ -167,7 +167,7 @@ services:
       - "8080:8080"
     {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
     volumes:
-      - {{ $.Metadata.Name }}-metastore-data:{{ dir (index $.Spec.Signoz.Spec.Env "SIGNOZ_SQLSTORE_SQLITE_PATH") }}
+      - {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-data:{{ dir (index $.Spec.Signoz.Spec.Env "SIGNOZ_SQLSTORE_SQLITE_PATH") }}
     {{- end }}
     deploy:
       replicas: {{ int $.Spec.Signoz.Spec.Cluster.Replicas }}
@@ -228,11 +228,11 @@ volumes:
   {{ $.Metadata.Name }}-telemetrystore-user-scripts:
   {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
-  {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data:
+  {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data:
   {{- end }}
   {{- end }}
   {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
-  {{ $.Metadata.Name }}-metastore-data:
+  {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-data:
   {{- end }}
 configs:
   {{- range $replicaIdx := until (int $.Spec.TelemetryKeeper.Spec.Cluster.Replicas) }}

--- a/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
@@ -101,7 +101,7 @@ services:
   {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}:
-    image: docker.io/{{ $.Spec.MetaStore.Kind }}:{{ $.Spec.MetaStore.Spec.Version }}
+    image: {{ $.Spec.MetaStore.Spec.Image }}
     networks:
       - {{ $.Metadata.Name }}-network
     {{- if $.Spec.MetaStore.Spec.Env }}

--- a/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
@@ -98,6 +98,7 @@ services:
       mode: global
       restart_policy:
         condition: none
+  {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}:
     image: docker.io/{{ $.Spec.MetaStore.Kind }}:{{ $.Spec.MetaStore.Spec.Version }}
@@ -122,6 +123,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+  {{- end }}
   {{- end }}
   {{ $.Metadata.Name }}-ingester:
     image: {{ $.Spec.Ingester.Spec.Image }}
@@ -163,6 +165,10 @@ services:
     {{- end }}
     ports:
       - "8080:8080"
+    {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
+    volumes:
+      - {{ $.Metadata.Name }}-metastore-data:/var/lib/signoz
+    {{- end }}
     deploy:
       replicas: {{ int $.Spec.Signoz.Spec.Cluster.Replicas }}
       restart_policy:
@@ -220,8 +226,13 @@ volumes:
   {{- end }}
   {{- end }}
   {{ $.Metadata.Name }}-telemetrystore-user-scripts:
+  {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data:
+  {{- end }}
+  {{- end }}
+  {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
+  {{ $.Metadata.Name }}-metastore-data:
   {{- end }}
 configs:
   {{- range $replicaIdx := until (int $.Spec.TelemetryKeeper.Spec.Cluster.Replicas) }}

--- a/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
@@ -167,7 +167,7 @@ services:
       - "8080:8080"
     {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
     volumes:
-      - {{ $.Metadata.Name }}-metastore-data:/var/lib/signoz
+      - {{ $.Metadata.Name }}-metastore-data:{{ dir (index $.Spec.Signoz.Spec.Env "SIGNOZ_SQLSTORE_SQLITE_PATH") }}
     {{- end }}
     deploy:
       replicas: {{ int $.Spec.Signoz.Spec.Cluster.Replicas }}

--- a/internal/molding/signozmolding/signoz.go
+++ b/internal/molding/signozmolding/signoz.go
@@ -50,7 +50,12 @@ func (molding *signoz) MoldV1Alpha1(ctx context.Context, config *v1alpha1.Castin
 
 	switch config.Spec.MetaStore.Kind {
 	case v1alpha1.MetaStoreKindSQLite:
-		config.Spec.Signoz.Status.Env["SIGNOZ_SQLSTORE_SQLITE_PATH"] = "/var/lib/signoz/signoz.db"
+		sqliteDir := "/var/lib/signoz"
+		if userDir, ok := config.Spec.Signoz.Spec.Env["SIGNOZ_SQLSTORE_SQLITE_PATH"]; ok && userDir != "" {
+			sqliteDir = strings.TrimRight(userDir, "/")
+			delete(config.Spec.Signoz.Spec.Env, "SIGNOZ_SQLSTORE_SQLITE_PATH")
+		}
+		config.Spec.Signoz.Status.Env["SIGNOZ_SQLSTORE_SQLITE_PATH"] = fmt.Sprintf("%s/signoz.db", sqliteDir)
 	case v1alpha1.MetaStoreKindPostgres:
 		if config.Spec.MetaStore.Status.Addresses.DSN != nil {
 			if val, ok := config.Spec.Signoz.Spec.Env["SIGNOZ_SQLSTORE_POSTGRES_DSN"]; ok {

--- a/internal/molding/signozmolding/signoz.go
+++ b/internal/molding/signozmolding/signoz.go
@@ -50,12 +50,7 @@ func (molding *signoz) MoldV1Alpha1(ctx context.Context, config *v1alpha1.Castin
 
 	switch config.Spec.MetaStore.Kind {
 	case v1alpha1.MetaStoreKindSQLite:
-		sqliteDir := "/var/lib/signoz"
-		if userDir, ok := config.Spec.Signoz.Spec.Env["SIGNOZ_SQLSTORE_SQLITE_PATH"]; ok && userDir != "" {
-			sqliteDir = strings.TrimRight(userDir, "/")
-			delete(config.Spec.Signoz.Spec.Env, "SIGNOZ_SQLSTORE_SQLITE_PATH")
-		}
-		config.Spec.Signoz.Status.Env["SIGNOZ_SQLSTORE_SQLITE_PATH"] = fmt.Sprintf("%s/signoz.db", sqliteDir)
+		config.Spec.Signoz.Status.Env["SIGNOZ_SQLSTORE_SQLITE_PATH"] = "/var/lib/signoz/signoz.db"
 	case v1alpha1.MetaStoreKindPostgres:
 		if config.Spec.MetaStore.Status.Addresses.DSN != nil {
 			if val, ok := config.Spec.Signoz.Spec.Env["SIGNOZ_SQLSTORE_POSTGRES_DSN"]; ok {


### PR DESCRIPTION
#### Fixes
- MetaStore volumes now have a postfix for the technology being used
- Default to postgres if not defined in casting
    - Renders the proper block and volume for postgres when not defined
    - Image comes from spec vs hardcoding `docker.io`
- Include support for sqlite
    - Renders the right env vars and path for sqlite
    - Omits volumes and services for postgres as they are mutually excluded
    - Uses env vars for custom locations of sqlite if needed
