### PR TITLE
fix(standalone): fetch binaries at runtime for standalone

### DIFF
--- a/docs/concepts/moldings.md
+++ b/docs/concepts/moldings.md
@@ -48,7 +48,7 @@ spec:
 | `cluster.replicas` | Number of replicas |
 | `cluster.shards` | Number of shards (TelemetryStore only) |
 | `env` | Environment variables as a key-value map |
-| `config.data` | Config file overrides: filename to file contents |
+| `config.data` | Config file overrides merged with the generated config: filename to contents |
 
 ### Disabling a molding
 
@@ -63,7 +63,7 @@ spec:
 
 ### Custom config files
 
-Use `config.data` to override the contents of a component's config files. The key is the filename; the value is the file contents.
+Use `config.data` to override a component's config files. The key is the filename; whatever you set gets merged with the config Foundry generates, so you only set what you want to change.
 
 ```yaml
 spec:

--- a/docs/concepts/patches.md
+++ b/docs/concepts/patches.md
@@ -16,7 +16,7 @@ This gives you full coverage over the generated output without Foundry needing t
 | Field | Required | Description |
 |---|---|---|
 | `type` | No | Patch driver. Defaults to `jsonpatch`. |
-| `target` | Yes | Output file to patch. Supports exact path, basename, or glob. |
+| `target` | Yes | Output file to patch, relative to `pours/` (e.g. `deployment/compose.yaml`). Exact path or glob. |
 | `operations` | Yes | List of JSON Patch (RFC 6902) operations. |
 
 ## JSON Patch operations
@@ -31,6 +31,8 @@ This gives you full coverage over the generated output without Foundry needing t
 | `test` | Assert a value equals the given value. Fails if not. | `op`, `path`, `value` |
 
 ## Target matching
+
+Targets are matched against each generated file's path relative to `pours/`, so every path begins with `deployment/`.
 
 - **Exact path:** `target: "deployment/compose.yaml"`
 - **Glob:** `target: "deployment/telemetrystore-*.yaml"` matches multiple files
@@ -47,7 +49,7 @@ Set a memory limit on ClickHouse and add a custom environment variable to SigNoz
 ```yaml
 spec:
   patches:
-    - target: "compose.yaml"
+    - target: "deployment/compose.yaml"
       operations:
         - op: replace
           path: /services/clickhouse/mem_limit
