### PR TITLE
fix(foundryctl): user settings override

### DIFF
--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -449,20 +449,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -513,17 +499,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -538,6 +513,32 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1
       enabled: true
       image: clickhouse/clickhouse-server:25.12.5
       version: 25.12.5
@@ -569,20 +570,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -633,17 +620,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -658,3 +634,29 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -332,20 +332,6 @@ services:
         macros:
             replica: "00"
             shard: "00"
-        profiles:
-            default:
-                allow_simdjson: 0
-                load_balancing: random
-                log_queries: 1
-        quotas:
-            default:
-                interval:
-                    duration: 3600
-                    errors: 0
-                    execution_time: 0
-                    queries: 0
-                    read_rows: 0
-                    result_rows: 0
         user_directories:
           users_xml:
             path: users.xml
@@ -396,17 +382,6 @@ services:
         tcp_port: 9000
         user_defined_executable_functions_config: '*function.yaml'
         user_scripts_path: /var/lib/clickhouse/user_scripts/
-        users:
-            default:
-                access_management: 1
-                named_collection_control: 1
-                networks:
-                    ip: ::/0
-                password: ""
-                profile: default
-                quota: default
-                show_named_collection: 1
-                show_named_collection_secrets: 1
       source: ./configs/telemetrystore/config-0-0.yaml
       target: /etc/clickhouse-server/config.yaml
       type: bind
@@ -426,6 +401,35 @@ services:
           type: executable
       source: ./configs/telemetrystore/functions.yaml
       target: /etc/clickhouse-server/functions.yaml
+      type: bind
+    - content: |
+        profiles:
+            default:
+                allow_simdjson: 0
+                load_balancing: random
+                log_queries: 1
+        quotas:
+            default:
+                interval:
+                    duration: 3600
+                    errors: 0
+                    execution_time: 0
+                    queries: 0
+                    read_rows: 0
+                    result_rows: 0
+        users:
+            default:
+                access_management: 1
+                named_collection_control: 1
+                networks:
+                    ip: ::/0
+                password: ""
+                profile: default
+                quota: default
+                show_named_collection: 1
+                show_named_collection_secrets: 1
+      source: ./configs/telemetrystore/users.yaml
+      target: /etc/clickhouse-server/users.d/users.yaml
       type: bind
   signoz-telemetrystore-clickhouse-user-scripts:
     command:

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -449,20 +449,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -513,17 +499,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -538,6 +513,32 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1
       enabled: true
       image: clickhouse/clickhouse-server:25.12.5
       version: 25.12.5
@@ -569,20 +570,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -633,17 +620,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -658,3 +634,29 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1

--- a/docs/examples/docker/compose/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose/pours/deployment/compose.yaml
@@ -126,6 +126,7 @@ services:
     - signoz-telemetrystore-user-scripts:/var/lib/clickhouse/user_scripts:ro
     - ./telemetrystore/clickhouse/config-0-0.yaml:/etc/clickhouse-server/config.yaml:ro
     - ./telemetrystore/clickhouse/functions.yaml:/etc/clickhouse-server/functions.yaml:ro
+    - ./telemetrystore/clickhouse/users.yaml:/etc/clickhouse-server/users.d/users.yaml:ro
   signoz-telemetrystore-clickhouse-user-scripts:
     command:
     - bash

--- a/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -31,11 +31,6 @@ path: /var/lib/clickhouse/
 processors_profile_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-profiles:
-  default:
-    allow_simdjson: 0
-    load_balancing: random
-    log_queries: 1
 query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
@@ -46,15 +41,6 @@ query_thread_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 query_views_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
-quotas:
-  default:
-    interval:
-      duration: 3600
-      errors: 0
-      execution_time: 0
-      queries: 0
-      read_rows: 0
-      result_rows: 0
 remote_servers:
   cluster:
     shard:
@@ -77,17 +63,6 @@ user_directories:
     path: users.xml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
-users:
-  default:
-    access_management: 1
-    named_collection_control: 1
-    networks:
-      ip: ::/0
-    password: ""
-    profile: default
-    quota: default
-    show_named_collection: 1
-    show_named_collection_secrets: 1
 zookeeper:
   node:
   - host: signoz-telemetrykeeper-clickhousekeeper-0

--- a/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/users.yaml
+++ b/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/users.yaml
@@ -1,0 +1,25 @@
+profiles:
+  default:
+    allow_simdjson: 0
+    load_balancing: random
+    log_queries: 1
+quotas:
+  default:
+    interval:
+      duration: 3600
+      errors: 0
+      execution_time: 0
+      queries: 0
+      read_rows: 0
+      result_rows: 0
+users:
+  default:
+    access_management: 1
+    named_collection_control: 1
+    networks:
+      ip: ::/0
+    password: ""
+    profile: default
+    quota: default
+    show_named_collection: 1
+    show_named_collection_secrets: 1

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -449,20 +449,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -513,17 +499,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -538,6 +513,32 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1
       enabled: true
       image: clickhouse/clickhouse-server:25.12.5
       version: 25.12.5
