### PR TITLE
fix: templated signoz and ingester services with replicaIdx suffix

### DIFF
--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -146,7 +146,7 @@ spec:
                   exporters:
                     - signozclickhousemeter
           opamp.yaml: |
-            server_endpoint: ws://signoz-signoz:4320/v1/opamp
+            server_endpoint: ws://signoz-signoz-0:4320/v1/opamp
       enabled: true
       env:
         SIGNOZ_OTEL_COLLECTOR_TIMEOUT: 10m
@@ -155,7 +155,7 @@ spec:
     status:
       addresses:
         otlp:
-        - tcp://signoz-ingester:4318
+        - tcp://signoz-ingester-0:4318
       config:
         data:
           ingester.yaml: |
@@ -292,7 +292,7 @@ spec:
                   exporters:
                     - signozclickhousemeter
           opamp.yaml: |
-            server_endpoint: ws://signoz-signoz:4320/v1/opamp
+            server_endpoint: ws://signoz-signoz-0:4320/v1/opamp
       env:
         SIGNOZ_OTEL_COLLECTOR_TIMEOUT: 10m
   metastore:
@@ -333,9 +333,9 @@ spec:
     status:
       addresses:
         apiserver:
-        - tcp://signoz-signoz:8080
+        - tcp://signoz-signoz-0:8080
         opamp:
-        - ws://signoz-signoz:4320
+        - ws://signoz-signoz-0:4320
       config: {}
       env:
         SIGNOZ_SQLSTORE_POSTGRES_DSN: postgres://signoz:signoz@signoz-metastore-postgres-0:5432/signoz?sslmode=disable

--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -155,7 +155,8 @@ spec:
     status:
       addresses:
         otlp:
-        - tcp://signoz-ingester-0:4318
+        - tcp://signoz-ingester:4318
+        - tcp://signoz-ingester:4317
       config:
         data:
           ingester.yaml: |

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -1,11 +1,10 @@
 services:
-  signoz-ingester-0:
+  ingester:
     command:
     - -c
     - |
       /signoz-otel-collector migrate sync check &&
       /signoz-otel-collector --config=/etc/otel-collector-config.yaml --manager-config=/etc/opamp-config.yaml --copy-path=/var/tmp/collector-config.yaml
-    container_name: signoz-ingester-0
     depends_on:
       signoz-signoz-0:
         condition: service_started
@@ -13,6 +12,8 @@ services:
         condition: service_healthy
       signoz-telemetrystore-migrator:
         condition: service_completed_successfully
+    deploy:
+      replicas: 1
     entrypoint:
     - /bin/sh
     environment:
@@ -24,6 +25,10 @@ services:
       options:
         max-file: "3"
         max-size: 50m
+    networks:
+      default:
+        aliases:
+        - signoz-ingester
     volumes:
     - content: |
         connectors:

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -1,13 +1,13 @@
 services:
-  signoz-ingester:
+  signoz-ingester-0:
     command:
     - -c
     - |
       /signoz-otel-collector migrate sync check &&
       /signoz-otel-collector --config=/etc/otel-collector-config.yaml --manager-config=/etc/opamp-config.yaml --copy-path=/var/tmp/collector-config.yaml
-    container_name: signoz-ingester
+    container_name: signoz-ingester-0
     depends_on:
-      signoz-signoz:
+      signoz-signoz-0:
         condition: service_started
       signoz-telemetrystore-clickhouse-0-0:
         condition: service_healthy
@@ -162,7 +162,7 @@ services:
       target: /etc/otel-collector-config.yaml
       type: bind
     - content: |
-        server_endpoint: ws://signoz-signoz:4320/v1/opamp
+        server_endpoint: ws://signoz-signoz-0:4320/v1/opamp
       source: ./configs/ingester/opamp.yaml
       target: /etc/opamp-config.yaml
       type: bind
@@ -187,8 +187,8 @@ services:
     - source: signoz-metastore-0-data
       target: /var/lib/postgresql/data
       type: volume
-  signoz-signoz:
-    container_name: signoz-signoz
+  signoz-signoz-0:
+    container_name: signoz-signoz-0
     depends_on:
       signoz-metastore-postgres-0:
         condition: service_healthy
@@ -217,7 +217,7 @@ services:
         max-file: "3"
         max-size: 50m
     volumes:
-    - source: signoz-signoz-data
+    - source: signoz-signoz-0-data
       target: /var/lib/signoz/
       type: volume
   signoz-telemetrykeeper-clickhousekeeper-0:
