### PR TITLE
chore: upgrade clickhouse version to 25.12.5

### DIFF
--- a/api/v1alpha1/installation/telemetrykeeper_kind.go
+++ b/api/v1alpha1/installation/telemetrykeeper_kind.go
@@ -17,7 +17,7 @@ var _ fmt.Stringer = (*TelemetryKeeperKind)(nil)
 var _ jsonschema.Enum = (*TelemetryKeeperKind)(nil)
 
 var (
-	TelemetryKeeperKindClickhouseKeeper TelemetryKeeperKind = TelemetryKeeperKind{s: "clickhousekeeper", image: "clickhouse/clickhouse-keeper:25.5.6", version: "25.5.6"}
+	TelemetryKeeperKindClickhouseKeeper TelemetryKeeperKind = TelemetryKeeperKind{s: "clickhousekeeper", image: "clickhouse/clickhouse-keeper:25.12.5", version: "25.12.5"}
 	TelemetryKeeperKindZookeeper        TelemetryKeeperKind = TelemetryKeeperKind{s: "zookeeper", image: "signoz/zookeeper:3.7.1", version: "3.7.1"}
 )
 

--- a/api/v1alpha1/installation/telemetrystore.go
+++ b/api/v1alpha1/installation/telemetrystore.go
@@ -39,8 +39,8 @@ func DefaultTelemetryStore() TelemetryStore {
 				Replicas: v1alpha1.IntPtr(0),
 				Shards:   v1alpha1.IntPtr(1),
 			},
-			Version: "25.5.6",
-			Image:   "clickhouse/clickhouse-server:25.5.6",
+			Version: "25.12.5",
+			Image:   "clickhouse/clickhouse-server:25.12.5",
 		},
 	}
 }

--- a/docs/concepts/casting.md
+++ b/docs/concepts/casting.md
@@ -129,7 +129,7 @@ spec:
       image: signoz/signoz:v0.110.0
   telemetrystore:
     spec:
-      image: clickhouse/clickhouse-server:25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
       cluster:
         replicas: 1
         shards: 1

--- a/docs/concepts/moldings.md
+++ b/docs/concepts/moldings.md
@@ -32,7 +32,7 @@ Override a molding by giving it a `spec` block. Whatever you set gets merged wit
 spec:
   telemetrystore:
     spec:
-      image: clickhouse/clickhouse-server:25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
       cluster:
         replicas: 1
         shards: 1

--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -386,8 +386,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -539,8 +539,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -243,7 +243,7 @@ services:
       - -q
       - ls
       timeout: 10s
-    image: clickhouse/clickhouse-keeper:25.5.6
+    image: clickhouse/clickhouse-keeper:25.12.5
     logging:
       options:
         max-file: "3"
@@ -297,7 +297,7 @@ services:
       - -q
       - 0.0.0.0:8123/ping
       timeout: 5s
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     logging:
       options:
         max-file: "3"
@@ -441,7 +441,7 @@ services:
       tar -xvzf histogram-quantile.tar.gz
       mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
     exclude_from_hc: true
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     logging:
       options:
         max-file: "3"

--- a/docs/examples/docker/compose-mcp/casting.yaml.lock
+++ b/docs/examples/docker/compose-mcp/casting.yaml.lock
@@ -394,8 +394,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -547,8 +547,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/docker/compose-mcp/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose-mcp/pours/deployment/compose.yaml
@@ -117,7 +117,7 @@ services:
       - -q
       - ls
       timeout: 10s
-    image: clickhouse/clickhouse-keeper:25.5.6
+    image: clickhouse/clickhouse-keeper:25.12.5
     networks:
     - signoz-network
     volumes:
@@ -144,7 +144,7 @@ services:
       - -q
       - http://localhost:8123/ping
       timeout: 10s
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     networks:
     - signoz-network
     volumes:
@@ -166,7 +166,7 @@ services:
       tar -xvzf histogram-quantile.tar.gz
       mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
     container_name: signoz-telemetrystore-clickhouse-user-scripts
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     networks:
     - signoz-network
     volumes:

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -386,8 +386,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -539,8 +539,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/docker/compose/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose/pours/deployment/compose.yaml
@@ -92,7 +92,7 @@ services:
       - -q
       - ls
       timeout: 10s
-    image: clickhouse/clickhouse-keeper:25.5.6
+    image: clickhouse/clickhouse-keeper:25.12.5
     networks:
     - signoz-network
     volumes:
@@ -119,7 +119,7 @@ services:
       - -q
       - http://localhost:8123/ping
       timeout: 10s
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     networks:
     - signoz-network
     volumes:
@@ -141,7 +141,7 @@ services:
       tar -xvzf histogram-quantile.tar.gz
       mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
     container_name: signoz-telemetrystore-clickhouse-user-scripts
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     networks:
     - signoz-network
     volumes:

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -386,8 +386,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -539,8 +539,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/docker/swarm/pours/deployment/compose.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/compose.yaml
@@ -111,7 +111,7 @@ services:
       - -q
       - ls
       timeout: 10s
-    image: clickhouse/clickhouse-keeper:25.5.6
+    image: clickhouse/clickhouse-keeper:25.12.5
     networks:
     - signoz-network
     volumes:
@@ -140,7 +140,7 @@ services:
       - http://localhost:8123/ping
       timeout: 10s
     hostname: signoz-telemetrystore-clickhouse-0-0
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     networks:
     - signoz-network
     volumes:
@@ -163,7 +163,7 @@ services:
       mode: global
       restart_policy:
         condition: none
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     networks:
     - signoz-network
     volumes:

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -385,8 +385,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -538,8 +538,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrykeeper.tf.json
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrykeeper.tf.json
@@ -19,7 +19,7 @@
       },
       {
         "name": "signoz-telemetrykeeper-clickhousekeeper-0",
-        "image": "clickhouse/clickhouse-keeper:25.5.6",
+        "image": "clickhouse/clickhouse-keeper:25.12.5",
         "essential": true,
         "entryPoint": ["/usr/bin/clickhouse-keeper", "--config-file=/etc/clickhouse-keeper/keeper.yaml"],
         "portMappings": [

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore.tf.json
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore.tf.json
@@ -34,7 +34,7 @@
       },
       {
         "name": "signoz-telemetrystore-clickhouse-0-0",
-        "image": "clickhouse/clickhouse-server:25.5.6",
+        "image": "clickhouse/clickhouse-server:25.12.5",
         "essential": true,
         "environment": [{"name":"CLICKHOUSE_SKIP_USER_SETUP","value":"1"}],
         "portMappings": [

--- a/docs/examples/kubernetes/helm-patches/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm-patches/casting.yaml.lock
@@ -400,8 +400,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -516,8 +516,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/kubernetes/helm-patches/pours/deployment/values.yaml
+++ b/docs/examples/kubernetes/helm-patches/pours/deployment/values.yaml
@@ -3,7 +3,7 @@ clickhouse:
   fullnameOverride: signoz-telemetrystore-clickhouse
   image:
     repository: clickhouse/clickhouse-server
-    tag: 25.5.6
+    tag: 25.12.5
   layout:
     replicasCount: 0
     shardsCount: 1

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -383,8 +383,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -536,8 +536,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/kubernetes/helm/pours/deployment/values.yaml
+++ b/docs/examples/kubernetes/helm/pours/deployment/values.yaml
@@ -3,7 +3,7 @@ clickhouse:
   fullnameOverride: signoz-telemetrystore-clickhouse
   image:
     repository: clickhouse/clickhouse-server
-    tag: 25.5.6
+    tag: 25.12.5
   layout:
     replicasCount: 0
     shardsCount: 1

--- a/docs/examples/kubernetes/kustomize-patches/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize-patches/casting.yaml.lock
@@ -420,8 +420,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -598,8 +598,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/kubernetes/kustomize-patches/pours/deployment/telemetrykeeper/clickhousekeeper/clickhousekeeperinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize-patches/pours/deployment/telemetrykeeper/clickhousekeeper/clickhousekeeperinstallation.yaml
@@ -30,7 +30,7 @@ spec:
       name: default
       spec:
         containers:
-        - image: clickhouse/clickhouse-keeper:25.5.6
+        - image: clickhouse/clickhouse-keeper:25.12.5
           imagePullPolicy: IfNotPresent
           name: clickhouse-keeper
           resources:

--- a/docs/examples/kubernetes/kustomize-patches/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize-patches/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: signoz-clickhouse
     app.kubernetes.io/part-of: signoz
-    app.kubernetes.io/version: 25.5.6
+    app.kubernetes.io/version: 25.12.5
   name: signoz-clickhouse
 spec:
   configuration:
@@ -147,7 +147,7 @@ spec:
           app.kubernetes.io/component: telemetrystore
           app.kubernetes.io/instance: signoz
           app.kubernetes.io/name: signoz-clickhouse
-          app.kubernetes.io/version: 25.5.6
+          app.kubernetes.io/version: 25.12.5
       name: default
       spec:
         containers:
@@ -155,7 +155,7 @@ spec:
           - /bin/bash
           - -c
           - /usr/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml
-          image: clickhouse/clickhouse-server:25.5.6
+          image: clickhouse/clickhouse-server:25.12.5
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 10

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -383,8 +383,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -590,8 +590,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/kubernetes/kustomize/pours/deployment/telemetrykeeper/clickhousekeeper/clickhousekeeperinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/telemetrykeeper/clickhousekeeper/clickhousekeeperinstallation.yaml
@@ -30,7 +30,7 @@ spec:
       name: default
       spec:
         containers:
-        - image: clickhouse/clickhouse-keeper:25.5.6
+        - image: clickhouse/clickhouse-keeper:25.12.5
           imagePullPolicy: IfNotPresent
           name: clickhouse-keeper
           resources:

--- a/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: signoz-clickhouse
     app.kubernetes.io/part-of: signoz
-    app.kubernetes.io/version: 25.5.6
+    app.kubernetes.io/version: 25.12.5
   name: signoz-clickhouse
 spec:
   configuration:
@@ -173,7 +173,7 @@ spec:
           app.kubernetes.io/component: telemetrystore
           app.kubernetes.io/instance: signoz
           app.kubernetes.io/name: signoz-clickhouse
-          app.kubernetes.io/version: 25.5.6
+          app.kubernetes.io/version: 25.12.5
       name: default
       spec:
         containers:
@@ -181,7 +181,7 @@ spec:
           - /bin/bash
           - -c
           - /usr/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml
-          image: clickhouse/clickhouse-server:25.5.6
+          image: clickhouse/clickhouse-server:25.12.5
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 10

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -385,8 +385,8 @@ spec:
               console: true
               level: information
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -554,8 +554,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/railway/template/pours/deployment/telemetrykeeper/Dockerfile
+++ b/docs/examples/railway/template/pours/deployment/telemetrykeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-keeper:25.5.6
+FROM clickhouse/clickhouse-keeper:25.12.5
 
 # Copy all keeper config files
 COPY keeper.d/ /etc/clickhouse-keeper/

--- a/docs/examples/railway/template/pours/deployment/telemetrystore/Dockerfile
+++ b/docs/examples/railway/template/pours/deployment/telemetrystore/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-server:25.5.6
+FROM clickhouse/clickhouse-server:25.12.5
 
 COPY config.d/ /etc/clickhouse-server/
 

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -382,8 +382,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -537,8 +537,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrykeeper/Dockerfile
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrykeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-keeper:25.5.6
+FROM clickhouse/clickhouse-keeper:25.12.5
 
 # Copy all keeper config files
 COPY keeper.d/ /etc/clickhouse-keeper/

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/Dockerfile
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-server:25.5.6
+FROM clickhouse/clickhouse-server:25.12.5
 
 COPY config.d/ /etc/clickhouse-server/
 

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -398,8 +398,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -551,8 +551,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/systemd/binary/pours/deployment/signoz-telemetrykeeper-clickhousekeeper-0.service
+++ b/docs/examples/systemd/binary/pours/deployment/signoz-telemetrykeeper-clickhousekeeper-0.service
@@ -15,6 +15,6 @@ User=clickhouse
 
 [Unit]
 After=time-sync.target network-online.target
-Description=ClickHouse Keeper (v25.5.6)
+Description=ClickHouse Keeper (v25.12.5)
 Requires=network-online.target
 Wants=time-sync.target

--- a/docs/examples/systemd/binary/pours/deployment/signoz-telemetrystore-clickhouse-0-0.service
+++ b/docs/examples/systemd/binary/pours/deployment/signoz-telemetrystore-clickhouse-0-0.service
@@ -15,6 +15,6 @@ User=clickhouse
 
 [Unit]
 After=time-sync.target network-online.target
-Description=ClickHouse Server (v25.5.6)
+Description=ClickHouse Server (v25.12.5)
 Requires=network-online.target
 Wants=time-sync.target

--- a/docs/standalone/Dockerfile.multi-arch
+++ b/docs/standalone/Dockerfile.multi-arch
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install ClickHouse from the official DEB repo (https://clickhouse.com/docs/install),
 # pinned to the release Foundry targets. Keep CLICKHOUSE_VERSION in sync with the
 # default image tag in api/v1alpha1/installation/telemetrystore.go.
-ARG CLICKHOUSE_VERSION=25.5.6
+ARG CLICKHOUSE_VERSION=25.12.5
 RUN curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' | \
         gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg arch=$(dpkg --print-architecture)] https://packages.clickhouse.com/deb stable main" \

--- a/internal/casting/systemdcasting/templates/clickhouse.telemetrystore.v2556.service.gotmpl
+++ b/internal/casting/systemdcasting/templates/clickhouse.telemetrystore.v2556.service.gotmpl
@@ -1,5 +1,5 @@
 [Unit]
-Description=ClickHouse Server (v25.5.6)
+Description=ClickHouse Server (v25.12.5)
 Requires=network-online.target
 After=time-sync.target network-online.target
 Wants=time-sync.target

--- a/internal/casting/systemdcasting/templates/clickhousekeeper.telemetrykeeper.v2556.service.gotmpl
+++ b/internal/casting/systemdcasting/templates/clickhousekeeper.telemetrykeeper.v2556.service.gotmpl
@@ -1,5 +1,5 @@
 [Unit]
-Description=ClickHouse Keeper (v25.5.6)
+Description=ClickHouse Keeper (v25.12.5)
 Requires=network-online.target
 After=time-sync.target network-online.target
 Wants=time-sync.target

--- a/internal/config/yamlconfig/config_test.go
+++ b/internal/config/yamlconfig/config_test.go
@@ -39,8 +39,8 @@ spec:
 				assert.True(t, *casting.Spec.Ingester.Spec.Enabled)
 				// The default telemetrykeeper kind carries its image and version
 				assert.Equal(t, installation.TelemetryKeeperKindClickhouseKeeper, casting.Spec.TelemetryKeeper.Kind)
-				assert.Equal(t, "clickhouse/clickhouse-keeper:25.5.6", casting.Spec.TelemetryKeeper.Spec.Image)
-				assert.Equal(t, "25.5.6", casting.Spec.TelemetryKeeper.Spec.Version)
+				assert.Equal(t, "clickhouse/clickhouse-keeper:25.12.5", casting.Spec.TelemetryKeeper.Spec.Image)
+				assert.Equal(t, "25.12.5", casting.Spec.TelemetryKeeper.Spec.Version)
 			},
 		},
 		{


### PR DESCRIPTION
Update clickhouse version since collector v0.145+ requires atleast clickhouse v25.12.5 to support the table settings migration added in https://github.com/SigNoz/signoz-otel-collector/pull/833