@@ -569,20 +570,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -633,17 +620,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -658,3 +634,29 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1

--- a/docs/examples/docker/swarm/pours/deployment/compose.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/compose.yaml
@@ -9,6 +9,8 @@ configs:
     file: telemetrystore/clickhouse/config-0-0.yaml
   telemetrystore-functions:
     file: telemetrystore/clickhouse/functions.yaml
+  telemetrystore-users:
+    file: telemetrystore/clickhouse/users.yaml
 networks:
   signoz-network:
     attachable: true
@@ -122,6 +124,8 @@ services:
       target: /etc/clickhouse-server/config.yaml
     - source: telemetrystore-functions
       target: /etc/clickhouse-server/functions.yaml
+    - source: telemetrystore-users
+      target: /etc/clickhouse-server/users.d/users.yaml
     deploy:
       restart_policy:
         condition: on-failure

--- a/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -31,11 +31,6 @@ path: /var/lib/clickhouse/
 processors_profile_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-profiles:
-  default:
-    allow_simdjson: 0
-    load_balancing: random
-    log_queries: 1
 query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
@@ -46,15 +41,6 @@ query_thread_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 query_views_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
-quotas:
-  default:
-    interval:
-      duration: 3600
-      errors: 0
-      execution_time: 0
-      queries: 0
-      read_rows: 0
-      result_rows: 0
 remote_servers:
   cluster:
     shard:
@@ -77,17 +63,6 @@ user_directories:
     path: users.xml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
-users:
-  default:
-    access_management: 1
-    named_collection_control: 1
-    networks:
-      ip: ::/0
-    password: ""
-    profile: default
-    quota: default
-    show_named_collection: 1
-    show_named_collection_secrets: 1
 zookeeper:
   node:
   - host: signoz-telemetrykeeper-clickhousekeeper-0

--- a/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/users.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/users.yaml
@@ -1,0 +1,25 @@
+profiles:
+  default:
+    allow_simdjson: 0
+    load_balancing: random
+    log_queries: 1
+quotas:
+  default:
+    interval:
+      duration: 3600
+      errors: 0
+      execution_time: 0
+      queries: 0
+      read_rows: 0
+      result_rows: 0
+users:
+  default:
+    access_management: 1
+    named_collection_control: 1
+    networks:
+      ip: ::/0
+    password: ""
+    profile: default
+    quota: default
+    show_named_collection: 1
+    show_named_collection_secrets: 1

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -448,20 +448,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -512,17 +498,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -537,6 +512,32 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1
       enabled: true
       image: clickhouse/clickhouse-server:25.12.5
       version: 25.12.5
@@ -568,20 +569,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -632,17 +619,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -657,3 +633,29 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore.tf.json
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore.tf.json
@@ -37,6 +37,8 @@
         "image": "clickhouse/clickhouse-server:25.12.5",
         "essential": true,
         "environment": [{"name":"CLICKHOUSE_SKIP_USER_SETUP","value":"1"}],