@@ -469,8 +469,8 @@ services:
 volumes:
   signoz-metastore-0-data:
     name: signoz-metastore-0-data
-  signoz-signoz-data:
-    name: signoz-signoz-data
+  signoz-signoz-0-data:
+    name: signoz-signoz-0-data
   signoz-telemetrykeeper-0-data:
     name: signoz-telemetrykeeper-0-data
   signoz-telemetrystore-0-0-data:

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -155,7 +155,8 @@ spec:
     status:
       addresses:
         otlp:
-        - tcp://signoz-ingester-0:4317
+        - tcp://signoz-ingester:4318
+        - tcp://signoz-ingester:4317
       config:
         data:
           ingester.yaml: |

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -146,7 +146,7 @@ spec:
                   exporters:
                     - signozclickhousemeter
           opamp.yaml: |
-            server_endpoint: ws://signoz-signoz:4320/v1/opamp
+            server_endpoint: ws://signoz-signoz-0:4320/v1/opamp
       enabled: true
       env:
         SIGNOZ_OTEL_COLLECTOR_TIMEOUT: 10m
@@ -155,7 +155,7 @@ spec:
     status:
       addresses:
         otlp:
-        - tcp://signoz-ingester:4317
+        - tcp://signoz-ingester-0:4317
       config:
         data:
           ingester.yaml: |
@@ -292,7 +292,7 @@ spec:
                   exporters:
                     - signozclickhousemeter
           opamp.yaml: |
-            server_endpoint: ws://signoz-signoz:4320/v1/opamp
+            server_endpoint: ws://signoz-signoz-0:4320/v1/opamp
       env:
         SIGNOZ_OTEL_COLLECTOR_TIMEOUT: 10m
   metastore:
@@ -333,9 +333,9 @@ spec:
     status:
       addresses:
         apiserver:
-        - tcp://signoz-signoz:8080
+        - tcp://signoz-signoz-0:8080
         opamp:
-        - ws://signoz-signoz:4320
+        - ws://signoz-signoz-0:4320
       config: {}
       env:
         SIGNOZ_SQLSTORE_POSTGRES_DSN: postgres://signoz:signoz@signoz-metastore-postgres-0:5432/signoz?sslmode=disable

--- a/docs/examples/docker/compose/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose/pours/deployment/compose.yaml
@@ -1,14 +1,14 @@
+name: signoz
 networks:
   signoz-network:
     name: signoz-network
 services:
-  signoz-ingester-0:
+  ingester:
     command:
     - -c
     - |
       /signoz-otel-collector migrate sync check &&
       /signoz-otel-collector --config=/etc/otel-collector-config.yaml --manager-config=/etc/opamp-config.yaml --copy-path=/var/tmp/collector-config.yaml
-    container_name: signoz-ingester-0
     deploy:
       restart_policy:
         condition: on-failure
@@ -19,7 +19,9 @@ services:
     - SIGNOZ_OTEL_COLLECTOR_TIMEOUT=10m
     image: signoz/signoz-otel-collector:latest
     networks:
-    - signoz-network
+      signoz-network:
+        aliases:
+        - signoz-ingester
     ports:
     - 4317:4317
     - 4318:4318

--- a/docs/examples/docker/compose/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose/pours/deployment/compose.yaml
@@ -2,15 +2,14 @@ networks:
   signoz-network:
     name: signoz-network
 services:
-  signoz-ingester:
+  signoz-ingester-0:
     command:
     - -c
     - |
       /signoz-otel-collector migrate sync check &&
       /signoz-otel-collector --config=/etc/otel-collector-config.yaml --manager-config=/etc/opamp-config.yaml --copy-path=/var/tmp/collector-config.yaml
-    container_name: signoz-ingester
+    container_name: signoz-ingester-0
     deploy:
-      replicas: 1
       restart_policy:
         condition: on-failure
     entrypoint:
@@ -46,8 +45,8 @@ services:
     - signoz-network
     volumes:
     - signoz-metastore-postgres-0-data:/var/lib/postgresql/data
-  signoz-signoz:
-    container_name: signoz-signoz
+  signoz-signoz-0:
+    container_name: signoz-signoz-0
     deploy:
       restart_policy:
         condition: on-failure

