### PR TITLE
fix(build): fix formatting of build.yaml for GO_BUILD_FLAGS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,8 +51,8 @@ jobs:
         -ldflags='-s -w
         -X github.com/signoz/foundry/internal/version.version=${{ needs.prepare.outputs.version }}
         -X github.com/signoz/foundry/internal/version.hash=${{ needs.prepare.outputs.hash }}
-        -X github.com/signoz/foundry/internal/ledger.key=YPscRxkyHv2Fn0aOucmLrMYBBVAC1AFu'
-        -X github.com/signoz/foundry/internal/updater.repository=SigNoz/foundry
+        -X github.com/signoz/foundry/internal/ledger.key=YPscRxkyHv2Fn0aOucmLrMYBBVAC1AFu
+        -X github.com/signoz/foundry/internal/updater.repository=SigNoz/foundry'
 
       GO_NAME: foundryctl
       DOCKER_BASE_IMAGES: '{"distroless":"gcr.io/distroless/base:latest"}'


### PR DESCRIPTION
#### Fixes

- Fixes the broken formatting for build args as part of the PR #132 