+        "entryPoint": ["/bin/sh", "-c"],
+        "command": ["mkdir -p /etc/clickhouse-server/users.d && if [ -f /etc/clickhouse-server/config.d/users.yaml ]; then mv /etc/clickhouse-server/config.d/users.yaml /etc/clickhouse-server/users.d/users.yaml; fi; exec /entrypoint.sh"],
         "portMappings": [
           {"name": "native", "containerPort": 9000, "protocol": "tcp"},
           {"name": "http", "containerPort": 8123, "protocol": "tcp", "appProtocol": "http"},

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config-0-0.yaml
@@ -31,11 +31,6 @@ path: /var/lib/clickhouse/
 processors_profile_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-profiles:
-  default:
-    allow_simdjson: 0
-    load_balancing: random
-    log_queries: 1
 query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
@@ -46,15 +41,6 @@ query_thread_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 query_views_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
-quotas:
-  default:
-    interval:
-      duration: 3600
-      errors: 0
-      execution_time: 0
-      queries: 0
-      read_rows: 0
-      result_rows: 0
 remote_servers:
   cluster:
     shard:
@@ -77,17 +63,6 @@ user_directories:
     path: users.xml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
-users:
-  default:
-    access_management: 1
-    named_collection_control: 1
-    networks:
-      ip: ::/0
-    password: ""
-    profile: default
-    quota: default
-    show_named_collection: 1
-    show_named_collection_secrets: 1
 zookeeper:
   node:
   - host: telemetrykeeper-clickhousekeeper.signoz.local

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/users.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/users.yaml
@@ -1,0 +1,25 @@
+profiles:
+  default:
+    allow_simdjson: 0
+    load_balancing: random
+    log_queries: 1
+quotas:
+  default:
+    interval:
+      duration: 3600
+      errors: 0
+      execution_time: 0
+      queries: 0
+      read_rows: 0
+      result_rows: 0
+users:
+  default:
+    access_management: 1
+    named_collection_control: 1
+    networks:
+      ip: ::/0
+    password: ""
+    profile: default
+    quota: default
+    show_named_collection: 1
+    show_named_collection_secrets: 1

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -446,20 +446,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -510,17 +496,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -535,6 +510,32 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1
       enabled: true
       image: clickhouse/clickhouse-server:25.12.5
       version: 25.12.5
@@ -566,20 +567,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -630,17 +617,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -655,3 +631,29 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -479,9 +479,6 @@ spec:
               default:
                 allow_experimental_window_functions: "1"
                 allow_nondeterministic_mutations: "1"
-                allow_simdjson: 0
-                load_balancing: random
-                log_queries: 1
                 max_threads: 16
                 query_plan_max_limit_for_lazy_materialization: "0"
                 secondary_indices_enable_bulk_filtering: "0"
@@ -498,15 +495,6 @@ spec:
               ttl: event_date + INTERVAL 1 DAY DELETE
             query_views_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
-            quotas:
-              default:
-                interval:
-                  duration: 3600
-                  errors: 0
-                  execution_time: 0
-                  queries: 0
-                  read_rows: 0
-                  result_rows: 0
             remote_servers:
               cluster:
                 shard:
@@ -559,16 +547,6 @@ spec:
                 password: 27ff0399-0d3a-4bd8-919d-17c2181e6fb9
                 profile: default
                 quota: default
-              default:
-                access_management: 1
-                named_collection_control: 1
-                networks:
-                  ip: ::/0
-                password: ""
-                profile: default
-                quota: default
-                show_named_collection: 1
-                show_named_collection_secrets: 1
             zookeeper:
               node:
               - host: signoz-clickhouse-keeper-0
@@ -589,6 +567,32 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1
       enabled: true
       image: clickhouse/clickhouse-server:25.12.5
       version: 25.12.5
@@ -653,9 +657,6 @@ spec:
               default:
                 allow_experimental_window_functions: "1"
                 allow_nondeterministic_mutations: "1"
-                allow_simdjson: 0
-                load_balancing: random
-                log_queries: 1
                 max_threads: 16
                 query_plan_max_limit_for_lazy_materialization: "0"
                 secondary_indices_enable_bulk_filtering: "0"
@@ -672,15 +673,6 @@ spec:
               ttl: event_date + INTERVAL 1 DAY DELETE
             query_views_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
-            quotas:
-              default:
-                interval:
-                  duration: 3600
-                  errors: 0
-                  execution_time: 0
-                  queries: 0
-                  read_rows: 0
-                  result_rows: 0
             remote_servers:
               cluster:
                 shard:
@@ -733,16 +725,6 @@ spec:
                 password: 27ff0399-0d3a-4bd8-919d-17c2181e6fb9
                 profile: default
                 quota: default
-              default:
-                access_management: 1
-                named_collection_control: 1
-                networks:
-                  ip: ::/0
-                password: ""
-                profile: default
-                quota: default
-                show_named_collection: 1
-                show_named_collection_secrets: 1
             zookeeper:
               node:
               - host: signoz-clickhouse-keeper-0
@@ -763,6 +745,32 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1
       extras:
         _overrides: |
           async_load_databases: false

--- a/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
@@ -121,17 +121,9 @@ spec:
           string elements_chain = 8;
         }
     profiles:
-      admin/max_threads: 16
-      admin/query_plan_max_limit_for_lazy_materialization: "0"
-      admin/secondary_indices_enable_bulk_filtering: "0"
-      default/allow_experimental_window_functions: "1"
-      default/allow_nondeterministic_mutations: "1"
       default/allow_simdjson: 0
       default/load_balancing: random
       default/log_queries: 1
-      default/max_threads: 16
-      default/query_plan_max_limit_for_lazy_materialization: "0"
-      default/secondary_indices_enable_bulk_filtering: "0"
     quotas:
       default/interval/duration: 3600
       default/interval/errors: 0
@@ -140,16 +132,6 @@ spec:
       default/interval/read_rows: 0
       default/interval/result_rows: 0
     users:
-      admin/networks/ip:
-      - 10.0.0.0/8
-      - 100.64.0.0/10
-      - 172.16.0.0/12
-      - 192.0.0.0/24
-      - 198.18.0.0/15
-      - 192.168.0.0/16
-      admin/password: 27ff0399-0d3a-4bd8-919d-17c2181e6fb9
-      admin/profile: default
-      admin/quota: default
       default/access_management: 1
       default/named_collection_control: 1
       default/networks/ip: ::/0

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -476,11 +476,6 @@ spec:
             processors_profile_log:
               flush_interval_milliseconds: 30000
               ttl: event_date + INTERVAL 1 DAY DELETE
-            profiles:
-              default:
-                allow_simdjson: 0
-                load_balancing: random
-                log_queries: 1
             query_log:
               flush_interval_milliseconds: 30000
               partition_by: toYYYYMM(event_date)
@@ -491,15 +486,6 @@ spec:
               ttl: event_date + INTERVAL 1 DAY DELETE
             query_views_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
-            quotas:
-              default:
-                interval:
-                  duration: 3600
-                  errors: 0
-                  execution_time: 0
-                  queries: 0
-                  read_rows: 0
-                  result_rows: 0
             remote_servers:
               cluster:
                 shard:
@@ -522,17 +508,6 @@ spec:
                 path: users.xml
             user_files_path: /var/lib/clickhouse/user_files/
             user_scripts_path: /etc/clickhouse-server/user_scripts/
-            users:
-              default:
-                access_management: 1
-                named_collection_control: 1
-                networks:
-                  ip: ::/0
-                password: ""
-                profile: default
-                quota: default
-                show_named_collection: 1
-                show_named_collection_secrets: 1
             zookeeper:
               node:
               - host: signoz-telemetrykeeper-clickhousekeeper.railway.internal
@@ -553,6 +528,32 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1
       enabled: true
       image: clickhouse/clickhouse-server:25.12.5
       version: 25.12.5
@@ -596,11 +597,6 @@ spec:
             processors_profile_log:
               flush_interval_milliseconds: 30000
               ttl: event_date + INTERVAL 1 DAY DELETE
-            profiles:
-              default:
-                allow_simdjson: 0
-                load_balancing: random
-                log_queries: 1
             query_log:
               flush_interval_milliseconds: 30000
               partition_by: toYYYYMM(event_date)
@@ -611,15 +607,6 @@ spec:
               ttl: event_date + INTERVAL 1 DAY DELETE
             query_views_log:
               ttl: event_date + INTERVAL 1 DAY DELETE
-            quotas:
-              default:
-                interval:
-                  duration: 3600
-                  errors: 0
-                  execution_time: 0
-                  queries: 0
-                  read_rows: 0
-                  result_rows: 0
             remote_servers:
               cluster:
                 shard:
@@ -642,17 +629,6 @@ spec:
                 path: users.xml
             user_files_path: /var/lib/clickhouse/user_files/
             user_scripts_path: /etc/clickhouse-server/user_scripts/
-            users:
-              default:
-                access_management: 1
-                named_collection_control: 1
-                networks:
-                  ip: ::/0
-                password: ""
-                profile: default
-                quota: default
-                show_named_collection: 1
-                show_named_collection_secrets: 1
             zookeeper:
               node:
               - host: signoz-telemetrykeeper-clickhousekeeper.railway.internal
@@ -673,6 +649,32 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1
       extras:
         _overrides: |
           listen_host: '::'

--- a/docs/examples/railway/template/pours/deployment/telemetrystore/Dockerfile
+++ b/docs/examples/railway/template/pours/deployment/telemetrystore/Dockerfile
@@ -2,6 +2,11 @@ FROM clickhouse/clickhouse-server:25.12.5
 
 COPY config.d/ /etc/clickhouse-server/
 
+# Relocate the users/profiles/quotas overlay into users.d/ so ClickHouse merges
+# it over the image's stock users.xml (the config.d COPY lands it flat otherwise).
+RUN mkdir -p /etc/clickhouse-server/users.d \
+    && mv /etc/clickhouse-server/users.yaml /etc/clickhouse-server/users.d/users.yaml
+
 RUN mkdir -p /etc/clickhouse-server/user_scripts/ \
     && chown clickhouse:clickhouse /etc/clickhouse-server/user_scripts
 

--- a/docs/examples/railway/template/pours/deployment/telemetrystore/Dockerfile
+++ b/docs/examples/railway/template/pours/deployment/telemetrystore/Dockerfile
@@ -2,8 +2,6 @@ FROM clickhouse/clickhouse-server:25.12.5
 
 COPY config.d/ /etc/clickhouse-server/
 
-# Relocate the users/profiles/quotas overlay into users.d/ so ClickHouse merges
-# it over the image's stock users.xml (the config.d COPY lands it flat otherwise).
 RUN mkdir -p /etc/clickhouse-server/users.d \
     && mv /etc/clickhouse-server/users.yaml /etc/clickhouse-server/users.d/users.yaml
 

