### PR TITLE
fix(tooler): detect both legacy docker-compose and the docker cli compose plugin

### DIFF
--- a/internal/tooler/dockercomposetooler/tooler.go
+++ b/internal/tooler/dockercomposetooler/tooler.go
@@ -2,7 +2,9 @@ package dockercomposetooler
 
 import (
 	"context"
+	"os/exec"
 
+	"github.com/signoz/foundry/internal/errors"
 	root "github.com/signoz/foundry/internal/tooler"
 )
 
@@ -20,6 +22,18 @@ func (tooler *dockerComposeTooler) Name() string {
 
 func (tooler *dockerComposeTooler) Gauge(ctx context.Context) error {
 	return root.AnyOneExecChecker(ctx, "docker-compose", "docker compose")
+	// Legacy standalone binary.
+	if err := root.ExecChecker(ctx, "docker-compose"); err == nil {
+		return nil
+	}
+
+	if err := root.ExecChecker(ctx, "docker"); err == nil {
+		if err := exec.CommandContext(ctx, "docker", "compose", "version").Run(); err == nil {
+			return nil
+		}
+	}
+
+	return errors.Newf(errors.TypeNotFound, "neither 'docker-compose' nor the 'docker compose' plugin is available")
 }
 
 func (tooler *dockerComposeTooler) Install(ctx context.Context) error {

--- a/internal/tooler/dockercomposetooler/tooler.go
+++ b/internal/tooler/dockercomposetooler/tooler.go
@@ -21,7 +21,6 @@ func (tooler *dockerComposeTooler) Name() string {
 }
 
 func (tooler *dockerComposeTooler) Gauge(ctx context.Context) error {
-	return root.AnyOneExecChecker(ctx, "docker-compose", "docker compose")
 	// Legacy standalone binary.
 	if err := root.ExecChecker(ctx, "docker-compose"); err == nil {
 		return nil


### PR DESCRIPTION
Hey, 
this is fix of pull request:
https://github.com/SigNoz/foundry/pull/126