### PR TITLE
fix(clickhouse-keeper): use /var/lib/clickhouse-keeper in config

### DIFF
--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -376,14 +376,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
       enabled: true
       image: clickhouse/clickhouse-keeper:25.12.5
@@ -410,14 +410,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
   telemetrystore:
     kind: clickhouse

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -266,14 +266,14 @@ services:
             force_sync: false
             snapshot_distance: 100000
             snapshots_to_keep: 3
-          log_storage_path: /var/lib/clickhouse/coordination/log
+          log_storage_path: /var/lib/clickhouse-keeper/coordination/log
           raft_configuration:
             server:
             - hostname: signoz-telemetrykeeper-clickhousekeeper-0
               port: 9234
               id: 0
           server_id: 0
-          snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+          snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
           tcp_port: 9181
       source: ./configs/telemetrykeeper/keeper-0.yaml
       target: /etc/clickhouse-keeper/keeper.yaml

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -376,14 +376,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
       enabled: true
       image: clickhouse/clickhouse-keeper:25.12.5
@@ -410,14 +410,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
   telemetrystore:
     kind: clickhouse

--- a/docs/examples/docker/compose/pours/deployment/telemetrykeeper/clickhousekeeper/keeper-0.yaml
+++ b/docs/examples/docker/compose/pours/deployment/telemetrykeeper/clickhousekeeper/keeper-0.yaml
@@ -7,14 +7,14 @@ keeper_server:
     snapshot_distance: 100000
     snapshots_to_keep: 3
   four_letter_word_white_list: '*'
-  log_storage_path: /var/lib/clickhouse/coordination/log
+  log_storage_path: /var/lib/clickhouse-keeper/coordination/log
   raft_configuration:
     server:
     - hostname: signoz-telemetrykeeper-clickhousekeeper-0
       id: 0
       port: 9234
   server_id: 0
-  snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+  snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
   tcp_port: 9181
 listen_host: 0.0.0.0
 logger:

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -376,14 +376,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
       enabled: true
       image: clickhouse/clickhouse-keeper:25.12.5
@@ -410,14 +410,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
   telemetrystore:
     kind: clickhouse

--- a/docs/examples/docker/swarm/pours/deployment/telemetrykeeper/clickhousekeeper/keeper-0.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/telemetrykeeper/clickhousekeeper/keeper-0.yaml
@@ -7,14 +7,14 @@ keeper_server:
     snapshot_distance: 100000
     snapshots_to_keep: 3
   four_letter_word_white_list: '*'
-  log_storage_path: /var/lib/clickhouse/coordination/log
+  log_storage_path: /var/lib/clickhouse-keeper/coordination/log
   raft_configuration:
     server:
     - hostname: signoz-telemetrykeeper-clickhousekeeper-0
       id: 0
       port: 9234
   server_id: 0
-  snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+  snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
   tcp_port: 9181
 listen_host: 0.0.0.0
 logger:

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -375,14 +375,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: telemetrykeeper-clickhousekeeper.signoz.local
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
       enabled: true
       image: clickhouse/clickhouse-keeper:25.12.5
@@ -409,14 +409,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: telemetrykeeper-clickhousekeeper.signoz.local
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
   telemetrystore:
     kind: clickhouse

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrykeeper/clickhousekeeper/keeper-0.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrykeeper/clickhousekeeper/keeper-0.yaml
@@ -7,14 +7,14 @@ keeper_server:
     snapshot_distance: 100000
     snapshots_to_keep: 3
   four_letter_word_white_list: '*'
-  log_storage_path: /var/lib/clickhouse/coordination/log
+  log_storage_path: /var/lib/clickhouse-keeper/coordination/log
   raft_configuration:
     server:
     - hostname: telemetrykeeper-clickhousekeeper.signoz.local
       id: 0
       port: 9234
   server_id: 0
-  snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+  snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
   tcp_port: 9181
 listen_host: 0.0.0.0
 logger:

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -373,14 +373,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: signoz-telemetrykeeper-zookeeper-0
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
       enabled: true
       image: clickhouse/clickhouse-keeper:25.12.5
@@ -407,14 +407,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: signoz-telemetrykeeper-zookeeper-0
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
   telemetrystore:
     kind: clickhouse

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -373,14 +373,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: signoz-clickhouse-keeper-0
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
       enabled: true
       image: clickhouse/clickhouse-keeper:25.12.5
@@ -407,14 +407,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: signoz-clickhouse-keeper-0
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
   telemetrystore:
     kind: clickhouse

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -371,14 +371,14 @@ spec:
               http_control:
                 endpoint: /ready
                 port: 9182
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: localhost
                   id: 0
                   port: 9234
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
             listen_host: '::'
             logger:
@@ -408,14 +408,14 @@ spec:
               http_control:
                 endpoint: /ready
                 port: 9182
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: localhost
                   id: 0
                   port: 9234
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
             listen_host: '::'
             logger:

--- a/docs/examples/railway/template/pours/deployment/telemetrykeeper/keeper.d/keeper-0.yaml
+++ b/docs/examples/railway/template/pours/deployment/telemetrykeeper/keeper.d/keeper-0.yaml
@@ -10,14 +10,14 @@ keeper_server:
   http_control:
     endpoint: /ready
     port: 9182
-  log_storage_path: /var/lib/clickhouse/coordination/log
+  log_storage_path: /var/lib/clickhouse-keeper/coordination/log
   raft_configuration:
     server:
     - hostname: localhost
       id: 0
       port: 9234
   server_id: 0
-  snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+  snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
   tcp_port: 9181
 listen_host: '::'
 logger:

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -372,14 +372,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
       enabled: true
       image: clickhouse/clickhouse-keeper:25.12.5
@@ -406,14 +406,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: signoz-telemetrykeeper-clickhousekeeper-0
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
       extras:
         service_names: signoz-telemetrykeeper-clickhousekeeper-0

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrykeeper/keeper.d/keeper-0.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrykeeper/keeper.d/keeper-0.yaml
@@ -7,14 +7,14 @@ keeper_server:
     snapshot_distance: 100000
     snapshots_to_keep: 3
   four_letter_word_white_list: '*'
-  log_storage_path: /var/lib/clickhouse/coordination/log
+  log_storage_path: /var/lib/clickhouse-keeper/coordination/log
   raft_configuration:
     server:
     - hostname: signoz-telemetrykeeper-clickhousekeeper-0
       id: 0
       port: 9234
   server_id: 0
-  snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+  snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
   tcp_port: 9181
 listen_host: 0.0.0.0
 logger:

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -388,14 +388,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: localhost
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
       enabled: true
       image: clickhouse/clickhouse-keeper:25.12.5
@@ -422,14 +422,14 @@ spec:
                 force_sync: false
                 snapshot_distance: 100000
                 snapshots_to_keep: 3
-              log_storage_path: /var/lib/clickhouse/coordination/log
+              log_storage_path: /var/lib/clickhouse-keeper/coordination/log
               raft_configuration:
                 server:
                 - hostname: localhost
                   port: 9234
                   id: 0
               server_id: 0
-              snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+              snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
               tcp_port: 9181
   telemetrystore:
     kind: clickhouse

--- a/docs/examples/systemd/binary/pours/deployment/telemetrykeeper/clickhousekeeper/keeper-0.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/telemetrykeeper/clickhousekeeper/keeper-0.yaml
@@ -7,14 +7,14 @@ keeper_server:
     snapshot_distance: 100000
     snapshots_to_keep: 3
   four_letter_word_white_list: '*'
-  log_storage_path: /var/lib/clickhouse/coordination/log
+  log_storage_path: /var/lib/clickhouse-keeper/coordination/log
   raft_configuration:
     server:
     - hostname: localhost
       id: 0
       port: 9234
   server_id: 0
-  snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+  snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
   tcp_port: 9181
 listen_host: 0.0.0.0
 logger:

--- a/internal/molding/telemetrykeepermolding/templates/keeper.clickhouse.v25125.yaml.gotmpl
+++ b/internal/molding/telemetrykeepermolding/templates/keeper.clickhouse.v25125.yaml.gotmpl
@@ -11,7 +11,7 @@ keeper_server:
     force_sync: false
     snapshot_distance: 100000
     snapshots_to_keep: 3
-  log_storage_path: /var/lib/clickhouse/coordination/log
+  log_storage_path: /var/lib/clickhouse-keeper/coordination/log
   raft_configuration:
     server:
     {{- range $i := until .ServerCount }}
@@ -21,5 +21,5 @@ keeper_server:
       id: {{ $i }}
     {{- end }}
   server_id: {{ .ServerID }}
-  snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+  snapshot_storage_path: /var/lib/clickhouse-keeper/coordination/snapshots
   tcp_port: {{ (index .ClientAddresses .ServerID).Port }}


### PR DESCRIPTION
Fix telemetrykeeper molding to output the same path for log_storage_path and snapshot_storage_path as was used in castings.

#### Fixes

- telemetrykeeper path to match the one used in volumes and mounts in all castings