--- a/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config-0-0.yaml
+++ b/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config-0-0.yaml
@@ -31,11 +31,6 @@ path: /var/lib/clickhouse/
 processors_profile_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-profiles:
-  default:
-    allow_simdjson: 0
-    load_balancing: random
-    log_queries: 1
 query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
@@ -46,15 +41,6 @@ query_thread_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 query_views_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
-quotas:
-  default:
-    interval:
-      duration: 3600
-      errors: 0
-      execution_time: 0
-      queries: 0
-      read_rows: 0
-      result_rows: 0
 remote_servers:
   cluster:
     shard:
@@ -77,17 +63,6 @@ user_directories:
     path: users.xml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /etc/clickhouse-server/user_scripts/
-users:
-  default:
-    access_management: 1
-    named_collection_control: 1
-    networks:
-      ip: ::/0
-    password: ""
-    profile: default
-    quota: default
-    show_named_collection: 1
-    show_named_collection_secrets: 1
 zookeeper:
   node:
   - host: signoz-telemetrykeeper-clickhousekeeper.railway.internal

--- a/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/users.yaml
+++ b/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/users.yaml
@@ -1,0 +1,25 @@
+profiles:
+  default:
+    allow_simdjson: 0
+    load_balancing: random
+    log_queries: 1
+quotas:
+  default:
+    interval:
+      duration: 3600
+      errors: 0
+      execution_time: 0
+      queries: 0
+      read_rows: 0
+      result_rows: 0
+users:
+  default:
+    access_management: 1
+    named_collection_control: 1
+    networks:
+      ip: ::/0
+    password: ""
+    profile: default
+    quota: default
+    show_named_collection: 1
+    show_named_collection_secrets: 1

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -447,20 +447,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -511,17 +497,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -536,6 +511,32 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1
       enabled: true
       image: clickhouse/clickhouse-server:25.12.5
       version: 25.12.5
@@ -567,20 +568,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -631,17 +618,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -656,5 +632,31 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1
       extras:
         service_names: signoz-telemetrystore-clickhouse-0-0

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/Dockerfile
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/Dockerfile
@@ -2,8 +2,6 @@ FROM clickhouse/clickhouse-server:25.12.5
 
 COPY config.d/ /etc/clickhouse-server/
 
-# Relocate the users/profiles/quotas overlay into users.d/ so ClickHouse merges
-# it over the image's stock users.xml (the config.d COPY lands it flat otherwise).
 RUN mkdir -p /etc/clickhouse-server/users.d \
     && mv /etc/clickhouse-server/users.yaml /etc/clickhouse-server/users.d/users.yaml
 

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/Dockerfile
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/Dockerfile
@@ -2,6 +2,11 @@ FROM clickhouse/clickhouse-server:25.12.5
 
 COPY config.d/ /etc/clickhouse-server/
 
+# Relocate the users/profiles/quotas overlay into users.d/ so ClickHouse merges
+# it over the image's stock users.xml (the config.d COPY lands it flat otherwise).
+RUN mkdir -p /etc/clickhouse-server/users.d \
+    && mv /etc/clickhouse-server/users.yaml /etc/clickhouse-server/users.d/users.yaml
+
 RUN mkdir -p /var/lib/clickhouse/user_scripts/ \
     && chown clickhouse:clickhouse /var/lib/clickhouse/user_scripts
 

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config-0-0.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config-0-0.yaml
@@ -31,11 +31,6 @@ path: /var/lib/clickhouse/
 processors_profile_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-profiles:
-  default:
-    allow_simdjson: 0
-    load_balancing: random
-    log_queries: 1
 query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
@@ -46,15 +41,6 @@ query_thread_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 query_views_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
-quotas:
-  default:
-    interval:
-      duration: 3600
-      errors: 0
-      execution_time: 0
-      queries: 0
-      read_rows: 0
-      result_rows: 0
 remote_servers:
   cluster:
     shard:
@@ -77,17 +63,6 @@ user_directories:
     path: users.xml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
-users:
-  default:
-    access_management: 1
-    named_collection_control: 1
-    networks:
-      ip: ::/0
-    password: ""
-    profile: default
-    quota: default
-    show_named_collection: 1
-    show_named_collection_secrets: 1
 zookeeper:
   node:
   - host: signoz-telemetrykeeper-clickhousekeeper-0

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/users.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/users.yaml
@@ -1,0 +1,25 @@
+profiles:
+  default:
+    allow_simdjson: 0
+    load_balancing: random
+    log_queries: 1
+quotas:
+  default:
+    interval:
+      duration: 3600
+      errors: 0
+      execution_time: 0
+      queries: 0
+      read_rows: 0
+      result_rows: 0
+users:
+  default:
+    access_management: 1
+    named_collection_control: 1
+    networks:
+      ip: ::/0
+    password: ""
+    profile: default
+    quota: default
+    show_named_collection: 1
+    show_named_collection_secrets: 1

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -461,20 +461,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -525,17 +511,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -550,6 +525,32 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1
       enabled: true
       image: clickhouse/clickhouse-server:25.12.5
       version: 25.12.5