--- a/docs/examples/docker/compose/pours/deployment/ingester/opamp.yaml
+++ b/docs/examples/docker/compose/pours/deployment/ingester/opamp.yaml
@@ -1,1 +1,1 @@
-server_endpoint: ws://signoz-signoz:4320/v1/opamp
+server_endpoint: ws://signoz-signoz-0:4320/v1/opamp

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -146,7 +146,7 @@ spec:
                   exporters:
                     - signozclickhousemeter
           opamp.yaml: |
-            server_endpoint: ws://signoz-signoz:4320/v1/opamp
+            server_endpoint: ws://signoz-signoz-0:4320/v1/opamp
       enabled: true
       env:
         SIGNOZ_OTEL_COLLECTOR_TIMEOUT: 10m
@@ -155,7 +155,7 @@ spec:
     status:
       addresses:
         otlp:
-        - tcp://signoz-ingester:9000
+        - tcp://signoz-ingester-0:9000
       config:
         data:
           ingester.yaml: |
@@ -292,7 +292,7 @@ spec:
                   exporters:
                     - signozclickhousemeter
           opamp.yaml: |
-            server_endpoint: ws://signoz-signoz:4320/v1/opamp
+            server_endpoint: ws://signoz-signoz-0:4320/v1/opamp
       env:
         SIGNOZ_OTEL_COLLECTOR_TIMEOUT: 10m
   metastore:
@@ -333,9 +333,9 @@ spec:
     status:
       addresses:
         apiserver:
-        - tcp://signoz-signoz:8080
+        - tcp://signoz-signoz-0:8080
         opamp:
-        - ws://signoz-signoz:4320
+        - ws://signoz-signoz-0:4320
       config: {}
       env:
         SIGNOZ_SQLSTORE_POSTGRES_DSN: postgres://signoz:signoz@signoz-metastore-postgres-0:5432/signoz?sslmode=disable

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -155,7 +155,8 @@ spec:
     status:
       addresses:
         otlp:
-        - tcp://signoz-ingester-0:9000
+        - tcp://signoz-ingester:4318
+        - tcp://signoz-ingester:4317
       config:
         data:
           ingester.yaml: |

--- a/docs/examples/docker/swarm/pours/deployment/compose.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/compose.yaml
@@ -15,7 +15,7 @@ networks:
     driver: overlay
     name: signoz-network
 services:
-  signoz-ingester-0:
+  ingester:
     command:
     - -c
     - |
@@ -26,6 +26,8 @@ services:
       target: /etc/otel-collector-config.yaml
     - source: manager-config
       target: /etc/opamp-config.yaml
+    deploy:
+      replicas: 1
     entrypoint:
     - /bin/sh
     environment:
@@ -33,7 +35,9 @@ services:
     - SIGNOZ_OTEL_COLLECTOR_TIMEOUT=10m
     image: signoz/signoz-otel-collector:latest
     networks:
-    - signoz-network
+      signoz-network:
+        aliases:
+        - signoz-ingester
     ports:
     - 4317:4317
     - 4318:4318

--- a/docs/examples/docker/swarm/pours/deployment/compose.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/compose.yaml
@@ -15,7 +15,7 @@ networks:
     driver: overlay
     name: signoz-network
 services:
-  signoz-ingester:
+  signoz-ingester-0:
     command:
     - -c
     - |
@@ -58,9 +58,8 @@ services:
     - signoz-network
     volumes:
     - signoz-metastore-postgres-0-data:/var/lib/postgresql/data
-  signoz-signoz:
+  signoz-signoz-0:
     deploy:
-      replicas: 1
       restart_policy:
         condition: on-failure
     environment:

--- a/docs/examples/docker/swarm/pours/deployment/ingester/opamp.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/ingester/opamp.yaml
@@ -1,1 +1,1 @@
-server_endpoint: ws://signoz-signoz:4320/v1/opamp
+server_endpoint: ws://signoz-signoz-0:4320/v1/opamp

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -146,7 +146,7 @@ spec:
                   exporters:
                     - signozclickhousemeter
           opamp.yaml: |
-            server_endpoint: ws://signoz-signoz:4320/v1/opamp
+            server_endpoint: ws://signoz-signoz-0:4320/v1/opamp
       enabled: true
       env:
         SIGNOZ_OTEL_COLLECTOR_TIMEOUT: 10m
@@ -292,7 +292,7 @@ spec:
                   exporters:
                     - signozclickhousemeter
           opamp.yaml: |
-            server_endpoint: ws://signoz-signoz:4320/v1/opamp
+            server_endpoint: ws://signoz-signoz-0:4320/v1/opamp
       env:
         SIGNOZ_OTEL_COLLECTOR_TIMEOUT: 10m
   metastore:
@@ -331,9 +331,9 @@ spec:
     status:
       addresses:
         apiserver:
-        - tcp://signoz-signoz:8080
+        - tcp://signoz-signoz-0:8080
         opamp:
-        - ws://signoz-signoz:4320
+        - ws://signoz-signoz-0:4320
       config: {}
       env:
         SIGNOZ_SQLSTORE_PROVIDER: postgres

--- a/docs/examples/render/blueprint/pours/deployment/configs/ingester/opamp.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/ingester/opamp.yaml
@@ -1,1 +1,1 @@
-server_endpoint: ws://signoz-signoz:4320/v1/opamp
+server_endpoint: ws://signoz-signoz-0:4320/v1/opamp

--- a/docs/examples/render/blueprint/pours/deployment/render.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/render.yaml
@@ -69,7 +69,7 @@ services:
   healthCheckPath: /api/v1/health
   image:
     url: signoz/signoz:latest
-  name: signoz-signoz
+  name: signoz-signoz-0
   plan: standard
   runtime: image
   type: web

--- a/internal/casting/coolifycasting/enricher.go
+++ b/internal/casting/coolifycasting/enricher.go
@@ -101,18 +101,14 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		config.Spec.MetaStore.Status.Addresses.DSN = metastoreContainerNames
 
 	case v1alpha1.MoldingKindIngester:
-		containerNames, err := enricher.material.GetStringSlice("services|@keys")
-		if err != nil {
-			return errors.Wrapf(err, errors.TypeInternal, "failed to get ingester container names")
-		}
+		// The ingester is scaled via `deploy.replicas` and reached through the
+		// `<metadata.name>-ingester` network alias on the default network,
+		// which compose load-balances across all replicas.
+		config.Spec.Ingester.Status.Addresses.OTLP = []string{
+			domain.MustNewAddress("tcp", config.Metadata.Name+"-ingester", 4318).String(),
+			domain.MustNewAddress("tcp", config.Metadata.Name+"-ingester", 4317).String(),
 
-		var ingesterContainerNames []string
-		for _, containerName := range containerNames {
-			if strings.Contains(containerName, "ingester") {
-				ingesterContainerNames = append(ingesterContainerNames, domain.MustNewAddress("tcp", containerName, 4318).String())
-			}
 		}
-		config.Spec.Ingester.Status.Addresses.OTLP = ingesterContainerNames
 	}
 
 	return nil

--- a/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
+++ b/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
@@ -136,8 +136,9 @@ services:
         max-file: "3"
   {{- end }}
   {{- end }}
