### PR TITLE
fix(tooler): detect both legacy docker-compose and the docker cli compose plugin

### DIFF
--- a/internal/tooler/dockercomposetooler/tooler.go
+++ b/internal/tooler/dockercomposetooler/tooler.go
@@ -2,7 +2,9 @@ package dockercomposetooler
 
 import (
 	"context"
+	"os/exec"
 
+	"github.com/signoz/foundry/internal/errors"
 	root "github.com/signoz/foundry/internal/tooler"
 )
 
@@ -19,7 +21,18 @@ func (tooler *dockerComposeTooler) Name() string {
 }
 
 func (tooler *dockerComposeTooler) Gauge(ctx context.Context) error {
-	return root.AnyOneExecChecker(ctx, "docker-compose", "docker compose")
+	// Legacy standalone binary.
+	if err := root.ExecChecker(ctx, "docker-compose"); err == nil {
+		return nil
+	}
+
+	if err := root.ExecChecker(ctx, "docker"); err == nil {
+		if err := exec.CommandContext(ctx, "docker", "compose", "version").Run(); err == nil {
+			return nil
+		}
+	}
+
+	return errors.Newf(errors.TypeNotFound, "neither 'docker-compose' nor the 'docker compose' plugin is available")
 }
 
 func (tooler *dockerComposeTooler) Install(ctx context.Context) error {


### PR DESCRIPTION
#### Fixes

- `dockercomposetooler.Gauge` now detects the Docker CLI Compose plugin in addition to the legacy `docker-compose` binary

#### Context

`Gauge` previously called `AnyOneExecChecker(ctx, "docker-compose", "docker compose")`, which resolves to `exec.LookPath` on each name. The `"docker compose"` arm could never succeed, the modern Compose ships as a Docker CLI plugin under Docker's plugin directory, not as a standalone binary on PATH. The check only passed incidentally on systems that also expose a `docker-compose` shim.

#### Changes

- `internal/tooler/dockercomposetooler/tooler.go`: replace the single `AnyOneExecChecker` call with explicit fallback:
   - `ExecChecker("docker-compose")`: legacy binary (unchanged behaviour)
  - else `ExecChecker("docker")` + `docker compose version`:  actually invokes the CLI so the plugin dispatch can resolve (mirrors `dockerswarmtooler`)
   - else `errors.Newf(errors.TypeNotFound, …)` with a descriptive message

#### Test plan

- [x] System with only legacy `docker-compose` — passes
- [x] System with only the `docker compose` plugin — passes
- [x] System with neither — returns `TypeNotFound` with a clear message