@@ -581,20 +582,6 @@ spec:
             macros:
                 replica: "00"
                 shard: "00"
-            profiles:
-                default:
-                    allow_simdjson: 0
-                    load_balancing: random
-                    log_queries: 1
-            quotas:
-                default:
-                    interval:
-                        duration: 3600
-                        errors: 0
-                        execution_time: 0
-                        queries: 0
-                        read_rows: 0
-                        result_rows: 0
             user_directories:
               users_xml:
                 path: users.xml
@@ -645,17 +632,6 @@ spec:
             tcp_port: 9000
             user_defined_executable_functions_config: '*function.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
-            users:
-                default:
-                    access_management: 1
-                    named_collection_control: 1
-                    networks:
-                        ip: ::/0
-                    password: ""
-                    profile: default
-                    quota: default
-                    show_named_collection: 1
-                    show_named_collection_secrets: 1
           functions.yaml: |
             functions:
               argument:
@@ -670,3 +646,29 @@ spec:
               name: histogramQuantile
               return_type: Float64
               type: executable
+          users.yaml: |
+            profiles:
+                default:
+                    allow_simdjson: 0
+                    load_balancing: random
+                    log_queries: 1
+            quotas:
+                default:
+                    interval:
+                        duration: 3600
+                        errors: 0
+                        execution_time: 0
+                        queries: 0
+                        read_rows: 0
+                        result_rows: 0
+            users:
+                default:
+                    access_management: 1
+                    named_collection_control: 1
+                    networks:
+                        ip: ::/0
+                    password: ""
+                    profile: default
+                    quota: default
+                    show_named_collection: 1
+                    show_named_collection_secrets: 1

--- a/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -31,11 +31,6 @@ path: /var/lib/clickhouse/
 processors_profile_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-profiles:
-  default:
-    allow_simdjson: 0
-    load_balancing: random
-    log_queries: 1
 query_log:
   flush_interval_milliseconds: 30000
   partition_by: toYYYYMM(event_date)
@@ -46,15 +41,6 @@ query_thread_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
 query_views_log:
   ttl: event_date + INTERVAL 1 DAY DELETE
-quotas:
-  default:
-    interval:
-      duration: 3600
-      errors: 0
-      execution_time: 0
-      queries: 0
-      read_rows: 0
-      result_rows: 0
 remote_servers:
   cluster:
     shard:
@@ -77,17 +63,6 @@ user_directories:
     path: users.xml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
-users:
-  default:
-    access_management: 1
-    named_collection_control: 1
-    networks:
-      ip: ::/0
-    password: ""
-    profile: default
-    quota: default
-    show_named_collection: 1
-    show_named_collection_secrets: 1
 zookeeper:
   node:
   - host: localhost

--- a/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/users.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/users.yaml
@@ -1,0 +1,25 @@
+profiles:
+  default:
+    allow_simdjson: 0
+    load_balancing: random
+    log_queries: 1
+quotas:
+  default:
+    interval:
+      duration: 3600
+      errors: 0
+      execution_time: 0
+      queries: 0
+      read_rows: 0
+      result_rows: 0
+users:
+  default:
+    access_management: 1
+    named_collection_control: 1
+    networks:
+      ip: ::/0
+    password: ""
+    profile: default
+    quota: default
+    show_named_collection: 1
+    show_named_collection_secrets: 1

--- a/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
+++ b/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
@@ -132,6 +132,11 @@ services:
         target: /etc/clickhouse-server/functions.yaml
         content: |
 {{ index $.Spec.TelemetryStore.Spec.Config.Data "functions.yaml" | indent 10 }}
+      - type: bind
+        source: ./configs/telemetrystore/users.yaml
+        target: /etc/clickhouse-server/users.d/users.yaml
+        content: |
+{{ index $.Spec.TelemetryStore.Spec.Config.Data "users.yaml" | indent 10 }}
     logging:
       options:
         max-size: 50m

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -83,6 +83,7 @@ services:
       - {{ $.Metadata.Name }}-telemetrystore-user-scripts:/var/lib/clickhouse/user_scripts:ro
       - ./telemetrystore/{{ $.Spec.TelemetryStore.Kind }}/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml:/etc/clickhouse-server/config.yaml:ro
       - ./telemetrystore/{{ $.Spec.TelemetryStore.Kind }}/functions.yaml:/etc/clickhouse-server/functions.yaml:ro
