### PR TITLE
chore(systemd): derive signoz asset paths from install root via env

### DIFF
--- a/docs/examples/systemd/binary/README.md
+++ b/docs/examples/systemd/binary/README.md
@@ -25,6 +25,23 @@ sudo chown -R signoz:signoz /opt/signoz /var/lib/signoz /opt/ingester /var/lib/i
 
 The `signoz` user must also have traverse permissions to the `pours/` output directory.
 
+## Download SigNoz
+
+Download the SigNoz release tarball and extract it into `/opt/signoz`:
+
+```bash
+ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+sudo mkdir -p /opt/signoz
+curl -fsSL "https://github.com/SigNoz/signoz/releases/latest/download/signoz_linux_${ARCH}.tar.gz" \
+  | sudo tar -xz --strip-components=1 -C /opt/signoz
+```
+
+> [!IMPORTANT]
+> Extract the full tarball, do not move the `signoz` binary on its own. SigNoz resolves
+> the web frontend and notification templates relative to the binary, so `bin/`, `web/`,
+> `templates/`, and `conf/` must stay together under `/opt/signoz`. Moving only the binary
+> leaves the UI and alert/email templates unresolved.
+
 ## Configuration
 
 ```yaml

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -328,10 +328,13 @@ spec:
       config: {}
       enabled: true
       env:
+        SIGNOZ_ALERTMANAGER_SIGNOZ_TEMPLATES: /opt/signoz/templates/alertmanager/*.gotmpl
+        SIGNOZ_EMAILING_TEMPLATES_DIRECTORY: /opt/signoz/templates/email
         SIGNOZ_SQLSTORE_POSTGRES_DSN: postgres://signoz:signoz@localhost:5432/signoz?sslmode=disable
         SIGNOZ_SQLSTORE_PROVIDER: postgres
         SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_DSN: tcp://localhost:9000
         SIGNOZ_TELEMETRYSTORE_PROVIDER: clickhouse
+        SIGNOZ_WEB_DIRECTORY: /opt/signoz/web
       image: signoz/signoz:latest
       version: latest
     status:
@@ -342,10 +345,13 @@ spec:
         - ws://localhost:4320
       config: {}
       env:
+        SIGNOZ_ALERTMANAGER_SIGNOZ_TEMPLATES: /opt/signoz/templates/alertmanager/*.gotmpl
+        SIGNOZ_EMAILING_TEMPLATES_DIRECTORY: /opt/signoz/templates/email
         SIGNOZ_SQLSTORE_POSTGRES_DSN: postgres://signoz:signoz@localhost:5432/signoz?sslmode=disable
         SIGNOZ_SQLSTORE_PROVIDER: postgres
         SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_DSN: tcp://localhost:9000
         SIGNOZ_TELEMETRYSTORE_PROVIDER: clickhouse
+        SIGNOZ_WEB_DIRECTORY: /opt/signoz/web
   telemetrykeeper:
     kind: clickhousekeeper
     spec:

--- a/docs/examples/systemd/binary/pours/deployment/signoz-signoz.service
+++ b/docs/examples/systemd/binary/pours/deployment/signoz-signoz.service
@@ -2,11 +2,13 @@
 WantedBy=multi-user.target
 
 [Service]
-Environment=SIGNOZ_WEB_DIRECTORY=/opt/signoz/web
+Environment=SIGNOZ_ALERTMANAGER_SIGNOZ_TEMPLATES=/opt/signoz/templates/alertmanager/*.gotmpl
+Environment=SIGNOZ_EMAILING_TEMPLATES_DIRECTORY=/opt/signoz/templates/email
 Environment=SIGNOZ_SQLSTORE_POSTGRES_DSN=postgres://signoz:signoz@localhost:5432/signoz?sslmode=disable
 Environment=SIGNOZ_SQLSTORE_PROVIDER=postgres
 Environment=SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_DSN=tcp://localhost:9000
 Environment=SIGNOZ_TELEMETRYSTORE_PROVIDER=clickhouse
+Environment=SIGNOZ_WEB_DIRECTORY=/opt/signoz/web
 ExecStart=/opt/signoz/bin/signoz server
 Group=signoz
 KillMode=mixed

--- a/internal/casting/systemdcasting/enricher.go
+++ b/internal/casting/systemdcasting/enricher.go
@@ -2,6 +2,7 @@ package systemdcasting
 
 import (
 	"context"
+	"path"
 
 	"github.com/signoz/foundry/api/v1alpha1"
 	"github.com/signoz/foundry/api/v1alpha1/installation"
@@ -141,6 +142,17 @@ func (e *linuxMoldingEnricher) enrichSignoz(config *installation.Casting) error 
 		}
 		config.Metadata.Annotations["foundry.signoz.io/signoz-binary-path"] = signozBin
 	}
+
+	// The binary defaults these to its in-container paths, so point them at the
+	// extracted tarball tree (binary lives at <root>/bin/signoz).
+	root := path.Dir(path.Dir(signozBin))
+	if config.Spec.Signoz.Status.Env == nil {
+		config.Spec.Signoz.Status.Env = make(map[string]string)
+	}
+	env := config.Spec.Signoz.Status.Env
+	env["SIGNOZ_WEB_DIRECTORY"] = path.Join(root, "web")
+	env["SIGNOZ_EMAILING_TEMPLATES_DIRECTORY"] = path.Join(root, "templates", "email")
+	env["SIGNOZ_ALERTMANAGER_SIGNOZ_TEMPLATES"] = path.Join(root, "templates", "alertmanager", "*.gotmpl")
 
 	return nil
 }

--- a/internal/casting/systemdcasting/templates/signoz.service.gotmpl
+++ b/internal/casting/systemdcasting/templates/signoz.service.gotmpl
@@ -14,7 +14,6 @@ WorkingDirectory=/opt/signoz
 {{- $signozBinaryPath := index $.Metadata.Annotations "foundry.signoz.io/signoz-binary-path" }}
 ExecStart={{ $signozBinaryPath }} server
 {{- end }}
-Environment=SIGNOZ_WEB_DIRECTORY=/opt/signoz/web
 {{- range $key, $value := $.Spec.Signoz.Spec.Env }}
 Environment={{ $key }}={{ $value }}
 {{- end }}


### PR DESCRIPTION

#### Chores

- Align the signoz assets (templates, web) with the signoz tarball structure in systemdcasting
- Update the systemdcasting to help folks with downloading binary and with instructions on keeping things aligned


Related: https://github.com/SigNoz/platform-pod/issues/2347