@@ -64,7 +66,7 @@ Change the restart policy and add a memory limit on a service unit:
 ```yaml
 spec:
   patches:
-    - target: "signoz-ingester.service"
+    - target: "deployment/signoz-ingester.service"
       operations:
         - op: replace
           path: /Service/Restart

--- a/docs/examples/systemd/binary/README.md
+++ b/docs/examples/systemd/binary/README.md
@@ -12,32 +12,36 @@ Deploys SigNoz on bare metal as systemd units — one service per component (Sig
 
 ## Prerequisites
 
-Install the component binaries below; `cast` handles everything else. They are expected at standard locations — install elsewhere and point to them with [annotations](#annotations).
+Install the component binaries to their default locations; `cast` handles everything else. To install elsewhere, point to them with [annotations](#annotations).
 
-- [SigNoz](https://github.com/SigNoz/signoz/releases/latest)
-- [SigNoz OTel Collector](https://github.com/SigNoz/signoz-otel-collector/releases/latest)
-- [ClickHouse](https://clickhouse.com/docs/install) — a single `clickhouse` binary serves both the telemetry store and the keeper
-- [PostgreSQL](https://www.postgresql.org/download/) — only when `metastore.kind` is `postgres`
-- [SigNoz MCP Server](https://github.com/SigNoz/signoz-mcp-server#self-hosted-installation) — only when MCP is enabled (`spec.mcp.spec.enabled: true`)
+The SigNoz binaries are GitHub release tarballs, each extracted into its `/opt` directory:
+
+```bash
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+
+# SigNoz (query engine + UI)
+sudo mkdir -p /opt/signoz
+curl -fsSL "https://github.com/SigNoz/signoz/releases/latest/download/signoz_linux_${ARCH}.tar.gz" \
+  | sudo tar -xz --strip-components=1 -C /opt/signoz
+
+# OTel Collector (ingester)
+sudo mkdir -p /opt/ingester
+curl -fsSL "https://github.com/SigNoz/signoz-otel-collector/releases/latest/download/signoz-otel-collector_linux_${ARCH}.tar.gz" \
+  | sudo tar -xz --strip-components=1 -C /opt/ingester
+
+# MCP server (only when spec.mcp.spec.enabled is true)
+sudo mkdir -p /opt/mcp
+curl -fsSL "https://github.com/SigNoz/signoz-mcp-server/releases/latest/download/signoz-mcp-server_linux_${ARCH}.tar.gz" \
+  | sudo tar -xz --strip-components=1 -C /opt/mcp
+```
 
 > [!IMPORTANT]
-> Install SigNoz by extracting the **full** release tarball into `/opt/signoz` — do not move the `signoz` binary on its own. It resolves the web UI and email/alert templates relative to itself, so `bin/`, `web/`, `templates/`, and `conf/` must stay together:
->
-> ```bash
-> ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-> sudo mkdir -p /opt/signoz
-> curl -fsSL "https://github.com/SigNoz/signoz/releases/latest/download/signoz_linux_${ARCH}.tar.gz" \
->   | sudo tar -xz --strip-components=1 -C /opt/signoz
-> ```
+> Extract the **full** SigNoz tarball; do not move the `signoz` binary on its own. It loads the web UI and email/alert templates relative to itself, so `bin/`, `web/`, `templates/`, and `conf/` must stay together.
 
-> [!NOTE]
-> The MCP server is optional. When `spec.mcp.spec.enabled` is `true`, install its [self-hosted binary](https://github.com/SigNoz/signoz-mcp-server#self-hosted-installation) to the default location:
->
-> ```bash
-> ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-> curl -fsSL "https://github.com/SigNoz/signoz-mcp-server/releases/latest/download/signoz-mcp-server_linux_${ARCH}.tar.gz" | tar -xz
-> sudo install -D signoz-mcp-server /opt/mcp/bin/signoz-mcp-server
-> ```
+ClickHouse and PostgreSQL are installed from their own packages:
+
+- [ClickHouse](https://clickhouse.com/docs/install): one `clickhouse` binary serves both the telemetry store and the keeper
+- [PostgreSQL](https://www.postgresql.org/download/): only when `metastore.kind` is `postgres`
 
 ## Configuration
 

--- a/docs/reference/casting-file.md
+++ b/docs/reference/casting-file.md
@@ -73,7 +73,7 @@ Each molding (`signoz`, `ingester`, `telemetrystore`, `telemetrykeeper`) accepts
 | `cluster.replicas` | int | `1` | Number of replicas |
 | `cluster.shards` | int | `1` | Number of shards (TelemetryStore only) |
 | `env` | map | `{}` | Environment variables as key-value pairs |
-| `config.data` | map | `{}` | Config file overrides: filename to file contents |
+| `config.data` | map | `{}` | Config file overrides merged with the generated config: filename to contents |
 
 ## TelemetryKeeper
 
@@ -128,7 +128,7 @@ spec:
 | Field | Required | Description |
 | --- | --- | --- |
 | `type` | No | Patch driver. Default: `jsonpatch`. |
-| `target` | Yes | Output file to patch. Exact path, basename, or glob. |
+| `target` | Yes | Output file to patch, relative to `pours/` (e.g. `deployment/compose.yaml`). Exact path or glob. |
 | `operations` | Yes | List of JSON Patch (RFC 6902) operations. |
 
 See [Patches](../concepts/patches.md) for operation details and examples.

--- a/docs/standalone/Dockerfile.multi-arch
+++ b/docs/standalone/Dockerfile.multi-arch
@@ -3,12 +3,12 @@ ARG DEBIAN_SHA="pass-a-valid-docker-sha-otherwise-this-will-fail"
 FROM debian@sha256:${DEBIAN_SHA}
 LABEL maintainer="signoz"
 
-ARG OS="linux"
-ARG ARCH
-
-ARG SIGNOZ_VERSION=latest
-ARG INGESTER_VERSION=latest
-ARG FOUNDRY_VERSION=latest
+# All SigNoz binaries (signoz, otel-collector, foundryctl) are fetched at
+# container start by entrypoint.sh; versions are overridable at `docker run`
+# (e.g. -e SIGNOZ_VERSION=v0.x.y). Only ClickHouse is baked in (via apt).
+ENV SIGNOZ_VERSION=latest
+ENV INGESTER_VERSION=latest
+ENV FOUNDRY_VERSION=latest
 
 # Install systemd
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -26,49 +26,37 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
           /lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup* \
           /lib/systemd/system/systemd-update-utmp*
 
-# SigNoz
-RUN mkdir -p /opt/signoz && \
-    curl -fsSL "https://github.com/SigNoz/signoz/releases/${SIGNOZ_VERSION}/download/signoz_${OS}_${ARCH}.tar.gz" | \
-        tar -xz --strip-components=1 -C /opt/signoz && \
-    chmod +x /opt/signoz/bin/signoz
-
-# OTel Collector (ingester)
-RUN mkdir -p /opt/ingester && \
-    curl -fsSL "https://github.com/SigNoz/signoz-otel-collector/releases/${INGESTER_VERSION}/download/signoz-otel-collector_${OS}_${ARCH}.tar.gz" | \
-        tar -xz --strip-components=1 -C /opt/ingester && \
-    chmod +x /opt/ingester/bin/signoz-otel-collector
-
-# Foundry
-RUN mkdir -p /usr/local/bin && \
-    curl -fsSL "https://github.com/SigNoz/foundry/releases/${FOUNDRY_VERSION}/download/foundry_${OS}_${ARCH}.tar.gz" | \
-        tar -xz --strip-components=1 -C /tmp && \
-    mv /tmp/bin/foundryctl /usr/local/bin/foundryctl && \
-    chmod +x /usr/local/bin/foundryctl
-
-
-# Install ClickHouse from apt repo
+# Install ClickHouse from the official DEB repo (https://clickhouse.com/docs/install),
+# pinned to the release Foundry targets. Keep CLICKHOUSE_VERSION in sync with the
+# default image tag in api/v1alpha1/installation/telemetrystore.go.
+ARG CLICKHOUSE_VERSION=25.5.6
 RUN curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' | \
         gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" \
+    echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg arch=$(dpkg --print-architecture)] https://packages.clickhouse.com/deb stable main" \
         > /etc/apt/sources.list.d/clickhouse.list && \
     apt-get update && \
+    pkg_version="$(apt-cache madison clickhouse-server | awk -v v="${CLICKHOUSE_VERSION}." 'index($3, v) == 1 { print $3; exit }')" && \
+    if [ -z "${pkg_version}" ]; then echo "ClickHouse ${CLICKHOUSE_VERSION} not available in the apt repo" >&2; exit 1; fi && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        clickhouse-server \
-        clickhouse-client && \
+        clickhouse-common-static="${pkg_version}" \
+        clickhouse-server="${pkg_version}" \
+        clickhouse-client="${pkg_version}" && \
     systemctl disable clickhouse-server || true
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -r -m -d /opt/signoz -s /bin/false signoz && \
-    mkdir -p /var/lib/signoz /var/lib/ingester /etc/foundry /opt/signoz/web && \
-    chown signoz:signoz /var/lib/signoz /var/lib/ingester /opt/signoz
+    mkdir -p /var/lib/signoz /var/lib/ingester /etc/foundry /opt/signoz /opt/ingester && \
+    chown signoz:signoz /var/lib/signoz /var/lib/ingester /opt/signoz /opt/ingester
 
 COPY docs/standalone/casting.yaml /etc/foundry/casting.yaml
 COPY docs/standalone/foundry-setup.service /etc/systemd/system/foundry-setup.service
-RUN mkdir -p /var/lib/foundry && systemctl enable foundry-setup.service
+COPY docs/standalone/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh && mkdir -p /var/lib/foundry && systemctl enable foundry-setup.service
 
 EXPOSE 8080 4317 4318
 VOLUME ["/var/lib/clickhouse", "/var/lib/signoz"]
 
 STOPSIGNAL SIGRTMIN+3
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/sbin/init"]

--- a/docs/standalone/README.md
+++ b/docs/standalone/README.md
@@ -17,7 +17,7 @@ An OpenTelemetry-native observability backend in a single Docker image. The stan
 - **SQLite** - metadata storage
 - **[Foundry](https://github.com/SigNoz/foundry)** - deployment orchestration via `foundryctl`
 
-Applications can send telemetry using OpenTelemetry's standard defaults (OTLP gRPC/HTTP) without additional configuration. On first boot, Foundry generates all service configs and starts components via systemd.
+Applications can send telemetry using OpenTelemetry's standard defaults (OTLP gRPC/HTTP) without additional configuration. On first boot the container fetches the SigNoz app binaries (see [Versions](#versions)), then Foundry generates all service configs and starts components via systemd.
 
 ## Prerequisites
 
@@ -39,6 +39,21 @@ Send telemetry to:
 
 - OTLP gRPC: `localhost:4317`
 - OTLP HTTP: `localhost:4318`
+
+## Versions
+
+The SigNoz, OTel Collector, and `foundryctl` binaries are fetched at container start, so you can pin them per run (only ClickHouse is baked into the image):
+
+```bash
+docker run -d --name signoz --privileged \
+    -e SIGNOZ_VERSION=v0.x.y \
+    -e INGESTER_VERSION=v0.x.y \
+    -e FOUNDRY_VERSION=v0.x.y \
+    -p 8080:8080 -p 4317:4317 -p 4318:4318 \
+    signoz/signoz-standalone:latest
+```
+
+> First start needs network access to fetch these binaries.
 
 ## Customization
 

--- a/docs/standalone/casting.yaml
+++ b/docs/standalone/casting.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1alpha1
+kind: Installation
 metadata:
   name: signoz
   annotations:

--- a/docs/standalone/entrypoint.sh
+++ b/docs/standalone/entrypoint.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# entrypoint.sh - Fetches the SigNoz binaries (signoz, otel-collector,
+# foundryctl) at container start, then execs the container command (systemd,
+# which runs foundry-setup.service -> foundryctl cast).
+#
+# Only ClickHouse is baked into the image; everything else is fetched here so
+# versions can be chosen at `docker run`.
+#
+# Environment:
+#   SIGNOZ_VERSION     SigNoz version to fetch (tag or "latest"). Default: latest.
+#   INGESTER_VERSION   OTel Collector version to fetch (tag or "latest"). Default: latest.
+#   FOUNDRY_VERSION    foundryctl version to fetch (tag or "latest"). Default: latest.
+
+set -euo pipefail
+
+# Constants.
+readonly SIGNOZ_DIR="/opt/signoz"
+readonly INGESTER_DIR="/opt/ingester"
+readonly FOUNDRY_BIN="/usr/local/bin/foundryctl"
+readonly FOUNDRY_INSTALL_URL="https://signoz.io/foundry.sh"
+
+info() {
+  echo "[INFO] $*"
+}
+
+err() {
+  echo "[ERROR] $*" >&2
+}
+
+die() {
+  err "$*"
+  exit 1
+}
+
+# Sets PLATFORM_ARCH; the container is always linux, so only the arch varies.
+init_platform() {
+  local raw_arch
+  raw_arch="$(uname -m)"
+  case "${raw_arch}" in
+    x86_64 | amd64) PLATFORM_ARCH="amd64" ;;
+    aarch64 | arm64) PLATFORM_ARCH="arm64" ;;
+    *) die "Unsupported architecture: ${raw_arch}" ;;
+  esac
+}
+
+# install_release <repo> <version> <dest>: download the SigNoz GitHub release
+# tarball for <repo> at <version> ("latest" or a tag) and extract it into <dest>.
+install_release() {
+  local repo="$1" version="$2" dest="$3"
+  local asset="${repo}_linux_${PLATFORM_ARCH}.tar.gz" url
+
+  if [[ "${version}" == "latest" ]]; then
+    url="https://github.com/SigNoz/${repo}/releases/latest/download/${asset}"
+  else
+    url="https://github.com/SigNoz/${repo}/releases/download/${version}/${asset}"
+  fi
+
+  info "Fetching ${repo} ${version}"
+  mkdir -p "${dest}"
+  curl -fsSL "${url}" | tar -xz --strip-components=1 -C "${dest}"
+}
+
+# Installs foundryctl via the official installer into FOUNDRY_BIN's directory.
+# The installer reads FOUNDRY_VERSION literally and rejects "latest", so for the
+# default we unset it and let the installer resolve the newest release itself.
+install_foundry() {
+  local version="$1" dir
+  dir="$(dirname "${FOUNDRY_BIN}")"
+  info "Installing foundryctl ${version}"
+  if [[ "${version}" == "latest" ]]; then
+    curl -fsSL "${FOUNDRY_INSTALL_URL}" \
+      | env -u FOUNDRY_VERSION FOUNDRY_INSTALL_DIR="${dir}" FOUNDRY_ASSUME_YES=true bash
+  else
+    curl -fsSL "${FOUNDRY_INSTALL_URL}" \
+      | env FOUNDRY_INSTALL_DIR="${dir}" FOUNDRY_VERSION="${version}" FOUNDRY_ASSUME_YES=true bash
+  fi
+}
+
+# Fetches any missing binaries, then hands their directories to the signoz user.
+run() {
+  init_platform
+
+  if [[ ! -x "${SIGNOZ_DIR}/bin/signoz" ]]; then
+    install_release signoz "${SIGNOZ_VERSION:-latest}" "${SIGNOZ_DIR}"
+    chmod +x "${SIGNOZ_DIR}/bin/signoz"
+  fi
+
+  if [[ ! -x "${INGESTER_DIR}/bin/signoz-otel-collector" ]]; then
+    install_release signoz-otel-collector "${INGESTER_VERSION:-latest}" "${INGESTER_DIR}"
+    chmod +x "${INGESTER_DIR}/bin/signoz-otel-collector"
+  fi
+
+  if [[ ! -x "${FOUNDRY_BIN}" ]]; then
+    install_foundry "${FOUNDRY_VERSION:-latest}"
+  fi
+
+  chown -R signoz:signoz "${SIGNOZ_DIR}" "${INGESTER_DIR}"
+}
+
+run
+exec "$@"


### PR DESCRIPTION

#### Fixes

- Fetch binaries at runtime for standalone
- Fixes across docs for spec.config merge handling, patches target paths, systemdcasting docs for binaries downloading 


Related https://github.com/SigNoz/platform-pod/issues/1522, https://github.com/SigNoz/platform-pod/issues/2527