+      - ./telemetrystore/{{ $.Spec.TelemetryStore.Kind }}/users.yaml:/etc/clickhouse-server/users.d/users.yaml:ro
     healthcheck:
       test:
        - "CMD"

--- a/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
@@ -84,6 +84,8 @@ services:
         target: /etc/clickhouse-server/config.yaml
       - source: telemetrystore-functions
         target: /etc/clickhouse-server/functions.yaml
+      - source: telemetrystore-users
+        target: /etc/clickhouse-server/users.d/users.yaml
     deploy:
       restart_policy:
         condition: on-failure
@@ -281,6 +283,8 @@ configs:
   {{- end }}
   telemetrystore-functions:
     file: telemetrystore/{{ $.Spec.TelemetryStore.Kind }}/functions.yaml
+  telemetrystore-users:
+    file: telemetrystore/{{ $.Spec.TelemetryStore.Kind }}/users.yaml
   ingester-config:
     file: ingester/ingester.yaml
   manager-config:

--- a/internal/casting/ecsterraformcasting/templates/module/telemetrystore.tf.json.gotmpl
+++ b/internal/casting/ecsterraformcasting/templates/module/telemetrystore.tf.json.gotmpl
@@ -42,6 +42,8 @@
         {{- $env = append $env (dict "name" $key "value" $value) }}
         {{- end }}
         "environment": {{ toJson $env }},
+        "entryPoint": ["/bin/sh", "-c"],
+        "command": ["mkdir -p /etc/clickhouse-server/users.d && if [ -f /etc/clickhouse-server/config.d/users.yaml ]; then mv /etc/clickhouse-server/config.d/users.yaml /etc/clickhouse-server/users.d/users.yaml; fi; exec /entrypoint.sh"],
         "portMappings": [
           {"name": "native", "containerPort": 9000, "protocol": "tcp"},
           {"name": "http", "containerPort": 8123, "protocol": "tcp", "appProtocol": "http"},

--- a/internal/casting/kuberneteskustomizecasting/templates/telemetrystore/clickhouse/clickhouseinstallation.yaml.gotmpl
+++ b/internal/casting/kuberneteskustomizecasting/templates/telemetrystore/clickhouse/clickhouseinstallation.yaml.gotmpl
@@ -16,6 +16,10 @@ spec:
     files:
 {{- $configData := $.Spec.TelemetryStore.Status.Config.Data }}
 {{- $config := index $configData "config-0-0.yaml" | fromYaml }}
+{{- /* profiles/users/quotas now live in the users.d overlay (users.yaml); the
+       ClickHouse operator maps them into the CHI spec itself, so read them from
+       there rather than config.yaml. */ -}}
+{{- $users := index $configData "users.yaml" | fromYaml }}
 {{- if $config }}
 {{- $files := omit $config "profiles" "users" "quotas" "remote_servers" "zookeeper" "macros" "tcp_port" "http_port" "interserver_http_port" "listen_host" "display_name" "distributed_ddl" }}
       config.d/crash.yaml: |
@@ -51,13 +55,13 @@ spec:
           string created_at = 7;
           string elements_chain = 8;
         }
-{{- if $config }}
+{{- if $users }}
     profiles:
-{{ index $config "profiles" | flattenKeys | toYaml | indent 6 }}
+{{ index $users "profiles" | flattenKeys | toYaml | indent 6 }}
     users:
-{{ index $config "users" | flattenKeys | toYaml | indent 6 }}
+{{ index $users "users" | flattenKeys | toYaml | indent 6 }}
     quotas:
-{{ index $config "quotas" | flattenKeys | toYaml | indent 6 }}
+{{ index $users "quotas" | flattenKeys | toYaml | indent 6 }}
 {{- end }}
     clusters:
     - name: cluster

--- a/internal/casting/railwaytemplatecasting/templates/Dockerfile.clickhouse.telemetrystore.v25125.gotmpl
+++ b/internal/casting/railwaytemplatecasting/templates/Dockerfile.clickhouse.telemetrystore.v25125.gotmpl
@@ -2,6 +2,9 @@ FROM {{$.Spec.TelemetryStore.Spec.Image }}
 
 COPY config.d/ /etc/clickhouse-server/
 
+RUN mkdir -p /etc/clickhouse-server/users.d \
+    && mv /etc/clickhouse-server/users.yaml /etc/clickhouse-server/users.d/users.yaml
+
 RUN mkdir -p /etc/clickhouse-server/user_scripts/ \
     && chown clickhouse:clickhouse /etc/clickhouse-server/user_scripts
 

--- a/internal/casting/rendercasting/templates/Dockerfile.clickhouse.telemetrystore.v25125.gotmpl
+++ b/internal/casting/rendercasting/templates/Dockerfile.clickhouse.telemetrystore.v25125.gotmpl
@@ -2,6 +2,9 @@ FROM {{$.Spec.TelemetryStore.Spec.Image }}
 
 COPY config.d/ /etc/clickhouse-server/
 