-  {{ $.Metadata.Name }}-signoz:
-    container_name: {{ $.Metadata.Name }}-signoz
+  {{- range $replicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
+  {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}:
+    container_name: {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}
     image: {{ $.Spec.Signoz.Spec.Image }}
     depends_on:
       {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
@@ -172,26 +173,30 @@ services:
       {{- end }}
     volumes:
       - type: volume
-        source: {{ $.Metadata.Name }}-signoz-data
+        source: {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}-data
         target: /var/lib/signoz/
     logging:
       options:
         max-size: 50m
         max-file: "3"
-  {{ $.Metadata.Name }}-ingester:
-    container_name: {{ $.Metadata.Name }}-ingester
+  {{- end }}
+  {{- range $replicaIdx := until (int $.Spec.Ingester.Spec.Cluster.Replicas) }}
+  {{ $.Metadata.Name }}-ingester-{{ $replicaIdx }}:
+    container_name: {{ $.Metadata.Name }}-ingester-{{ $replicaIdx }}
     image: {{ $.Spec.Ingester.Spec.Image }}
     depends_on:
       {{- range $shardIdx := $.Spec.TelemetryStore.Spec.Cluster.Shards }}
-      {{- range $replicaIdx := add $.Spec.TelemetryStore.Spec.Cluster.Replicas 1 }}
-      {{ $.Metadata.Name }}-telemetrystore-{{ $.Spec.TelemetryStore.Kind }}-{{ $shardIdx }}-{{ $replicaIdx }}:
+      {{- range $storeReplicaIdx := add $.Spec.TelemetryStore.Spec.Cluster.Replicas 1 }}
+      {{ $.Metadata.Name }}-telemetrystore-{{ $.Spec.TelemetryStore.Kind }}-{{ $shardIdx }}-{{ $storeReplicaIdx }}:
         condition: service_healthy
       {{- end }}
       {{- end }}
       {{ $.Metadata.Name }}-telemetrystore-migrator:
         condition: service_completed_successfully
-      {{ $.Metadata.Name }}-signoz:
+      {{- range $signozReplicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
+      {{ $.Metadata.Name }}-signoz-{{ $signozReplicaIdx }}:
         condition: service_started
+      {{- end }}
     environment:
       - OTEL_RESOURCE_ATTRIBUTES=host.name=signoz-host,os.type=linux
       - LOW_CARDINAL_EXCEPTION_GROUPING=false
@@ -222,6 +227,7 @@ services:
       options:
         max-size: 50m
         max-file: "3"
+  {{- end }}
   {{ $.Metadata.Name }}-telemetrystore-migrator:
     image: {{ $.Spec.Ingester.Spec.Image }}
     depends_on:
@@ -270,5 +276,7 @@ volumes:
     name: {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data
   {{- end }}
   {{- end }}
-  {{ $.Metadata.Name }}-signoz-data:
-    name: {{ $.Metadata.Name }}-signoz-data
+  {{- range $replicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
+  {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}-data:
+    name: {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}-data
+  {{- end }}

--- a/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
+++ b/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
@@ -180,10 +180,13 @@ services:
         max-size: 50m
         max-file: "3"
   {{- end }}
-  {{- range $replicaIdx := until (int $.Spec.Ingester.Spec.Cluster.Replicas) }}
-  {{ $.Metadata.Name }}-ingester-{{ $replicaIdx }}:
-    container_name: {{ $.Metadata.Name }}-ingester-{{ $replicaIdx }}
+  {{- $ingesterReplicas := int $.Spec.Ingester.Spec.Cluster.Replicas }}
+  ingester:
     image: {{ $.Spec.Ingester.Spec.Image }}
+    networks:
+      default:
+        aliases:
+          - {{ $.Metadata.Name }}-ingester
     depends_on:
       {{- range $shardIdx := $.Spec.TelemetryStore.Spec.Cluster.Shards }}
       {{- range $storeReplicaIdx := add $.Spec.TelemetryStore.Spec.Cluster.Replicas 1 }}
@@ -227,7 +230,8 @@ services:
       options:
         max-size: 50m
         max-file: "3"
-  {{- end }}
+    deploy:
+      replicas: {{ $ingesterReplicas }}
   {{ $.Metadata.Name }}-telemetrystore-migrator:
     image: {{ $.Spec.Ingester.Spec.Image }}
     depends_on:

--- a/internal/casting/dockercomposecasting/enricher.go
+++ b/internal/casting/dockercomposecasting/enricher.go
@@ -110,20 +110,13 @@ func (enricher *dockerComposeMoldingEnricher) EnrichStatus(ctx context.Context, 
 		config.Spec.MetaStore.Status.Addresses.DSN = metastoreContainerNames
 
 	case v1alpha1.MoldingKindIngester:
-		// Get ingester container names
-		containerNames, err := enricher.material.GetStringSlice("services|@keys")
-		if err != nil {
-			return errors.Wrapf(err, errors.TypeInternal, "failed to get ingester container names")
+		// The ingester is scaled via `deploy.replicas` and reached through the
+		// `<metadata.name>-ingester` network alias, which compose load-balances
+		// across all replicas.
+		config.Spec.Ingester.Status.Addresses.OTLP = []string{
+			domain.MustNewAddress("tcp", config.Metadata.Name+"-ingester", 4318).String(),
+			domain.MustNewAddress("tcp", config.Metadata.Name+"-ingester", 4317).String(),
 		}
-
-		var ingesterContainerNames []string
-		for _, containerName := range containerNames {
-			if strings.Contains(containerName, "ingester") {
-				ingesterContainerNames = append(ingesterContainerNames, domain.MustNewAddress("tcp", containerName, 4317).String())
-			}
-		}
-
-		config.Spec.Ingester.Status.Addresses.OTLP = ingesterContainerNames
 	}
 
 	return nil

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -133,8 +133,8 @@ services:
       - ./ingester/ingester.yaml:/etc/otel-collector-config.yaml:ro
       - ./ingester/opamp.yaml:/etc/opamp-config.yaml:ro
     ports:
-      - "4317:4317"
-      - "4318:4318"
+      - "{{ add 4317 (mul $replicaIdx 1000) }}:4317"
+      - "{{ add 4318 (mul $replicaIdx 1000) }}:4318"
     environment:
 {{ if and $.Spec.TelemetryStore.Spec.Enabled $.Spec.TelemetryStore.Status.Addresses.TCP (index $.Spec.TelemetryStore.Status.Addresses.TCP 0) }}
       - SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN={{ index $.Spec.TelemetryStore.Status.Addresses.TCP 0 }}
@@ -161,10 +161,10 @@ services:
       {{- end }}
     {{- end }}
     ports:
-      - "8080:8080"
+      - "{{ add 8080 (mul $replicaIdx 1000) }}:8080"
     {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
     volumes:
-      - {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-data:{{ dir (index $.Spec.Signoz.Spec.Env "SIGNOZ_SQLSTORE_SQLITE_PATH") }}
+      - {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data:{{ dir (index $.Spec.Signoz.Spec.Env "SIGNOZ_SQLSTORE_SQLITE_PATH") }}
     {{- end }}
     healthcheck:
       test:
@@ -227,6 +227,8 @@ volumes:
   {{- end }}
   {{- end }}
   {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
-  {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-data:
-    name: {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-data
+  {{- range $replicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
+  {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data:
+    name: {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data
+  {{- end }}
   {{- end }}

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -1,3 +1,4 @@
+name: {{ $.Metadata.Name }}
 services:
   {{- range $replicaIdx := until (int $.Spec.TelemetryKeeper.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-telemetrykeeper-{{ $.Spec.TelemetryKeeper.Kind }}-{{ $replicaIdx }}:
@@ -116,12 +117,13 @@ services:
       start_period: 30s
   {{- end }}
   {{- end }}
-  {{- range $replicaIdx := until (int $.Spec.Ingester.Spec.Cluster.Replicas) }}
-  {{ $.Metadata.Name }}-ingester-{{ $replicaIdx }}:
-    container_name: {{ $.Metadata.Name }}-ingester-{{ $replicaIdx }}
+  {{- $ingesterReplicas := int $.Spec.Ingester.Spec.Cluster.Replicas }}
+  ingester:
     image: {{ $.Spec.Ingester.Spec.Image }}
     networks:
-      - {{ $.Metadata.Name }}-network
+      {{ $.Metadata.Name }}-network:
+        aliases:
+          - {{ $.Metadata.Name }}-ingester
     entrypoint:
       - /bin/sh
     command:
@@ -132,9 +134,15 @@ services:
     volumes:
       - ./ingester/ingester.yaml:/etc/otel-collector-config.yaml:ro
       - ./ingester/opamp.yaml:/etc/opamp-config.yaml:ro
+    {{- if eq $ingesterReplicas 1 }}
     ports:
-      - "{{ add 4317 (mul $replicaIdx 1000) }}:4317"
-      - "{{ add 4318 (mul $replicaIdx 1000) }}:4318"
+      - "4317:4317"
+      - "4318:4318"
+    {{- else }}
+    expose:
+      - "4317"
+      - "4318"
+    {{- end }}
     environment:
 {{ if and $.Spec.TelemetryStore.Spec.Enabled $.Spec.TelemetryStore.Status.Addresses.TCP (index $.Spec.TelemetryStore.Status.Addresses.TCP 0) }}
       - SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN={{ index $.Spec.TelemetryStore.Status.Addresses.TCP 0 }}
@@ -145,9 +153,11 @@ services:
       {{- end }}
     {{- end }}
     deploy:
+      {{- if gt $ingesterReplicas 1 }}
+      replicas: {{ $ingesterReplicas }}
+      {{- end }}
       restart_policy:
         condition: on-failure
-  {{- end }}
   {{- range $replicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}:
     container_name: {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -116,8 +116,9 @@ services:
       start_period: 30s
   {{- end }}
   {{- end }}
-  {{ $.Metadata.Name }}-ingester:
-    container_name: {{ $.Metadata.Name }}-ingester
+  {{- range $replicaIdx := until (int $.Spec.Ingester.Spec.Cluster.Replicas) }}
+  {{ $.Metadata.Name }}-ingester-{{ $replicaIdx }}:
+    container_name: {{ $.Metadata.Name }}-ingester-{{ $replicaIdx }}
     image: {{ $.Spec.Ingester.Spec.Image }}
     networks:
       - {{ $.Metadata.Name }}-network
@@ -144,11 +145,12 @@ services:
       {{- end }}
     {{- end }}
     deploy:
-      replicas: {{ int $.Spec.Ingester.Spec.Cluster.Replicas }}
       restart_policy:
         condition: on-failure
-  {{ $.Metadata.Name }}-signoz:
-    container_name: {{ $.Metadata.Name }}-signoz
+  {{- end }}
+  {{- range $replicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
+  {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}:
+    container_name: {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}
     image: {{ $.Spec.Signoz.Spec.Image }}
     networks:
       - {{ $.Metadata.Name }}-network
@@ -178,6 +180,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
+  {{- end }}
   {{ $.Metadata.Name }}-telemetrystore-migrator:
     container_name: {{ $.Metadata.Name }}-telemetrystore-migrator
     image: {{ $.Spec.Ingester.Spec.Image }}

--- a/internal/casting/dockerswarmcasting/enricher.go
+++ b/internal/casting/dockerswarmcasting/enricher.go
@@ -99,18 +99,13 @@ func (enricher *dockerSwarmMoldingEnricher) EnrichStatus(ctx context.Context, ki
 		config.Spec.MetaStore.Status.Addresses.DSN = metastoreAddresses
 
 	case v1alpha1.MoldingKindIngester:
-		containerNames, err := enricher.material.GetStringSlice("services|@keys")
-		if err != nil {
-			return errors.Wrapf(err, errors.TypeInternal, "failed to get ingester service names")
+		// The ingester is scaled via `deploy.replicas` and reached through the
+		// `<metadata.name>-ingester` network alias, which Swarm's routing mesh
+		// load-balances across all replicas.
+		config.Spec.Ingester.Status.Addresses.OTLP = []string{
+			domain.MustNewAddress("tcp", config.Metadata.Name+"-ingester", 4318).String(),
+			domain.MustNewAddress("tcp", config.Metadata.Name+"-ingester", 4317).String(),
 		}
-
-		var ingesterAddresses []string
-		for _, name := range containerNames {
-			if strings.Contains(name, "ingester") {
-				ingesterAddresses = append(ingesterAddresses, domain.MustNewAddress("tcp", name, 9000).String())
-			}
-		}
-		config.Spec.Ingester.Status.Addresses.OTLP = ingesterAddresses
 	}
 
 	return nil

--- a/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
@@ -143,8 +143,8 @@ services:
       - source: manager-config
         target: /etc/opamp-config.yaml
     ports:
-      - "4317:4317"
-      - "4318:4318"
+      - "{{ add 4317 (mul $replicaIdx 1000) }}:4317"
+      - "{{ add 4318 (mul $replicaIdx 1000) }}:4318"
     environment:
 {{ if and $.Spec.TelemetryStore.Spec.Enabled $.Spec.TelemetryStore.Status.Addresses.TCP (index $.Spec.TelemetryStore.Status.Addresses.TCP 0) }}
       - SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN={{ index $.Spec.TelemetryStore.Status.Addresses.TCP 0 }}
@@ -167,10 +167,10 @@ services:
       {{- end }}
     {{- end }}
     ports:
-      - "8080:8080"
+      - "{{ add 8080 (mul $replicaIdx 1000) }}:8080"
     {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
     volumes:
-      - {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-data:{{ dir (index $.Spec.Signoz.Spec.Env "SIGNOZ_SQLSTORE_SQLITE_PATH") }}
+      - {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data:{{ dir (index $.Spec.Signoz.Spec.Env "SIGNOZ_SQLSTORE_SQLITE_PATH") }}
     {{- end }}
     deploy:
       restart_policy:
@@ -235,7 +235,9 @@ volumes:
   {{- end }}
   {{- end }}
   {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
-  {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-data:
+  {{- range $replicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
+  {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data:
+  {{- end }}
   {{- end }}
 configs:
   {{- range $replicaIdx := until (int $.Spec.TelemetryKeeper.Spec.Cluster.Replicas) }}

--- a/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
@@ -125,11 +125,13 @@ services:
       start_period: 30s
   {{- end }}
   {{- end }}
-  {{- range $replicaIdx := until (int $.Spec.Ingester.Spec.Cluster.Replicas) }}
-  {{ $.Metadata.Name }}-ingester-{{ $replicaIdx }}:
+  {{- $ingesterReplicas := int $.Spec.Ingester.Spec.Cluster.Replicas }}
+  ingester:
     image: {{ $.Spec.Ingester.Spec.Image }}
     networks:
-      - {{ $.Metadata.Name }}-network
+      {{ $.Metadata.Name }}-network:
+        aliases:
+          - {{ $.Metadata.Name }}-ingester
     entrypoint:
       - /bin/sh
     command:
@@ -143,8 +145,8 @@ services:
       - source: manager-config
         target: /etc/opamp-config.yaml
     ports:
-      - "{{ add 4317 (mul $replicaIdx 1000) }}:4317"
-      - "{{ add 4318 (mul $replicaIdx 1000) }}:4318"
+      - "4317:4317"
+      - "4318:4318"
     environment:
 {{ if and $.Spec.TelemetryStore.Spec.Enabled $.Spec.TelemetryStore.Status.Addresses.TCP (index $.Spec.TelemetryStore.Status.Addresses.TCP 0) }}
       - SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN={{ index $.Spec.TelemetryStore.Status.Addresses.TCP 0 }}
@@ -154,7 +156,8 @@ services:
       - {{ $key }}={{ $value }}
       {{- end }}
     {{- end }}
-  {{- end }}
+    deploy:
+      replicas: {{ $ingesterReplicas }}
   {{- range $replicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}:
     image: {{ $.Spec.Signoz.Spec.Image }}

--- a/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
@@ -125,7 +125,8 @@ services:
       start_period: 30s
   {{- end }}
   {{- end }}
-  {{ $.Metadata.Name }}-ingester:
+  {{- range $replicaIdx := until (int $.Spec.Ingester.Spec.Cluster.Replicas) }}
+  {{ $.Metadata.Name }}-ingester-{{ $replicaIdx }}:
     image: {{ $.Spec.Ingester.Spec.Image }}
     networks:
       - {{ $.Metadata.Name }}-network
@@ -153,7 +154,9 @@ services:
       - {{ $key }}={{ $value }}
       {{- end }}
     {{- end }}
-  {{ $.Metadata.Name }}-signoz:
+  {{- end }}
+  {{- range $replicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
+  {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}:
     image: {{ $.Spec.Signoz.Spec.Image }}
     networks:
       - {{ $.Metadata.Name }}-network
@@ -170,7 +173,6 @@ services:
       - {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-data:{{ dir (index $.Spec.Signoz.Spec.Env "SIGNOZ_SQLSTORE_SQLITE_PATH") }}
     {{- end }}
     deploy:
-      replicas: {{ int $.Spec.Signoz.Spec.Cluster.Replicas }}
       restart_policy:
         condition: on-failure
     healthcheck:
@@ -184,6 +186,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+  {{- end }}
   {{ $.Metadata.Name }}-telemetrystore-migrator:
     image: {{ $.Spec.Ingester.Spec.Image }}
     networks:

--- a/internal/casting/rendercasting/templates/render.yaml.gotmpl
+++ b/internal/casting/rendercasting/templates/render.yaml.gotmpl
@@ -73,7 +73,8 @@ services:
   {{ end }}
 
   {{ if $.Spec.Signoz.Spec.Enabled }}
-  - name: {{ $.Metadata.Name }}-signoz
+  {{ range $replicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
+  - name: {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}
     type: web
     plan: standard
     runtime: image
@@ -102,6 +103,7 @@ services:
           property: host
     {{ end }}
     {{ end }}
+  {{ end }}
   {{ end }}
 
   {{ if $.Spec.TelemetryStore.Spec.Enabled }}

--- a/internal/molding/metastoremolding/metastore.go
+++ b/internal/molding/metastoremolding/metastore.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	"github.com/signoz/foundry/api/v1alpha1/installation"
+	"github.com/signoz/foundry/internal/errors"
 )
 
 type metastore struct {
@@ -32,6 +33,11 @@ func (molding *metastore) MoldV1Alpha1(ctx context.Context, config *installation
 	}
 
 	switch config.Spec.MetaStore.Kind {
+	case installation.MetaStoreKindSQLite:
+		replicas := config.Spec.MetaStore.Spec.Cluster.Replicas
+		if replicas != nil && *replicas != 1 {
+			return errors.Newf(errors.TypeInvalidInput, "metastore.spec.cluster.replicas must be 1 when metastore.kind is sqlite; sqlite is embedded and per-instance storage is driven by signoz.spec.cluster.replicas (got %d)", *replicas)
+		}
 	case installation.MetaStoreKindPostgres:
 		if val, ok := config.Spec.MetaStore.Spec.Env["POSTGRES_DB"]; ok {
 			molding.logger.WarnContext(ctx, "POSTGRES_DB is going to be overridden", slog.String("value", val))


### PR DESCRIPTION

#### Fixes

- Templated the signoz and ingester services with a replicaIdx suffix
- Fixed volume names to respect signoz replicaIdx for the sqlite metastore
- Fixed port collisions for replicas of signoz and ingester