### PR TITLE
feat(moldings): bump telemetrystoreclickhouse version to 25.12.5

### DIFF
--- a/api/v1alpha1/installation/telemetrykeeper_kind.go
+++ b/api/v1alpha1/installation/telemetrykeeper_kind.go
@@ -17,7 +17,7 @@ var _ fmt.Stringer = (*TelemetryKeeperKind)(nil)
 var _ jsonschema.Enum = (*TelemetryKeeperKind)(nil)
 
 var (
-	TelemetryKeeperKindClickhouseKeeper TelemetryKeeperKind = TelemetryKeeperKind{s: "clickhousekeeper", image: "clickhouse/clickhouse-keeper:25.5.6", version: "25.5.6"}
+	TelemetryKeeperKindClickhouseKeeper TelemetryKeeperKind = TelemetryKeeperKind{s: "clickhousekeeper", image: "clickhouse/clickhouse-keeper:25.12.5", version: "25.12.5"}
 	TelemetryKeeperKindZookeeper        TelemetryKeeperKind = TelemetryKeeperKind{s: "zookeeper", image: "signoz/zookeeper:3.7.1", version: "3.7.1"}
 )
 

--- a/api/v1alpha1/installation/telemetrystore.go
+++ b/api/v1alpha1/installation/telemetrystore.go
@@ -39,8 +39,8 @@ func DefaultTelemetryStore() TelemetryStore {
 				Replicas: v1alpha1.IntPtr(0),
 				Shards:   v1alpha1.IntPtr(1),
 			},
-			Version: "25.5.6",
-			Image:   "clickhouse/clickhouse-server:25.5.6",
+			Version: "25.12.5",
+			Image:   "clickhouse/clickhouse-server:25.12.5",
 		},
 	}
 }

--- a/docs/concepts/casting.md
+++ b/docs/concepts/casting.md
@@ -129,7 +129,7 @@ spec:
       image: signoz/signoz:v0.110.0
   telemetrystore:
     spec:
-      image: clickhouse/clickhouse-server:25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
       cluster:
         replicas: 1
         shards: 1

--- a/docs/concepts/moldings.md
+++ b/docs/concepts/moldings.md
@@ -32,7 +32,7 @@ Override a molding by giving it a `spec` block. Whatever you set gets merged wit
 spec:
   telemetrystore:
     spec:
-      image: clickhouse/clickhouse-server:25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
       cluster:
         replicas: 1
         shards: 1

--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -386,8 +386,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -539,8 +539,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -243,7 +243,7 @@ services:
       - -q
       - ls
       timeout: 10s
-    image: clickhouse/clickhouse-keeper:25.5.6
+    image: clickhouse/clickhouse-keeper:25.12.5
     logging:
       options:
         max-file: "3"
@@ -297,7 +297,7 @@ services:
       - -q
       - 0.0.0.0:8123/ping
       timeout: 5s
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     logging:
       options:
         max-file: "3"
@@ -441,7 +441,7 @@ services:
       tar -xvzf histogram-quantile.tar.gz
       mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
     exclude_from_hc: true
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     logging:
       options:
         max-file: "3"

--- a/docs/examples/docker/compose-mcp/casting.yaml.lock
+++ b/docs/examples/docker/compose-mcp/casting.yaml.lock
@@ -394,8 +394,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -547,8 +547,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/docker/compose-mcp/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose-mcp/pours/deployment/compose.yaml
@@ -117,7 +117,7 @@ services:
       - -q
       - ls
       timeout: 10s
-    image: clickhouse/clickhouse-keeper:25.5.6
+    image: clickhouse/clickhouse-keeper:25.12.5
     networks:
     - signoz-network
     volumes:
@@ -144,7 +144,7 @@ services:
       - -q
       - http://localhost:8123/ping
       timeout: 10s
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     networks:
     - signoz-network
     volumes:
@@ -166,7 +166,7 @@ services:
       tar -xvzf histogram-quantile.tar.gz
       mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
     container_name: signoz-telemetrystore-clickhouse-user-scripts
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     networks:
     - signoz-network
     volumes:

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -386,8 +386,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -539,8 +539,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/docker/compose/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose/pours/deployment/compose.yaml
@@ -92,7 +92,7 @@ services:
       - -q
       - ls
       timeout: 10s
-    image: clickhouse/clickhouse-keeper:25.5.6
+    image: clickhouse/clickhouse-keeper:25.12.5
     networks:
     - signoz-network
     volumes:
@@ -119,7 +119,7 @@ services:
       - -q
       - http://localhost:8123/ping
       timeout: 10s
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     networks:
     - signoz-network
     volumes:
@@ -141,7 +141,7 @@ services:
       tar -xvzf histogram-quantile.tar.gz
       mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
     container_name: signoz-telemetrystore-clickhouse-user-scripts
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     networks:
     - signoz-network
     volumes:

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -386,8 +386,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -539,8 +539,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/docker/swarm/pours/deployment/compose.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/compose.yaml
@@ -111,7 +111,7 @@ services:
       - -q
       - ls
       timeout: 10s
-    image: clickhouse/clickhouse-keeper:25.5.6
+    image: clickhouse/clickhouse-keeper:25.12.5
     networks:
     - signoz-network
     volumes:
@@ -140,7 +140,7 @@ services:
       - http://localhost:8123/ping
       timeout: 10s
     hostname: signoz-telemetrystore-clickhouse-0-0
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     networks:
     - signoz-network
     volumes:
@@ -163,7 +163,7 @@ services:
       mode: global
       restart_policy:
         condition: none
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     networks:
     - signoz-network
     volumes:

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -385,8 +385,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -538,8 +538,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrykeeper.tf.json
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrykeeper.tf.json
@@ -19,7 +19,7 @@
       },
       {
         "name": "signoz-telemetrykeeper-clickhousekeeper-0",
-        "image": "clickhouse/clickhouse-keeper:25.5.6",
+        "image": "clickhouse/clickhouse-keeper:25.12.5",
         "essential": true,
         "entryPoint": ["/usr/bin/clickhouse-keeper", "--config-file=/etc/clickhouse-keeper/keeper.yaml"],
         "portMappings": [

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore.tf.json
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore.tf.json
@@ -34,7 +34,7 @@
       },
       {
         "name": "signoz-telemetrystore-clickhouse-0-0",
-        "image": "clickhouse/clickhouse-server:25.5.6",
+        "image": "clickhouse/clickhouse-server:25.12.5",
         "essential": true,
         "environment": [{"name":"CLICKHOUSE_SKIP_USER_SETUP","value":"1"}],
         "portMappings": [

--- a/docs/examples/kubernetes/helm-patches/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm-patches/casting.yaml.lock
@@ -400,8 +400,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -516,8 +516,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/kubernetes/helm-patches/pours/deployment/values.yaml
+++ b/docs/examples/kubernetes/helm-patches/pours/deployment/values.yaml
@@ -3,7 +3,7 @@ clickhouse:
   fullnameOverride: signoz-telemetrystore-clickhouse
   image:
     repository: clickhouse/clickhouse-server
-    tag: 25.5.6
+    tag: 25.12.5
   layout:
     replicasCount: 0
     shardsCount: 1

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -383,8 +383,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -536,8 +536,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/kubernetes/helm/pours/deployment/values.yaml
+++ b/docs/examples/kubernetes/helm/pours/deployment/values.yaml
@@ -3,7 +3,7 @@ clickhouse:
   fullnameOverride: signoz-telemetrystore-clickhouse
   image:
     repository: clickhouse/clickhouse-server
-    tag: 25.5.6
+    tag: 25.12.5
   layout:
     replicasCount: 0
     shardsCount: 1

--- a/docs/examples/kubernetes/kustomize-patches/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize-patches/casting.yaml.lock
@@ -420,8 +420,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -598,8 +598,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/kubernetes/kustomize-patches/pours/deployment/telemetrykeeper/clickhousekeeper/clickhousekeeperinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize-patches/pours/deployment/telemetrykeeper/clickhousekeeper/clickhousekeeperinstallation.yaml
@@ -30,7 +30,7 @@ spec:
       name: default
       spec:
         containers:
-        - image: clickhouse/clickhouse-keeper:25.5.6
+        - image: clickhouse/clickhouse-keeper:25.12.5
           imagePullPolicy: IfNotPresent
           name: clickhouse-keeper
           resources:

--- a/docs/examples/kubernetes/kustomize-patches/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize-patches/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: signoz-clickhouse
     app.kubernetes.io/part-of: signoz
-    app.kubernetes.io/version: 25.5.6
+    app.kubernetes.io/version: 25.12.5
   name: signoz-clickhouse
 spec:
   configuration:
@@ -147,7 +147,7 @@ spec:
           app.kubernetes.io/component: telemetrystore
           app.kubernetes.io/instance: signoz
           app.kubernetes.io/name: signoz-clickhouse
-          app.kubernetes.io/version: 25.5.6
+          app.kubernetes.io/version: 25.12.5
       name: default
       spec:
         containers:
@@ -155,7 +155,7 @@ spec:
           - /bin/bash
           - -c
           - /usr/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml
-          image: clickhouse/clickhouse-server:25.5.6
+          image: clickhouse/clickhouse-server:25.12.5
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 10

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -383,8 +383,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -590,8 +590,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/kubernetes/kustomize/pours/deployment/telemetrykeeper/clickhousekeeper/clickhousekeeperinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/telemetrykeeper/clickhousekeeper/clickhousekeeperinstallation.yaml
@@ -30,7 +30,7 @@ spec:
       name: default
       spec:
         containers:
-        - image: clickhouse/clickhouse-keeper:25.5.6
+        - image: clickhouse/clickhouse-keeper:25.12.5
           imagePullPolicy: IfNotPresent
           name: clickhouse-keeper
           resources:

--- a/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: signoz-clickhouse
     app.kubernetes.io/part-of: signoz
-    app.kubernetes.io/version: 25.5.6
+    app.kubernetes.io/version: 25.12.5
   name: signoz-clickhouse
 spec:
   configuration:
@@ -173,7 +173,7 @@ spec:
           app.kubernetes.io/component: telemetrystore
           app.kubernetes.io/instance: signoz
           app.kubernetes.io/name: signoz-clickhouse
-          app.kubernetes.io/version: 25.5.6
+          app.kubernetes.io/version: 25.12.5
       name: default
       spec:
         containers:
@@ -181,7 +181,7 @@ spec:
           - /bin/bash
           - -c
           - /usr/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml
-          image: clickhouse/clickhouse-server:25.5.6
+          image: clickhouse/clickhouse-server:25.12.5
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 10

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -385,8 +385,8 @@ spec:
               console: true
               level: information
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -554,8 +554,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -382,8 +382,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -537,8 +537,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrykeeper/Dockerfile
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrykeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-keeper:25.5.6
+FROM clickhouse/clickhouse-keeper:25.12.5
 
 # Copy all keeper config files
 COPY keeper.d/ /etc/clickhouse-keeper/

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -398,8 +398,8 @@ spec:
               snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
               tcp_port: 9181
       enabled: true
-      image: clickhouse/clickhouse-keeper:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-keeper:25.12.5
+      version: 25.12.5
     status:
       addresses:
         client:
@@ -551,8 +551,8 @@ spec:
               return_type: Float64
               type: executable
       enabled: true
-      image: clickhouse/clickhouse-server:25.5.6
-      version: 25.5.6
+      image: clickhouse/clickhouse-server:25.12.5
+      version: 25.12.5
     status:
       addresses:
         tcp:

--- a/docs/examples/systemd/binary/pours/deployment/signoz-telemetrykeeper-clickhousekeeper-0.service
+++ b/docs/examples/systemd/binary/pours/deployment/signoz-telemetrykeeper-clickhousekeeper-0.service
@@ -15,6 +15,6 @@ User=clickhouse
 
 [Unit]
 After=time-sync.target network-online.target
-Description=ClickHouse Keeper (v25.5.6)
+Description=ClickHouse Keeper (v25.12.5)
 Requires=network-online.target
 Wants=time-sync.target

--- a/docs/examples/systemd/binary/pours/deployment/signoz-telemetrystore-clickhouse-0-0.service
+++ b/docs/examples/systemd/binary/pours/deployment/signoz-telemetrystore-clickhouse-0-0.service
@@ -15,6 +15,6 @@ User=clickhouse
 
 [Unit]
 After=time-sync.target network-online.target
-Description=ClickHouse Server (v25.5.6)
+Description=ClickHouse Server (v25.12.5)
 Requires=network-online.target
 Wants=time-sync.target

--- a/docs/standalone/Dockerfile.multi-arch
+++ b/docs/standalone/Dockerfile.multi-arch
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install ClickHouse from the official DEB repo (https://clickhouse.com/docs/install),
 # pinned to the release Foundry targets. Keep CLICKHOUSE_VERSION in sync with the
 # default image tag in api/v1alpha1/installation/telemetrystore.go.
-ARG CLICKHOUSE_VERSION=25.5.6
+ARG CLICKHOUSE_VERSION=25.12.5
 RUN curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' | \
         gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg arch=$(dpkg --print-architecture)] https://packages.clickhouse.com/deb stable main" \

--- a/internal/casting/railwaytemplatecasting/casting.go
+++ b/internal/casting/railwaytemplatecasting/casting.go
@@ -24,8 +24,6 @@ func New(logger *slog.Logger) *railwayTemplateCasting {
 	return &railwayTemplateCasting{
 		logger: logger,
 		castings: []*domain.Template{
-			telemetryKeeperClickhouseKeeperDockerfileTemplate,
-			telemetryStoreDockerfileTemplate,
 			ingesterDockerfileTemplate,
 			signozDockerfileTemplate,
 			telemetryStoreMigratorDockerfileTemplate,
@@ -49,9 +47,9 @@ func (c *railwayTemplateCasting) Forge(ctx context.Context, config installation.
 
 	// TelemetryKeeper: Dockerfile + configs + railway.json
 	if config.Spec.TelemetryKeeper.Spec.IsEnabled() {
-		keeperDockerfileTemplate := telemetryKeeperClickhouseKeeperDockerfileTemplate
-		if config.Spec.TelemetryKeeper.Kind == installation.TelemetryKeeperKindZookeeper {
-			keeperDockerfileTemplate = telemetryKeeperZookeeperDockerfileTemplate
+		keeperDockerfileTemplate := telemetryKeeperZookeeperDockerfileTemplate
+		if config.Spec.TelemetryKeeper.Kind != installation.TelemetryKeeperKindZookeeper {
+			keeperDockerfileTemplate, _ = telemetryKeeperClickhouseKeeperDockerfileTemplates.Resolve(config.Spec.TelemetryKeeper.Spec.Version)
 		}
 
 		dockerfileBuf := bytes.NewBuffer(nil)
@@ -76,7 +74,8 @@ func (c *railwayTemplateCasting) Forge(ctx context.Context, config installation.
 	// TelemetryStore: Dockerfile + configs + railway.json
 	if config.Spec.TelemetryStore.Spec.IsEnabled() {
 		dockerfileBuf := bytes.NewBuffer(nil)
-		if err := telemetryStoreDockerfileTemplate.Execute(dockerfileBuf, config); err != nil {
+		storeDockerfile, _ := telemetryStoreDockerfileTemplates.Resolve(config.Spec.TelemetryStore.Spec.Version)
+		if err := storeDockerfile.Execute(dockerfileBuf, config); err != nil {
 			return nil, errors.Wrapf(err, errors.TypeInternal, "telemetrystore dockerfile")
 		}
 		materials = append(materials, domain.NewBlobMaterial(dockerfileBuf.Bytes(), filepath.Join(casting.DeploymentDir, "telemetrystore/Dockerfile")))

--- a/internal/casting/railwaytemplatecasting/embed.go
+++ b/internal/casting/railwaytemplatecasting/embed.go
@@ -17,13 +17,17 @@ var (
 
 	// Version-stamped ClickHouse Dockerfiles, dispatched by the configured store/keeper version.
 	telemetryKeeperClickhouseKeeperDockerfilev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v2556.gotmpl", domain.FormatText)
-	telemetryKeeperClickhouseKeeperDockerfileTemplates                  = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
-		"25.5.6": telemetryKeeperClickhouseKeeperDockerfilev2556,
+	telemetryKeeperClickhouseKeeperDockerfilev25125    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v25125.gotmpl", domain.FormatText)
+	telemetryKeeperClickhouseKeeperDockerfileTemplates                  = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+		"25.5.6":  telemetryKeeperClickhouseKeeperDockerfilev2556,
+		"25.12.5": telemetryKeeperClickhouseKeeperDockerfilev25125,
 	})
 
 	telemetryStoreDockerfilev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v2556.gotmpl", domain.FormatText)
-	telemetryStoreDockerfileTemplates                  = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
-		"25.5.6": telemetryStoreDockerfilev2556,
+	telemetryStoreDockerfilev25125    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v25125.gotmpl", domain.FormatText)
+	telemetryStoreDockerfileTemplates                  = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+		"25.5.6":  telemetryStoreDockerfilev2556,
+		"25.12.5": telemetryStoreDockerfilev25125,
 	})
 
 	railwayTelemetryKeeperTemplate        *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/railway.telemetrykeeper.json.gotmpl", domain.FormatText)

--- a/internal/casting/railwaytemplatecasting/embed.go
+++ b/internal/casting/railwaytemplatecasting/embed.go
@@ -18,14 +18,14 @@ var (
 	// Version-stamped ClickHouse Dockerfiles, dispatched by the configured store/keeper version.
 	telemetryKeeperClickhouseKeeperDockerfilev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v2556.gotmpl", domain.FormatText)
 	telemetryKeeperClickhouseKeeperDockerfilev25125    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v25125.gotmpl", domain.FormatText)
-	telemetryKeeperClickhouseKeeperDockerfileTemplates                  = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+	telemetryKeeperClickhouseKeeperDockerfileTemplates                  = domain.MustNewVersionedTemplates("25.12.5", map[string]*domain.Template{
 		"25.5.6":  telemetryKeeperClickhouseKeeperDockerfilev2556,
 		"25.12.5": telemetryKeeperClickhouseKeeperDockerfilev25125,
 	})
 
 	telemetryStoreDockerfilev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v2556.gotmpl", domain.FormatText)
 	telemetryStoreDockerfilev25125    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v25125.gotmpl", domain.FormatText)
-	telemetryStoreDockerfileTemplates                  = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+	telemetryStoreDockerfileTemplates                  = domain.MustNewVersionedTemplates("25.12.5", map[string]*domain.Template{
 		"25.5.6":  telemetryStoreDockerfilev2556,
 		"25.12.5": telemetryStoreDockerfilev25125,
 	})

--- a/internal/casting/railwaytemplatecasting/embed.go
+++ b/internal/casting/railwaytemplatecasting/embed.go
@@ -10,12 +10,21 @@ import (
 var templates embed.FS
 
 var (
-	telemetryKeeperClickhouseKeeperDockerfileTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v2556.gotmpl", domain.FormatText)
-	telemetryKeeperZookeeperDockerfileTemplate        *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.zookeeper.telemetrykeeper.v371.gotmpl", domain.FormatText)
-	telemetryStoreDockerfileTemplate                  *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v2556.gotmpl", domain.FormatText)
-	ingesterDockerfileTemplate                        *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.ingester.gotmpl", domain.FormatText)
-	signozDockerfileTemplate                          *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.signoz.gotmpl", domain.FormatText)
-	telemetryStoreMigratorDockerfileTemplate          *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.telemetrystore-migrator.gotmpl", domain.FormatText)
+	telemetryKeeperZookeeperDockerfileTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.zookeeper.telemetrykeeper.v371.gotmpl", domain.FormatText)
+	ingesterDockerfileTemplate                 *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.ingester.gotmpl", domain.FormatText)
+	signozDockerfileTemplate                   *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.signoz.gotmpl", domain.FormatText)
+	telemetryStoreMigratorDockerfileTemplate   *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.telemetrystore-migrator.gotmpl", domain.FormatText)
+
+	// Version-stamped ClickHouse Dockerfiles, dispatched by the configured store/keeper version.
+	telemetryKeeperClickhouseKeeperDockerfilev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v2556.gotmpl", domain.FormatText)
+	telemetryKeeperClickhouseKeeperDockerfileTemplates                  = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
+		"25.5.6": telemetryKeeperClickhouseKeeperDockerfilev2556,
+	})
+
+	telemetryStoreDockerfilev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v2556.gotmpl", domain.FormatText)
+	telemetryStoreDockerfileTemplates                  = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
+		"25.5.6": telemetryStoreDockerfilev2556,
+	})
 
 	railwayTelemetryKeeperTemplate        *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/railway.telemetrykeeper.json.gotmpl", domain.FormatText)
 	railwayTelemetryStoreTemplate         *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/railway.telemetrystore.json.gotmpl", domain.FormatText)

--- a/internal/casting/railwaytemplatecasting/templates/Dockerfile.clickhouse.telemetrystore.v25125.gotmpl
+++ b/internal/casting/railwaytemplatecasting/templates/Dockerfile.clickhouse.telemetrystore.v25125.gotmpl
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-server:25.12.5
+FROM {{$.Spec.TelemetryStore.Spec.Image }}
 
 COPY config.d/ /etc/clickhouse-server/
 
@@ -9,6 +9,10 @@ ARG VERSION=v0.0.1
 
 ENV CLICKHOUSE_CONFIG=/etc/clickhouse-server/config-0-0.yaml
 ENV CLICKHOUSE_SKIP_USER_SETUP=1
+
+{{- range $key, $value := $.Spec.TelemetryStore.Spec.Env }}
+ENV {{ $key }}={{ $value }}
+{{- end }}
 
 # Download and install histogram-quantile binary
 RUN cat > /tmp/install-histogram-quantile.sh <<'EOF'

--- a/internal/casting/railwaytemplatecasting/templates/Dockerfile.clickhousekeeper.telemetrykeeper.v25125.gotmpl
+++ b/internal/casting/railwaytemplatecasting/templates/Dockerfile.clickhousekeeper.telemetrykeeper.v25125.gotmpl
@@ -1,7 +1,11 @@
-FROM clickhouse/clickhouse-keeper:25.12.5
+FROM {{ $.Spec.TelemetryKeeper.Spec.Image }}
 
 # Copy all keeper config files
 COPY keeper.d/ /etc/clickhouse-keeper/
+
+{{- range $key, $value := $.Spec.TelemetryKeeper.Spec.Env }}
+ENV {{ $key }}={{ $value }}
+{{- end }}
 # Create entrypoint script to dynamically select config based on replica index
 RUN cat > /entrypoint.sh <<'EOF'
 #!/bin/bash

--- a/internal/casting/rendercasting/casting.go
+++ b/internal/casting/rendercasting/casting.go
@@ -26,8 +26,6 @@ func New(logger *slog.Logger) *renderCasting {
 		logger: logger,
 		castings: []*domain.Template{
 			renderYAMLTemplate,
-			telemetryKeeperDockerfileTemplate,
-			telemetryStoreDockerfileTemplate,
 			ingesterDockerfileTemplate,
 		},
 	}
@@ -52,7 +50,8 @@ func (c *renderCasting) Forge(ctx context.Context, config installation.Casting, 
 	// straight from its image (runtime: image), so no Dockerfile is needed.
 	if config.Spec.TelemetryKeeper.Spec.IsEnabled() && config.Spec.TelemetryKeeper.Kind != installation.TelemetryKeeperKindZookeeper {
 		dockerfileBuf := bytes.NewBuffer(nil)
-		err := telemetryKeeperDockerfileTemplate.Execute(dockerfileBuf, config)
+		keeperDockerfile, _ := telemetryKeeperDockerfileTemplates.Resolve(config.Spec.TelemetryKeeper.Spec.Version)
+		err := keeperDockerfile.Execute(dockerfileBuf, config)
 		if err != nil {
 			return nil, errors.Wrapf(err, errors.TypeInternal, "failed to execute dockerfile keeper template")
 		}
@@ -72,7 +71,8 @@ func (c *renderCasting) Forge(ctx context.Context, config installation.Casting, 
 	// Add Dockerfile for telemetrystore services
 	if config.Spec.TelemetryStore.Spec.IsEnabled() {
 		dockerfileBuf := bytes.NewBuffer(nil)
-		err := telemetryStoreDockerfileTemplate.Execute(dockerfileBuf, config)
+		storeDockerfile, _ := telemetryStoreDockerfileTemplates.Resolve(config.Spec.TelemetryStore.Spec.Version)
+		err := storeDockerfile.Execute(dockerfileBuf, config)
 		if err != nil {
 			return nil, errors.Wrapf(err, errors.TypeInternal, "failed to execute dockerfile clickhouse template")
 		}

--- a/internal/casting/rendercasting/embed.go
+++ b/internal/casting/rendercasting/embed.go
@@ -10,8 +10,17 @@ import (
 var templates embed.FS
 
 var (
-	renderYAMLTemplate                *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/render.yaml.gotmpl", domain.FormatYAML)
-	telemetryKeeperDockerfileTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v2556.gotmpl", domain.FormatText)
-	telemetryStoreDockerfileTemplate  *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v2556.gotmpl", domain.FormatText)
-	ingesterDockerfileTemplate        *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.ingester.gotmpl", domain.FormatText)
+	renderYAMLTemplate         *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/render.yaml.gotmpl", domain.FormatYAML)
+	ingesterDockerfileTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.ingester.gotmpl", domain.FormatText)
+
+	// Version-stamped ClickHouse Dockerfiles, dispatched by the configured store/keeper version.
+	telemetryKeeperDockerfilev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v2556.gotmpl", domain.FormatText)
+	telemetryKeeperDockerfileTemplates                  = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
+		"25.5.6": telemetryKeeperDockerfilev2556,
+	})
+
+	telemetryStoreDockerfilev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v2556.gotmpl", domain.FormatText)
+	telemetryStoreDockerfileTemplates                  = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
+		"25.5.6": telemetryStoreDockerfilev2556,
+	})
 )

--- a/internal/casting/rendercasting/embed.go
+++ b/internal/casting/rendercasting/embed.go
@@ -16,14 +16,14 @@ var (
 	// Version-stamped ClickHouse Dockerfiles, dispatched by the configured store/keeper version.
 	telemetryKeeperDockerfilev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v2556.gotmpl", domain.FormatText)
 	telemetryKeeperDockerfilev25125    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v25125.gotmpl", domain.FormatText)
-	telemetryKeeperDockerfileTemplates                  = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+	telemetryKeeperDockerfileTemplates                  = domain.MustNewVersionedTemplates("25.12.5", map[string]*domain.Template{
 		"25.5.6":  telemetryKeeperDockerfilev2556,
 		"25.12.5": telemetryKeeperDockerfilev25125,
 	})
 
 	telemetryStoreDockerfilev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v2556.gotmpl", domain.FormatText)
 	telemetryStoreDockerfilev25125    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v25125.gotmpl", domain.FormatText)
-	telemetryStoreDockerfileTemplates                  = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+	telemetryStoreDockerfileTemplates                  = domain.MustNewVersionedTemplates("25.12.5", map[string]*domain.Template{
 		"25.5.6":  telemetryStoreDockerfilev2556,
 		"25.12.5": telemetryStoreDockerfilev25125,
 	})

--- a/internal/casting/rendercasting/embed.go
+++ b/internal/casting/rendercasting/embed.go
@@ -15,12 +15,16 @@ var (
 
 	// Version-stamped ClickHouse Dockerfiles, dispatched by the configured store/keeper version.
 	telemetryKeeperDockerfilev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v2556.gotmpl", domain.FormatText)
-	telemetryKeeperDockerfileTemplates                  = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
-		"25.5.6": telemetryKeeperDockerfilev2556,
+	telemetryKeeperDockerfilev25125    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhousekeeper.telemetrykeeper.v25125.gotmpl", domain.FormatText)
+	telemetryKeeperDockerfileTemplates                  = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+		"25.5.6":  telemetryKeeperDockerfilev2556,
+		"25.12.5": telemetryKeeperDockerfilev25125,
 	})
 
 	telemetryStoreDockerfilev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v2556.gotmpl", domain.FormatText)
-	telemetryStoreDockerfileTemplates                  = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
-		"25.5.6": telemetryStoreDockerfilev2556,
+	telemetryStoreDockerfilev25125    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/Dockerfile.clickhouse.telemetrystore.v25125.gotmpl", domain.FormatText)
+	telemetryStoreDockerfileTemplates                  = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+		"25.5.6":  telemetryStoreDockerfilev2556,
+		"25.12.5": telemetryStoreDockerfilev25125,
 	})
 )

--- a/internal/casting/rendercasting/embed_test.go
+++ b/internal/casting/rendercasting/embed_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestNotEmptyAndValid(t *testing.T) {
 	serviceTemplates := map[string]*domain.Template{
-		"telemetryKeeperDockerfileTemplate": telemetryKeeperDockerfileTemplate,
-		"telemetryStoreDockerfileTemplate":  telemetryStoreDockerfileTemplate,
-		"ingesterDockerfileTemplate":        ingesterDockerfileTemplate,
-		"renderYAMLTemplate":                renderYAMLTemplate,
+		"telemetryKeeperDockerfilev2556": telemetryKeeperDockerfilev2556,
+		"telemetryStoreDockerfilev2556":  telemetryStoreDockerfilev2556,
+		"ingesterDockerfileTemplate":     ingesterDockerfileTemplate,
+		"renderYAMLTemplate":             renderYAMLTemplate,
 	}
 
 	for name, st := range serviceTemplates {

--- a/internal/casting/rendercasting/embed_test.go
+++ b/internal/casting/rendercasting/embed_test.go
@@ -10,10 +10,12 @@ import (
 
 func TestNotEmptyAndValid(t *testing.T) {
 	serviceTemplates := map[string]*domain.Template{
-		"telemetryKeeperDockerfilev2556": telemetryKeeperDockerfilev2556,
-		"telemetryStoreDockerfilev2556":  telemetryStoreDockerfilev2556,
-		"ingesterDockerfileTemplate":     ingesterDockerfileTemplate,
-		"renderYAMLTemplate":             renderYAMLTemplate,
+		"telemetryKeeperDockerfilev2556":  telemetryKeeperDockerfilev2556,
+		"telemetryKeeperDockerfilev25125": telemetryKeeperDockerfilev25125,
+		"telemetryStoreDockerfilev2556":   telemetryStoreDockerfilev2556,
+		"telemetryStoreDockerfilev25125":  telemetryStoreDockerfilev25125,
+		"ingesterDockerfileTemplate":      ingesterDockerfileTemplate,
+		"renderYAMLTemplate":              renderYAMLTemplate,
 	}
 
 	for name, st := range serviceTemplates {

--- a/internal/casting/rendercasting/templates/Dockerfile.clickhouse.telemetrystore.v25125.gotmpl
+++ b/internal/casting/rendercasting/templates/Dockerfile.clickhouse.telemetrystore.v25125.gotmpl
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-server:25.12.5
+FROM {{$.Spec.TelemetryStore.Spec.Image }}
 
 COPY config.d/ /etc/clickhouse-server/
 

--- a/internal/casting/rendercasting/templates/Dockerfile.clickhousekeeper.telemetrykeeper.v25125.gotmpl
+++ b/internal/casting/rendercasting/templates/Dockerfile.clickhousekeeper.telemetrykeeper.v25125.gotmpl
@@ -1,14 +1,15 @@
-FROM clickhouse/clickhouse-keeper:25.12.5
+FROM {{ $.Spec.TelemetryKeeper.Spec.Image }}
 
 # Copy all keeper config files
 COPY keeper.d/ /etc/clickhouse-keeper/
+
 # Create entrypoint script to dynamically select config based on replica index
 RUN cat > /entrypoint.sh <<'EOF'
 #!/bin/bash
 set -euo pipefail
 
 # Extract replica index from service name, default to 0
-REPLICA_INDEX=$(echo "${RAILWAY_SERVICE_NAME:-}" | grep -oE "[0-9]+$" || echo "0")
+REPLICA_INDEX=$(echo "${RENDER_SERVICE_NAME:-}" | grep -oE "[0-9]+$" || echo "0")
 CONFIG_FILE="/etc/clickhouse-keeper/keeper-${REPLICA_INDEX}.yaml"
 
 # Fallback to keeper-0.yaml if replica-specific config doesn't exist

--- a/internal/casting/systemdcasting/casting.go
+++ b/internal/casting/systemdcasting/casting.go
@@ -111,9 +111,11 @@ func (c *systemdCasting) forgeTelemetryKeeper(cfg *installation.Casting) ([]doma
 		spec.Status.Extras["cfgPath"] = filepath.Join("/etc/clickhouse-keeper/", filepath.Base(cfgMats[0].Path()))
 	}
 
+	keeperSvcTmpl, _ := telemetryKeeperServiceTemplates.Resolve(spec.Spec.Version)
+
 	var materials []domain.Material
 	for r := range reps {
-		svcMat, err := c.renderTemplate(telemetryKeeperServiceTemplate, cfg, fmt.Sprintf("%s-telemetrykeeper-%s-%d%s", cfg.Metadata.Name, kind, r, svcSuffix))
+		svcMat, err := c.renderTemplate(keeperSvcTmpl, cfg, fmt.Sprintf("%s-telemetrykeeper-%s-%d%s", cfg.Metadata.Name, kind, r, svcSuffix))
 		if err != nil {
 			return nil, err
 		}
@@ -133,10 +135,12 @@ func (c *systemdCasting) forgeTelemetryStore(cfg *installation.Casting) ([]domai
 	reps := max(1, *spec.Spec.Cluster.Replicas+1)
 	shards := max(1, *spec.Spec.Cluster.Shards)
 
+	storeSvcTmpl, _ := telemetryStoreServiceTemplates.Resolve(spec.Spec.Version)
+
 	var materials []domain.Material
 	for s := range shards {
 		for r := range reps {
-			svcMat, err := c.renderTemplate(telemetryStoreServiceTemplate, cfg, fmt.Sprintf("%s-telemetrystore-%s-%d-%d%s", cfg.Metadata.Name, kind, s, r, svcSuffix))
+			svcMat, err := c.renderTemplate(storeSvcTmpl, cfg, fmt.Sprintf("%s-telemetrystore-%s-%d-%d%s", cfg.Metadata.Name, kind, s, r, svcSuffix))
 			if err != nil {
 				return nil, err
 			}

--- a/internal/casting/systemdcasting/embed.go
+++ b/internal/casting/systemdcasting/embed.go
@@ -19,14 +19,14 @@ var (
 	// Version-stamped ClickHouse units, dispatched by the configured store/keeper version.
 	telemetryStoreServicev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhouse.telemetrystore.v2556.service.gotmpl", domain.FormatINI)
 	telemetryStoreServicev25125    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhouse.telemetrystore.v25125.service.gotmpl", domain.FormatINI)
-	telemetryStoreServiceTemplates                  = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+	telemetryStoreServiceTemplates                  = domain.MustNewVersionedTemplates("25.12.5", map[string]*domain.Template{
 		"25.5.6":  telemetryStoreServicev2556,
 		"25.12.5": telemetryStoreServicev25125,
 	})
 
 	telemetryKeeperServicev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhousekeeper.telemetrykeeper.v2556.service.gotmpl", domain.FormatINI)
 	telemetryKeeperServicev25125    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhousekeeper.telemetrykeeper.v25125.service.gotmpl", domain.FormatINI)
-	telemetryKeeperServiceTemplates                  = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+	telemetryKeeperServiceTemplates                  = domain.MustNewVersionedTemplates("25.12.5", map[string]*domain.Template{
 		"25.5.6":  telemetryKeeperServicev2556,
 		"25.12.5": telemetryKeeperServicev25125,
 	})

--- a/internal/casting/systemdcasting/embed.go
+++ b/internal/casting/systemdcasting/embed.go
@@ -12,9 +12,18 @@ var templates embed.FS
 var (
 	signozServiceTemplate                 *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/signoz.service.gotmpl", domain.FormatINI)
 	ingesterServiceTemplate               *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/ingester.service.gotmpl", domain.FormatINI)
-	telemetryStoreServiceTemplate         *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhouse.telemetrystore.v2556.service.gotmpl", domain.FormatINI)
-	telemetryKeeperServiceTemplate        *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhousekeeper.telemetrykeeper.v2556.service.gotmpl", domain.FormatINI)
 	metaStoreServiceTemplate              *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/postgres.metastore.service.gotmpl", domain.FormatINI)
 	telemetryStoreMigratorServiceTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/migrator.telemetrystore.service.gotmpl", domain.FormatINI)
 	mcpServiceTemplate                    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/mcp.service.gotmpl", domain.FormatINI)
+
+	// Version-stamped ClickHouse units, dispatched by the configured store/keeper version.
+	telemetryStoreServicev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhouse.telemetrystore.v2556.service.gotmpl", domain.FormatINI)
+	telemetryStoreServiceTemplates                  = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
+		"25.5.6": telemetryStoreServicev2556,
+	})
+
+	telemetryKeeperServicev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhousekeeper.telemetrykeeper.v2556.service.gotmpl", domain.FormatINI)
+	telemetryKeeperServiceTemplates                  = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
+		"25.5.6": telemetryKeeperServicev2556,
+	})
 )

--- a/internal/casting/systemdcasting/embed.go
+++ b/internal/casting/systemdcasting/embed.go
@@ -18,12 +18,16 @@ var (
 
 	// Version-stamped ClickHouse units, dispatched by the configured store/keeper version.
 	telemetryStoreServicev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhouse.telemetrystore.v2556.service.gotmpl", domain.FormatINI)
-	telemetryStoreServiceTemplates                  = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
-		"25.5.6": telemetryStoreServicev2556,
+	telemetryStoreServicev25125    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhouse.telemetrystore.v25125.service.gotmpl", domain.FormatINI)
+	telemetryStoreServiceTemplates                  = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+		"25.5.6":  telemetryStoreServicev2556,
+		"25.12.5": telemetryStoreServicev25125,
 	})
 
 	telemetryKeeperServicev2556     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhousekeeper.telemetrykeeper.v2556.service.gotmpl", domain.FormatINI)
-	telemetryKeeperServiceTemplates                  = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
-		"25.5.6": telemetryKeeperServicev2556,
+	telemetryKeeperServicev25125    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhousekeeper.telemetrykeeper.v25125.service.gotmpl", domain.FormatINI)
+	telemetryKeeperServiceTemplates                  = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+		"25.5.6":  telemetryKeeperServicev2556,
+		"25.12.5": telemetryKeeperServicev25125,
 	})
 )

--- a/internal/casting/systemdcasting/embed_test.go
+++ b/internal/casting/systemdcasting/embed_test.go
@@ -11,7 +11,9 @@ import (
 func TestNotEmptyAndValid(t *testing.T) {
 	serviceTemplates := map[string]*domain.Template{
 		"telemetryStoreServicev2556":     telemetryStoreServicev2556,
+		"telemetryStoreServicev25125":    telemetryStoreServicev25125,
 		"telemetryKeeperServicev2556":    telemetryKeeperServicev2556,
+		"telemetryKeeperServicev25125":   telemetryKeeperServicev25125,
 		"metaStoreServiceTemplate":       metaStoreServiceTemplate,
 		"signozServiceTemplate":          signozServiceTemplate,
 		"ingesterServiceTemplate":        ingesterServiceTemplate,

--- a/internal/casting/systemdcasting/embed_test.go
+++ b/internal/casting/systemdcasting/embed_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestNotEmptyAndValid(t *testing.T) {
 	serviceTemplates := map[string]*domain.Template{
-		"telemetryStoreServiceTemplate":  telemetryStoreServiceTemplate,
-		"telemetryKeeperServiceTemplate": telemetryKeeperServiceTemplate,
+		"telemetryStoreServicev2556":     telemetryStoreServicev2556,
+		"telemetryKeeperServicev2556":    telemetryKeeperServicev2556,
 		"metaStoreServiceTemplate":       metaStoreServiceTemplate,
 		"signozServiceTemplate":          signozServiceTemplate,
 		"ingesterServiceTemplate":        ingesterServiceTemplate,

--- a/internal/casting/systemdcasting/templates/clickhouse.telemetrystore.v25125.service.gotmpl
+++ b/internal/casting/systemdcasting/templates/clickhouse.telemetrystore.v25125.service.gotmpl
@@ -1,0 +1,26 @@
+[Unit]
+Description=ClickHouse Server (v25.12.5)
+Requires=network-online.target
+After=time-sync.target network-online.target
+Wants=time-sync.target
+
+[Service]
+Type=simple
+User=clickhouse
+Group=clickhouse
+Restart=always
+RestartSec=30
+RuntimeDirectory=clickhouse
+{{- if and $.Metadata.Annotations (index $.Metadata.Annotations "foundry.signoz.io/telemetrystore-clickhouse-binary-path") }}
+{{- $clickhouseBinary := index $.Metadata.Annotations "foundry.signoz.io/telemetrystore-clickhouse-binary-path" }}
+ExecStart={{ $clickhouseBinary }} server --config=/etc/clickhouse-server/config-0-0.yaml --pid-file=/run/clickhouse/clickhouse.pid
+{{- end }}
+{{- range $key, $value := $.Spec.TelemetryStore.Spec.Env }}
+Environment={{ $key }}={{ $value }}
+{{- end }}
+LimitCORE=infinity
+LimitNOFILE=500000
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_IPC_LOCK CAP_SYS_NICE CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/casting/systemdcasting/templates/clickhousekeeper.telemetrykeeper.v25125.service.gotmpl
+++ b/internal/casting/systemdcasting/templates/clickhousekeeper.telemetrykeeper.v25125.service.gotmpl
@@ -1,0 +1,26 @@
+[Unit]
+Description=ClickHouse Keeper (v25.12.5)
+Requires=network-online.target
+After=time-sync.target network-online.target
+Wants=time-sync.target
+
+[Service]
+Type=simple
+User=clickhouse
+Group=clickhouse
+Restart=always
+RestartSec=30
+RuntimeDirectory=clickhouse-keeper
+{{- if and $.Spec.TelemetryKeeper.Status.Extras (index $.Spec.TelemetryKeeper.Status.Extras "cfgPath") }}
+{{- $keeperBinary := index $.Metadata.Annotations "foundry.signoz.io/telemetrykeeper-clickhousekeeper-binary-path" }}
+ExecStart={{ $keeperBinary }} keeper --config={{ index $.Spec.TelemetryKeeper.Status.Extras "cfgPath" }} --pid-file=/run/clickhouse-keeper/clickhouse-keeper.pid
+{{- end }}
+{{- range $key, $value := $.Spec.TelemetryKeeper.Spec.Env }}
+Environment={{ $key }}={{ $value }}
+{{- end }}
+LimitCORE=infinity
+LimitNOFILE=500000
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_IPC_LOCK CAP_SYS_NICE CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/config/yamlconfig/config_test.go
+++ b/internal/config/yamlconfig/config_test.go
@@ -39,8 +39,8 @@ spec:
 				assert.True(t, *casting.Spec.Ingester.Spec.Enabled)
 				// The default telemetrykeeper kind carries its image and version
 				assert.Equal(t, installation.TelemetryKeeperKindClickhouseKeeper, casting.Spec.TelemetryKeeper.Kind)
-				assert.Equal(t, "clickhouse/clickhouse-keeper:25.5.6", casting.Spec.TelemetryKeeper.Spec.Image)
-				assert.Equal(t, "25.5.6", casting.Spec.TelemetryKeeper.Spec.Version)
+				assert.Equal(t, "clickhouse/clickhouse-keeper:25.12.5", casting.Spec.TelemetryKeeper.Spec.Image)
+				assert.Equal(t, "25.12.5", casting.Spec.TelemetryKeeper.Spec.Version)
 			},
 		},
 		{

--- a/internal/domain/versioned_templates.go
+++ b/internal/domain/versioned_templates.go
@@ -1,0 +1,30 @@
+package domain
+
+// VersionedTemplates dispatches to a Template by a component version string. It
+// is the selection primitive for materials whose content can diverge across
+// component versions (for example, per-ClickHouse-version server configs). When
+// a requested version has no dedicated template, Resolve falls back to the
+// latest supported version, so pinning an unknown version still produces output.
+type VersionedTemplates struct {
+	latest    string
+	templates map[string]*Template
+}
+
+// NewVersionedTemplates builds a dispatch table keyed by version. latest is the
+// fallback version returned for unknown lookups and must have a template.
+func NewVersionedTemplates(latest string, templates map[string]*Template) *VersionedTemplates {
+	if _, ok := templates[latest]; !ok {
+		panic("domain: VersionedTemplates latest version " + latest + " has no template")
+	}
+	return &VersionedTemplates{latest: latest, templates: templates}
+}
+
+// Resolve returns the template for version, or the latest-version template when
+// version has no dedicated entry. The bool reports whether an exact match was
+// found, letting callers warn on fallback.
+func (vt *VersionedTemplates) Resolve(version string) (*Template, bool) {
+	if t, ok := vt.templates[version]; ok {
+		return t, true
+	}
+	return vt.templates[vt.latest], false
+}

--- a/internal/domain/versioned_templates.go
+++ b/internal/domain/versioned_templates.go
@@ -1,5 +1,7 @@
 package domain
 
+import "github.com/signoz/foundry/internal/errors"
+
 // VersionedTemplates dispatches to a Template by a component version string. It
 // is the selection primitive for materials whose content can diverge across
 // component versions (for example, per-ClickHouse-version server configs). When
@@ -12,11 +14,21 @@ type VersionedTemplates struct {
 
 // NewVersionedTemplates builds a dispatch table keyed by version. latest is the
 // fallback version returned for unknown lookups and must have a template.
-func NewVersionedTemplates(latest string, templates map[string]*Template) *VersionedTemplates {
+func NewVersionedTemplates(latest string, templates map[string]*Template) (*VersionedTemplates, error) {
 	if _, ok := templates[latest]; !ok {
-		panic("domain: VersionedTemplates latest version " + latest + " has no template")
+		return nil, errors.Newf(errors.TypeInvalidInput, "failed to create versioned templates: latest version %q has no template", latest)
 	}
-	return &VersionedTemplates{latest: latest, templates: templates}
+	return &VersionedTemplates{latest: latest, templates: templates}, nil
+}
+
+// MustNewVersionedTemplates is like NewVersionedTemplates but panics on error.
+// Use for package-level tables built from known-good literals.
+func MustNewVersionedTemplates(latest string, templates map[string]*Template) *VersionedTemplates {
+	vt, err := NewVersionedTemplates(latest, templates)
+	if err != nil {
+		panic(err)
+	}
+	return vt
 }
 
 // Resolve returns the template for version, or the latest-version template when

--- a/internal/domain/versioned_templates_test.go
+++ b/internal/domain/versioned_templates_test.go
@@ -1,0 +1,69 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionedTemplatesResolve(t *testing.T) {
+	old := MustNewTemplate("old", []byte("old"), FormatText)
+	latest := MustNewTemplate("latest", []byte("latest"), FormatText)
+	vt := MustNewVersionedTemplates("25.12.5", map[string]*Template{
+		"25.5.6":  old,
+		"25.12.5": latest,
+	})
+
+	tests := []struct {
+		name     string
+		version  string
+		expected *Template
+		exact    bool
+	}{
+		{"KnownOldVersion_ResolvesExact", "25.5.6", old, true},
+		{"KnownLatestVersion_ResolvesExact", "25.12.5", latest, true},
+		{"UnknownVersion_FallsBackToLatest", "26.0.0", latest, false},
+		{"EmptyVersion_FallsBackToLatest", "", latest, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, exact := vt.Resolve(tt.version)
+			assert.Equal(t, tt.expected, got)
+			assert.Equal(t, tt.exact, exact)
+		})
+	}
+}
+
+func TestNewVersionedTemplates(t *testing.T) {
+	tmpl := MustNewTemplate("t", []byte("t"), FormatText)
+
+	tests := []struct {
+		name      string
+		latest    string
+		templates map[string]*Template
+		pass      bool
+	}{
+		{"LatestPresent_Valid", "25.12.5", map[string]*Template{"25.12.5": tmpl}, true},
+		{"LatestMissing_Invalid", "25.12.5", map[string]*Template{"25.5.6": tmpl}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vt, err := NewVersionedTemplates(tt.latest, tt.templates)
+			if !tt.pass {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, vt)
+		})
+	}
+}
+
+func TestMustNewVersionedTemplates_PanicsOnMissingLatest(t *testing.T) {
+	tmpl := MustNewTemplate("t", []byte("t"), FormatText)
+	assert.Panics(t, func() {
+		MustNewVersionedTemplates("25.12.5", map[string]*Template{"25.5.6": tmpl})
+	})
+}

--- a/internal/molding/telemetrykeepermolding/telemetrykeeper.go
+++ b/internal/molding/telemetrykeepermolding/telemetrykeeper.go
@@ -50,12 +50,19 @@ func (molding *telemetrykeeper) moldClickhouseKeeper(ctx context.Context, config
 	// Extract enricher config overrides (applies to all keeper nodes).
 	overrides := config.Spec.TelemetryKeeper.Status.Extras["_overrides"]
 
+	// Select the keeper config template for the configured ClickHouse version.
+	version := config.Spec.TelemetryKeeper.Spec.Version
+	keeperTmpl, ok := keeperConfigTemplates.Resolve(version)
+	if !ok {
+		molding.logger.WarnContext(ctx, "no ClickHouse Keeper config template for version, using latest supported", slog.String("version", version))
+	}
+
 	// Generate per-server configs (each keeper node needs its own server_id)
 	configs := make(map[string]string, data.ServerCount)
 	for i := 0; i < data.ServerCount; i++ {
 		configBuf := bytes.NewBuffer(nil)
 		data.ServerID = i // 0-indexed, used for array indexing in template
-		if err := KeeperClickhousev2556YAML.Execute(configBuf, data); err != nil {
+		if err := keeperTmpl.Execute(configBuf, data); err != nil {
 			return foundryerrors.Wrapf(err, foundryerrors.TypeInternal, "failed to execute keeper template for server %d", data.ServerID)
 		}
 

--- a/internal/molding/telemetrykeepermolding/template.go
+++ b/internal/molding/telemetrykeepermolding/template.go
@@ -17,7 +17,7 @@ var (
 
 	// keeperConfigTemplates selects the ClickHouse Keeper config by the configured
 	// keeper version, falling back to the latest when unknown.
-	keeperConfigTemplates = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+	keeperConfigTemplates = domain.MustNewVersionedTemplates("25.12.5", map[string]*domain.Template{
 		"25.5.6":  keeperClickhousev2556YAML,
 		"25.12.5": keeperClickhousev25125YAML,
 	})

--- a/internal/molding/telemetrykeepermolding/template.go
+++ b/internal/molding/telemetrykeepermolding/template.go
@@ -12,7 +12,13 @@ import (
 var templates embed.FS
 
 var (
-	KeeperClickhousev2556YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/keeper.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
+	keeperClickhousev2556YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/keeper.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
+
+	// keeperConfigTemplates selects the ClickHouse Keeper config by the configured
+	// keeper version, falling back to the latest when unknown.
+	keeperConfigTemplates = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
+		"25.5.6": keeperClickhousev2556YAML,
+	})
 )
 
 // Data is the template data for rendering ClickHouse Keeper configs.

--- a/internal/molding/telemetrykeepermolding/template.go
+++ b/internal/molding/telemetrykeepermolding/template.go
@@ -12,12 +12,14 @@ import (
 var templates embed.FS
 
 var (
-	keeperClickhousev2556YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/keeper.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
+	keeperClickhousev2556YAML  *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/keeper.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
+	keeperClickhousev25125YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/keeper.clickhouse.v25125.yaml.gotmpl", domain.FormatYAML)
 
 	// keeperConfigTemplates selects the ClickHouse Keeper config by the configured
 	// keeper version, falling back to the latest when unknown.
-	keeperConfigTemplates = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
-		"25.5.6": keeperClickhousev2556YAML,
+	keeperConfigTemplates = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+		"25.5.6":  keeperClickhousev2556YAML,
+		"25.12.5": keeperClickhousev25125YAML,
 	})
 )
 

--- a/internal/molding/telemetrykeepermolding/template_test.go
+++ b/internal/molding/telemetrykeepermolding/template_test.go
@@ -7,5 +7,14 @@ import (
 )
 
 func TestTelemetryStore(t *testing.T) {
-	assert.NotEmpty(t, KeeperClickhousev2556YAML)
+	t.Parallel()
+
+	keeper, ok := keeperConfigTemplates.Resolve("25.5.6")
+	assert.True(t, ok)
+	assert.NotEmpty(t, keeper)
+
+	// An unknown version falls back to the latest supported template.
+	keeper, ok = keeperConfigTemplates.Resolve("0.0.0")
+	assert.False(t, ok)
+	assert.NotEmpty(t, keeper)
 }

--- a/internal/molding/telemetrykeepermolding/template_test.go
+++ b/internal/molding/telemetrykeepermolding/template_test.go
@@ -6,18 +6,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTelemetryStore(t *testing.T) {
-	t.Parallel()
-
-	// Every supported version resolves to a dedicated, non-nil template.
-	for _, version := range []string{"25.5.6", "25.12.5"} {
-		keeper, ok := keeperConfigTemplates.Resolve(version)
-		assert.True(t, ok, "keeper template should exist for %s", version)
-		assert.NotEmpty(t, keeper)
+func TestTelemetryKeeperTemplates(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		exact   bool
+	}{
+		{"Version2556_ResolvesExact", "25.5.6", true},
+		{"Version25125_ResolvesExact", "25.12.5", true},
+		{"UnknownVersion_FallsBackToLatest", "0.0.0", false},
 	}
 
-	// An unknown version falls back to the latest supported template.
-	keeper, ok := keeperConfigTemplates.Resolve("0.0.0")
-	assert.False(t, ok)
-	assert.NotEmpty(t, keeper)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keeper, ok := keeperConfigTemplates.Resolve(tt.version)
+			assert.Equal(t, tt.exact, ok)
+			assert.NotEmpty(t, keeper)
+		})
+	}
 }

--- a/internal/molding/telemetrykeepermolding/template_test.go
+++ b/internal/molding/telemetrykeepermolding/template_test.go
@@ -9,12 +9,15 @@ import (
 func TestTelemetryStore(t *testing.T) {
 	t.Parallel()
 
-	keeper, ok := keeperConfigTemplates.Resolve("25.5.6")
-	assert.True(t, ok)
-	assert.NotEmpty(t, keeper)
+	// Every supported version resolves to a dedicated, non-nil template.
+	for _, version := range []string{"25.5.6", "25.12.5"} {
+		keeper, ok := keeperConfigTemplates.Resolve(version)
+		assert.True(t, ok, "keeper template should exist for %s", version)
+		assert.NotEmpty(t, keeper)
+	}
 
 	// An unknown version falls back to the latest supported template.
-	keeper, ok = keeperConfigTemplates.Resolve("0.0.0")
+	keeper, ok := keeperConfigTemplates.Resolve("0.0.0")
 	assert.False(t, ok)
 	assert.NotEmpty(t, keeper)
 }

--- a/internal/molding/telemetrykeepermolding/templates/keeper.clickhouse.v25125.yaml.gotmpl
+++ b/internal/molding/telemetrykeepermolding/templates/keeper.clickhouse.v25125.yaml.gotmpl
@@ -1,0 +1,25 @@
+listen_host: 0.0.0.0
+logger:
+  level: information
+  console: true
+keeper_server:
+  four_letter_word_white_list: "*"
+  coordination_settings:
+    operation_timeout_ms: 10000
+    raft_logs_level: warning
+    session_timeout_ms: 30000
+    force_sync: false
+    snapshot_distance: 100000
+    snapshots_to_keep: 3
+  log_storage_path: /var/lib/clickhouse/coordination/log
+  raft_configuration:
+    server:
+    {{- range $i := until .ServerCount }}
+    {{- $addr := index $.RaftAddresses $i }}
+    - hostname: {{ $addr.Host }}
+      port: {{ $addr.Port }}
+      id: {{ $i }}
+    {{- end }}
+  server_id: {{ .ServerID }}
+  snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+  tcp_port: {{ (index .ClientAddresses .ServerID).Port }}

--- a/internal/molding/telemetrystoremolding/telemetrystore.go
+++ b/internal/molding/telemetrystoremolding/telemetrystore.go
@@ -39,8 +39,16 @@ func (molding *telemetrystore) MoldV1Alpha1(ctx context.Context, config *install
 	// Extract enricher config overrides (applies to all nodes).
 	overrides := config.Spec.TelemetryStore.Status.Extras["_overrides"]
 
+	// Select the config templates for the configured ClickHouse version.
+	version := config.Spec.TelemetryStore.Spec.Version
+	configTmpl, ok := clickhouseConfigTemplates.Resolve(version)
+	if !ok {
+		molding.logger.WarnContext(ctx, "no ClickHouse config template for version, using latest supported", slog.String("version", version))
+	}
+	functionsTmpl, _ := clickhouseFunctionsTemplates.Resolve(version)
+
 	functionBuf := bytes.NewBuffer(nil)
-	if err := FunctionsClickhousev2556YAML.Execute(functionBuf, data); err != nil {
+	if err := functionsTmpl.Execute(functionBuf, data); err != nil {
 		return foundryerrors.Wrapf(err, foundryerrors.TypeInternal, "failed to execute functions template")
 	}
 
@@ -52,7 +60,7 @@ func (molding *telemetrystore) MoldV1Alpha1(ctx context.Context, config *install
 			data.ReplicaID = r
 
 			configBuf := bytes.NewBuffer(nil)
-			if err := ConfigClickhousev2556YAML.Execute(configBuf, data); err != nil {
+			if err := configTmpl.Execute(configBuf, data); err != nil {
 				return foundryerrors.Wrapf(err, foundryerrors.TypeInternal, "failed to execute config template for shard %d replica %d", s, r)
 			}
 

--- a/internal/molding/telemetrystoremolding/template.go
+++ b/internal/molding/telemetrystoremolding/template.go
@@ -10,8 +10,21 @@ import (
 var templates embed.FS
 
 var (
-	ConfigClickhousev2556YAML    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/config.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
-	FunctionsClickhousev2556YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/functions.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
+	configClickhousev2556YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/config.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
+
+	functionsClickhousev2556YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/functions.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
+
+	// clickhouseConfigTemplates selects the per-node ClickHouse server config by
+	// the configured store version, falling back to the latest when unknown.
+	clickhouseConfigTemplates = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
+		"25.5.6": configClickhousev2556YAML,
+	})
+
+	// clickhouseFunctionsTemplates selects the ClickHouse UDF functions config by
+	// the configured store version, falling back to the latest when unknown.
+	clickhouseFunctionsTemplates = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
+		"25.5.6": functionsClickhousev2556YAML,
+	})
 )
 
 // Data is the template data for rendering ClickHouse telemetry store configs.

--- a/internal/molding/telemetrystoremolding/template.go
+++ b/internal/molding/telemetrystoremolding/template.go
@@ -18,14 +18,14 @@ var (
 
 	// clickhouseConfigTemplates selects the per-node ClickHouse server config by
 	// the configured store version, falling back to the latest when unknown.
-	clickhouseConfigTemplates = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+	clickhouseConfigTemplates = domain.MustNewVersionedTemplates("25.12.5", map[string]*domain.Template{
 		"25.5.6":  configClickhousev2556YAML,
 		"25.12.5": configClickhousev25125YAML,
 	})
 
 	// clickhouseFunctionsTemplates selects the ClickHouse UDF functions config by
 	// the configured store version, falling back to the latest when unknown.
-	clickhouseFunctionsTemplates = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+	clickhouseFunctionsTemplates = domain.MustNewVersionedTemplates("25.12.5", map[string]*domain.Template{
 		"25.5.6":  functionsClickhousev2556YAML,
 		"25.12.5": functionsClickhousev25125YAML,
 	})

--- a/internal/molding/telemetrystoremolding/template.go
+++ b/internal/molding/telemetrystoremolding/template.go
@@ -10,20 +10,24 @@ import (
 var templates embed.FS
 
 var (
-	configClickhousev2556YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/config.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
+	configClickhousev2556YAML  *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/config.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
+	configClickhousev25125YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/config.clickhouse.v25125.yaml.gotmpl", domain.FormatYAML)
 
-	functionsClickhousev2556YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/functions.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
+	functionsClickhousev2556YAML  *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/functions.clickhouse.v2556.yaml.gotmpl", domain.FormatYAML)
+	functionsClickhousev25125YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/functions.clickhouse.v25125.yaml.gotmpl", domain.FormatYAML)
 
 	// clickhouseConfigTemplates selects the per-node ClickHouse server config by
 	// the configured store version, falling back to the latest when unknown.
-	clickhouseConfigTemplates = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
-		"25.5.6": configClickhousev2556YAML,
+	clickhouseConfigTemplates = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+		"25.5.6":  configClickhousev2556YAML,
+		"25.12.5": configClickhousev25125YAML,
 	})
 
 	// clickhouseFunctionsTemplates selects the ClickHouse UDF functions config by
 	// the configured store version, falling back to the latest when unknown.
-	clickhouseFunctionsTemplates = domain.NewVersionedTemplates("25.5.6", map[string]*domain.Template{
-		"25.5.6": functionsClickhousev2556YAML,
+	clickhouseFunctionsTemplates = domain.NewVersionedTemplates("25.12.5", map[string]*domain.Template{
+		"25.5.6":  functionsClickhousev2556YAML,
+		"25.12.5": functionsClickhousev25125YAML,
 	})
 )
 

--- a/internal/molding/telemetrystoremolding/template_test.go
+++ b/internal/molding/telemetrystoremolding/template_test.go
@@ -7,6 +7,18 @@ import (
 )
 
 func TestTelemetryStore(t *testing.T) {
-	assert.NotEmpty(t, ConfigClickhousev2556YAML)
-	assert.NotEmpty(t, FunctionsClickhousev2556YAML)
+	t.Parallel()
+
+	config, ok := clickhouseConfigTemplates.Resolve("25.5.6")
+	assert.True(t, ok)
+	assert.NotEmpty(t, config)
+
+	functions, ok := clickhouseFunctionsTemplates.Resolve("25.5.6")
+	assert.True(t, ok)
+	assert.NotEmpty(t, functions)
+
+	// An unknown version falls back to the latest supported template.
+	config, ok = clickhouseConfigTemplates.Resolve("0.0.0")
+	assert.False(t, ok)
+	assert.NotEmpty(t, config)
 }

--- a/internal/molding/telemetrystoremolding/template_test.go
+++ b/internal/molding/telemetrystoremolding/template_test.go
@@ -6,22 +6,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTelemetryStore(t *testing.T) {
-	t.Parallel()
-
-	// Every supported version resolves to a dedicated, non-nil template.
-	for _, version := range []string{"25.5.6", "25.12.5"} {
-		config, ok := clickhouseConfigTemplates.Resolve(version)
-		assert.True(t, ok, "config template should exist for %s", version)
-		assert.NotEmpty(t, config)
-
-		functions, ok := clickhouseFunctionsTemplates.Resolve(version)
-		assert.True(t, ok, "functions template should exist for %s", version)
-		assert.NotEmpty(t, functions)
+func TestTelemetryStoreTemplates(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		exact   bool
+	}{
+		{"Version2556_ResolvesExact", "25.5.6", true},
+		{"Version25125_ResolvesExact", "25.12.5", true},
+		{"UnknownVersion_FallsBackToLatest", "0.0.0", false},
 	}
 
-	// An unknown version falls back to the latest supported template.
-	config, ok := clickhouseConfigTemplates.Resolve("0.0.0")
-	assert.False(t, ok)
-	assert.NotEmpty(t, config)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, ok := clickhouseConfigTemplates.Resolve(tt.version)
+			assert.Equal(t, tt.exact, ok)
+			assert.NotEmpty(t, config)
+
+			functions, ok := clickhouseFunctionsTemplates.Resolve(tt.version)
+			assert.Equal(t, tt.exact, ok)
+			assert.NotEmpty(t, functions)
+		})
+	}
 }

--- a/internal/molding/telemetrystoremolding/template_test.go
+++ b/internal/molding/telemetrystoremolding/template_test.go
@@ -9,16 +9,19 @@ import (
 func TestTelemetryStore(t *testing.T) {
 	t.Parallel()
 
-	config, ok := clickhouseConfigTemplates.Resolve("25.5.6")
-	assert.True(t, ok)
-	assert.NotEmpty(t, config)
+	// Every supported version resolves to a dedicated, non-nil template.
+	for _, version := range []string{"25.5.6", "25.12.5"} {
+		config, ok := clickhouseConfigTemplates.Resolve(version)
+		assert.True(t, ok, "config template should exist for %s", version)
+		assert.NotEmpty(t, config)
 
-	functions, ok := clickhouseFunctionsTemplates.Resolve("25.5.6")
-	assert.True(t, ok)
-	assert.NotEmpty(t, functions)
+		functions, ok := clickhouseFunctionsTemplates.Resolve(version)
+		assert.True(t, ok, "functions template should exist for %s", version)
+		assert.NotEmpty(t, functions)
+	}
 
 	// An unknown version falls back to the latest supported template.
-	config, ok = clickhouseConfigTemplates.Resolve("0.0.0")
+	config, ok := clickhouseConfigTemplates.Resolve("0.0.0")
 	assert.False(t, ok)
 	assert.NotEmpty(t, config)
 }

--- a/internal/molding/telemetrystoremolding/templates/config.clickhouse.v25125.yaml.gotmpl
+++ b/internal/molding/telemetrystoremolding/templates/config.clickhouse.v25125.yaml.gotmpl
@@ -1,0 +1,104 @@
+path: /var/lib/clickhouse/
+tmp_path: /var/lib/clickhouse/tmp/
+user_files_path: /var/lib/clickhouse/user_files/
+format_schema_path: /var/lib/clickhouse/format_schemas/
+dictionaries_config: '*_dictionary.xml'
+display_name: cluster
+distributed_ddl:
+    path: /clickhouse/task_queue/ddl
+http_port: 8123
+interserver_http_port: 9009
+listen_host: 0.0.0.0
+logger:
+    console: 1
+    count: 10
+    formatting:
+        type: console
+    level: information
+    size: 1000M
+macros:
+    replica: "{{ printf "%02d" .ReplicaID }}"
+    shard: "{{ printf "%02d" .ShardID }}"
+profiles:
+    default:
+        allow_simdjson: 0
+        load_balancing: random
+        log_queries: 1
+quotas:
+    default:
+        interval:
+            duration: 3600
+            errors: 0
+            execution_time: 0
+            queries: 0
+            read_rows: 0
+            result_rows: 0
+user_directories:
+  users_xml:
+    path: users.xml
+remote_servers:
+  cluster:
+    shard:
+{{- range $s := until .ShardCount }}
+    - replica:
+    {{- range $r := until $.ReplicaCount }}
+    {{- $idx := add (mul $s $.ReplicaCount) $r }}
+    {{- $addr := index $.StoreAddresses $idx }}
+          - host: {{ $addr.Host }}
+            port: {{ $addr.Port }}
+{{- end }}
+{{- end }}
+zookeeper:
+  node:
+{{- range $i, $addr := .KeeperAddresses }}
+    - host: {{ $addr.Host }}
+      port: {{ $addr.Port }}
+{{- end }}
+query_log:
+    flush_interval_milliseconds: 30000
+    partition_by: toYYYYMM(event_date)
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+query_thread_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+query_metric_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+query_views_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+part_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+metric_log:
+    flush_interval_milliseconds: 30000
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+asynchronous_metric_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+trace_log:
+    flush_interval_milliseconds: 30000
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+error_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+latency_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+processors_profile_log:
+    flush_interval_milliseconds: 30000
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+session_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+text_log:
+    flush_interval_milliseconds: 30000
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+zookeeper_log:
+    ttl: "event_date + INTERVAL 1 DAY DELETE"
+tcp_port: 9000
+user_defined_executable_functions_config: '*function.yaml'
+user_scripts_path: /var/lib/clickhouse/user_scripts/
+users:
+    default:
+        access_management: 1
+        named_collection_control: 1
+        networks:
+            ip: ::/0
+        password: ""
+        profile: default
+        quota: default
+        show_named_collection: 1
+        show_named_collection_secrets: 1

--- a/internal/molding/telemetrystoremolding/templates/functions.clickhouse.v25125.yaml.gotmpl
+++ b/internal/molding/telemetrystoremolding/templates/functions.clickhouse.v25125.yaml.gotmpl
@@ -1,0 +1,13 @@
+functions:
+  argument:
+      - name: buckets
+        type: Array(Float64)
+      - name: counts
+        type: Array(Float64)
+      - name: quantile
+        type: Array(Float64)
+  command: ./histogramQuantile
+  format: CSV
+  name: histogramQuantile
+  return_type: Float64
+  type: executable


### PR DESCRIPTION
Bumps the default ClickHouse to `25.12.5` and introduces version-keyed template dispatch so the generated ClickHouse config tracks the version declared in the casting. `25.5.6` stays selectable and an unpinned/unknown version falls back to the latest supported.

#### Features

- Default ClickHouse is now `25.12.5` across the telemetry store and keeper, the standalone image, and docs; example pours regenerated.
- ClickHouse materials are selected by the configured version: the store/keeper configs, systemd units, and render/railway Dockerfiles are chosen from `spec.telemetrystore.spec.version` / `spec.telemetrykeeper.spec.version`. Pinning a version renders that version's materials; an unknown version falls back to the latest. `25.5.6` remains selectable.



#### Note

Ingester (`signoz-otel-collector`) ↔ ClickHouse version compatibility is intentionally out of scope here. The default collector (`latest`) is compatible with `25.12.5`; anyone staying on `25.5.6` must pin the collector below the incompatible release (`v0.144.6`). Enforcing that pairing will be handled separately.

Related: https://github.com/SigNoz/platform-pod/issues/2569