+RUN mkdir -p /etc/clickhouse-server/users.d \
+    && mv /etc/clickhouse-server/users.yaml /etc/clickhouse-server/users.d/users.yaml
+
 RUN mkdir -p /var/lib/clickhouse/user_scripts/ \
     && chown clickhouse:clickhouse /var/lib/clickhouse/user_scripts
 

--- a/internal/molding/telemetrystoremolding/telemetrystore.go
+++ b/internal/molding/telemetrystoremolding/telemetrystore.go
@@ -44,6 +44,12 @@ func (molding *telemetrystore) MoldV1Alpha1(ctx context.Context, config *install
 		return foundryerrors.Wrapf(err, foundryerrors.TypeInternal, "failed to execute functions template")
 	}
 
+	// Generate the users/profiles/quotas overlay. This is cluster-wide.
+	usersBuf := bytes.NewBuffer(nil)
+	if err := UsersClickhousev25125YAML.Execute(usersBuf, data); err != nil {
+		return foundryerrors.Wrapf(err, foundryerrors.TypeInternal, "failed to execute users template")
+	}
+
 	// Generate per-node configs (each node needs its own macros.shard / macros.replica).
 	configs := make(map[string]string, data.ShardCount*data.ReplicaCount+1)
 	for s := 0; s < data.ShardCount; s++ {
@@ -71,6 +77,7 @@ func (molding *telemetrystore) MoldV1Alpha1(ctx context.Context, config *install
 		}
 	}
 	configs["functions.yaml"] = functionBuf.String()
+	configs["users.yaml"] = usersBuf.String()
 
 	config.Spec.TelemetryStore.Status.Config.Data = configs
 

--- a/internal/molding/telemetrystoremolding/template.go
+++ b/internal/molding/telemetrystoremolding/template.go
@@ -12,6 +12,7 @@ var templates embed.FS
 var (
 	ConfigClickhousev25125YAML    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/config.clickhouse.v25125.yaml.gotmpl", domain.FormatYAML)
 	FunctionsClickhousev25125YAML *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/functions.clickhouse.v25125.yaml.gotmpl", domain.FormatYAML)
+	UsersClickhousev25125YAML     *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/users.clickhouse.v25125.yaml.gotmpl", domain.FormatYAML)
 )
 
 // Data is the template data for rendering ClickHouse telemetry store configs.

--- a/internal/molding/telemetrystoremolding/templates/config.clickhouse.v25125.yaml.gotmpl
+++ b/internal/molding/telemetrystoremolding/templates/config.clickhouse.v25125.yaml.gotmpl
@@ -19,20 +19,6 @@ logger:
 macros:
     replica: "{{ printf "%02d" .ReplicaID }}"
     shard: "{{ printf "%02d" .ShardID }}"
-profiles:
-    default:
-        allow_simdjson: 0
-        load_balancing: random
-        log_queries: 1
-quotas:
-    default:
-        interval:
-            duration: 3600
-            errors: 0
-            execution_time: 0
-            queries: 0
-            read_rows: 0
-            result_rows: 0
 user_directories:
   users_xml:
     path: users.xml
@@ -91,14 +77,3 @@ zookeeper_log:
 tcp_port: 9000
 user_defined_executable_functions_config: '*function.yaml'
 user_scripts_path: /var/lib/clickhouse/user_scripts/
-users:
-    default:
-        access_management: 1
-        named_collection_control: 1
-        networks:
-            ip: ::/0
-        password: ""
-        profile: default
-        quota: default
-        show_named_collection: 1
-        show_named_collection_secrets: 1

--- a/internal/molding/telemetrystoremolding/templates/users.clickhouse.v25125.yaml.gotmpl
+++ b/internal/molding/telemetrystoremolding/templates/users.clickhouse.v25125.yaml.gotmpl
@@ -1,0 +1,25 @@
+profiles:
+    default:
+        allow_simdjson: 0
+        load_balancing: random
+        log_queries: 1
+quotas:
+    default:
+        interval:
+            duration: 3600
+            errors: 0
+            execution_time: 0
+            queries: 0
+            read_rows: 0
+            result_rows: 0
+users:
+    default:
+        access_management: 1
+        named_collection_control: 1
+        networks:
+            ip: ::/0
+        password: ""
+        profile: default
+        quota: default
+        show_named_collection: 1
+        show_named_collection_secrets: 1


### PR DESCRIPTION
#### Fixes
- Working & wired: compose, swarm, coolify, railway, render, ecs (all via users.d/), plus kustomize (CHI guard) all reflect custom config.data.
- Build, tests, lint green; examples regenerated.
