### PR TITLE
fix(foundryctl): using config.yaml for both server and users

### DIFF
--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -465,7 +465,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:
@@ -585,7 +585,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -465,7 +465,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:
@@ -585,7 +585,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -286,7 +286,7 @@ services:
         condition: service_completed_successfully
     environment:
     - CLICKHOUSE_SKIP_USER_SETUP=1
-    - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.yaml
+    - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config-0-0.yaml
     healthcheck:
       interval: 30s
       retries: 3
@@ -348,7 +348,7 @@ services:
                     result_rows: 0
         user_directories:
           users_xml:
-            path: config.yaml
+            path: config-0-0.yaml
         remote_servers:
           cluster:
             shard:
@@ -408,7 +408,7 @@ services:
                 show_named_collection: 1
                 show_named_collection_secrets: 1
       source: ./configs/telemetrystore/config-0-0.yaml
-      target: /etc/clickhouse-server/config.yaml
+      target: /etc/clickhouse-server/config-0-0.yaml
       type: bind
     - content: |
         functions:

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -348,7 +348,7 @@ services:
                     result_rows: 0
         user_directories:
           users_xml:
-            path: users.xml
+            path: config.yaml
         remote_servers:
           cluster:
             shard:

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -465,7 +465,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:
@@ -585,7 +585,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -465,7 +465,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:
@@ -585,7 +585,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/docker/compose/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose/pours/deployment/compose.yaml
@@ -105,7 +105,7 @@ services:
         condition: service_completed_successfully
     environment:
     - CLICKHOUSE_SKIP_USER_SETUP=1
-    - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.yaml
+    - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config-0-0.yaml
     healthcheck:
       interval: 30s
       retries: 3
@@ -124,7 +124,7 @@ services:
     volumes:
     - signoz-telemetrystore-0-0-data:/var/lib/clickhouse
     - signoz-telemetrystore-user-scripts:/var/lib/clickhouse/user_scripts:ro
-    - ./telemetrystore/clickhouse/config-0-0.yaml:/etc/clickhouse-server/config.yaml:ro
+    - ./telemetrystore/clickhouse/config-0-0.yaml:/etc/clickhouse-server/config-0-0.yaml:ro
     - ./telemetrystore/clickhouse/functions.yaml:/etc/clickhouse-server/functions.yaml:ro
   signoz-telemetrystore-clickhouse-user-scripts:
     command:

--- a/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -74,7 +74,7 @@ trace_log:
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:
-    path: config.yaml
+    path: config-0-0.yaml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
 users:

--- a/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -74,7 +74,7 @@ trace_log:
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:
-    path: users.xml
+    path: config.yaml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
 users:

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -465,7 +465,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:
@@ -585,7 +585,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -465,7 +465,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:
@@ -585,7 +585,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/docker/swarm/pours/deployment/compose.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/compose.yaml
@@ -119,7 +119,7 @@ services:
   signoz-telemetrystore-clickhouse-0-0:
     configs:
     - source: telemetrystore-config-0-0
-      target: /etc/clickhouse-server/config.yaml
+      target: /etc/clickhouse-server/config-0-0.yaml
     - source: telemetrystore-functions
       target: /etc/clickhouse-server/functions.yaml
     deploy:
@@ -127,7 +127,7 @@ services:
         condition: on-failure
     environment:
     - CLICKHOUSE_SKIP_USER_SETUP=1
-    - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.yaml
+    - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config-0-0.yaml
     healthcheck:
       interval: 30s
       retries: 3

--- a/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -74,7 +74,7 @@ trace_log:
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:
-    path: config.yaml
+    path: config-0-0.yaml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
 users:

--- a/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -74,7 +74,7 @@ trace_log:
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:
-    path: users.xml
+    path: config.yaml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
 users:

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -464,7 +464,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:
@@ -584,7 +584,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -464,7 +464,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:
@@ -584,7 +584,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore.tf.json
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore.tf.json
@@ -37,6 +37,8 @@
         "image": "clickhouse/clickhouse-server:25.12.5",
         "essential": true,
         "environment": [{"name":"CLICKHOUSE_SKIP_USER_SETUP","value":"1"}],
+        "entryPoint": ["/bin/sh", "-c"],
+        "command": ["ln -sf /etc/clickhouse-server/config.d/config-0-0.yaml /etc/clickhouse-server/config-0-0.yaml && exec /entrypoint.sh"],
         "portMappings": [
           {"name": "native", "containerPort": 9000, "protocol": "tcp"},
           {"name": "http", "containerPort": 8123, "protocol": "tcp", "appProtocol": "http"},

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config-0-0.yaml
@@ -74,7 +74,7 @@ trace_log:
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:
-    path: config.yaml
+    path: config-0-0.yaml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
 users:

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config-0-0.yaml
@@ -74,7 +74,7 @@ trace_log:
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:
-    path: users.xml
+    path: config.yaml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
 users:

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -462,7 +462,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:
@@ -582,7 +582,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -462,7 +462,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:
@@ -582,7 +582,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -543,7 +543,7 @@ spec:
             user_defined_executable_functions_config: /etc/clickhouse-server/functions/custom-functions.xml
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             user_files_path: /var/lib/clickhouse/user_files/
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
@@ -717,7 +717,7 @@ spec:
             user_defined_executable_functions_config: /etc/clickhouse-server/functions/custom-functions.xml
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             user_files_path: /var/lib/clickhouse/user_files/
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -543,7 +543,7 @@ spec:
             user_defined_executable_functions_config: /etc/clickhouse-server/functions/custom-functions.xml
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             user_files_path: /var/lib/clickhouse/user_files/
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
@@ -717,7 +717,7 @@ spec:
             user_defined_executable_functions_config: /etc/clickhouse-server/functions/custom-functions.xml
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             user_files_path: /var/lib/clickhouse/user_files/
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:

--- a/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
@@ -51,9 +51,6 @@ spec:
           flush_interval_milliseconds: 30000
           ttl: event_date + INTERVAL 1 DAY DELETE
         user_defined_executable_functions_config: /etc/clickhouse-server/functions/custom-functions.xml
-        user_directories:
-          users_xml:
-            path: config-0-0.yaml
         user_files_path: /var/lib/clickhouse/user_files/
         user_scripts_path: /var/lib/clickhouse/user_scripts/
         zookeeper_log:

--- a/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
@@ -53,7 +53,7 @@ spec:
         user_defined_executable_functions_config: /etc/clickhouse-server/functions/custom-functions.xml
         user_directories:
           users_xml:
-            path: users.xml
+            path: config.yaml
         user_files_path: /var/lib/clickhouse/user_files/
         user_scripts_path: /var/lib/clickhouse/user_scripts/
         zookeeper_log:

--- a/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/clickhouseinstallation.yaml
@@ -53,7 +53,7 @@ spec:
         user_defined_executable_functions_config: /etc/clickhouse-server/functions/custom-functions.xml
         user_directories:
           users_xml:
-            path: config.yaml
+            path: config-0-0.yaml
         user_files_path: /var/lib/clickhouse/user_files/
         user_scripts_path: /var/lib/clickhouse/user_scripts/
         zookeeper_log:

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -519,7 +519,7 @@ spec:
             user_defined_executable_functions_config: '*function.yaml'
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             user_files_path: /var/lib/clickhouse/user_files/
             user_scripts_path: /etc/clickhouse-server/user_scripts/
             users:
@@ -639,7 +639,7 @@ spec:
             user_defined_executable_functions_config: '*function.yaml'
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             user_files_path: /var/lib/clickhouse/user_files/
             user_scripts_path: /etc/clickhouse-server/user_scripts/
             users:

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -519,7 +519,7 @@ spec:
             user_defined_executable_functions_config: '*function.yaml'
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             user_files_path: /var/lib/clickhouse/user_files/
             user_scripts_path: /etc/clickhouse-server/user_scripts/
             users:
@@ -639,7 +639,7 @@ spec:
             user_defined_executable_functions_config: '*function.yaml'
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             user_files_path: /var/lib/clickhouse/user_files/
             user_scripts_path: /etc/clickhouse-server/user_scripts/
             users:

--- a/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config-0-0.yaml
+++ b/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config-0-0.yaml
@@ -74,7 +74,7 @@ trace_log:
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:
-    path: users.xml
+    path: config.yaml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /etc/clickhouse-server/user_scripts/
 users:

--- a/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config-0-0.yaml
+++ b/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config-0-0.yaml
@@ -74,7 +74,7 @@ trace_log:
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:
-    path: config.yaml
+    path: config-0-0.yaml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /etc/clickhouse-server/user_scripts/
 users:

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -463,7 +463,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:
@@ -583,7 +583,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -463,7 +463,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:
@@ -583,7 +583,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config-0-0.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config-0-0.yaml
@@ -74,7 +74,7 @@ trace_log:
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:
-    path: config.yaml
+    path: config-0-0.yaml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
 users:

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config-0-0.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config-0-0.yaml
@@ -74,7 +74,7 @@ trace_log:
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:
-    path: users.xml
+    path: config.yaml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
 users:

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -477,7 +477,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:
@@ -597,7 +597,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: users.xml
+                path: config.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -477,7 +477,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:
@@ -597,7 +597,7 @@ spec:
                         result_rows: 0
             user_directories:
               users_xml:
-                path: config.yaml
+                path: config-0-0.yaml
             remote_servers:
               cluster:
                 shard:

--- a/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -74,7 +74,7 @@ trace_log:
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:
-    path: config.yaml
+    path: config-0-0.yaml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
 users:

--- a/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -74,7 +74,7 @@ trace_log:
 user_defined_executable_functions_config: '*function.yaml'
 user_directories:
   users_xml:
-    path: users.xml
+    path: config.yaml
 user_files_path: /var/lib/clickhouse/user_files/
 user_scripts_path: /var/lib/clickhouse/user_scripts/
 users:

--- a/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
+++ b/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
@@ -103,7 +103,7 @@ services:
       {{- end }}
     environment:
       - CLICKHOUSE_SKIP_USER_SETUP=1
-      - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.yaml
+      - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml
     healthcheck:
       test:
         - CMD
@@ -124,7 +124,7 @@ services:
         read_only: true
       - type: bind
         source: ./configs/telemetrystore/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml
-        target: /etc/clickhouse-server/config.yaml
+        target: /etc/clickhouse-server/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml
         content: |
 {{ index $.Spec.TelemetryStore.Spec.Config.Data (printf "config-%d-%d.yaml" $shardIdx $replicaIdx) | indent 10 }}
       - type: bind

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -72,7 +72,7 @@ services:
       - {{ $.Metadata.Name }}-network
     environment:
       - CLICKHOUSE_SKIP_USER_SETUP=1
-      - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.yaml
+      - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml
     {{- if $.Spec.TelemetryStore.Spec.Env }}
       {{- range $key, $value := $.Spec.TelemetryStore.Spec.Env }}
       - {{ $key }}={{ $value }}
@@ -81,7 +81,7 @@ services:
     volumes:
       - {{ $.Metadata.Name }}-telemetrystore-{{ $shardIdx }}-{{ $replicaIdx }}-data:/var/lib/clickhouse
       - {{ $.Metadata.Name }}-telemetrystore-user-scripts:/var/lib/clickhouse/user_scripts:ro
-      - ./telemetrystore/{{ $.Spec.TelemetryStore.Kind }}/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml:/etc/clickhouse-server/config.yaml:ro
+      - ./telemetrystore/{{ $.Spec.TelemetryStore.Kind }}/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml:/etc/clickhouse-server/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml:ro
       - ./telemetrystore/{{ $.Spec.TelemetryStore.Kind }}/functions.yaml:/etc/clickhouse-server/functions.yaml:ro
     healthcheck:
       test:

--- a/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
@@ -70,7 +70,7 @@ services:
       - {{ $.Metadata.Name }}-network
     environment:
       - CLICKHOUSE_SKIP_USER_SETUP=1
-      - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.yaml
+      - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml
     {{- if $.Spec.TelemetryStore.Spec.Env }}
       {{- range $key, $value := $.Spec.TelemetryStore.Spec.Env }}
       - {{ $key }}={{ $value }}
@@ -81,7 +81,7 @@ services:
       - {{ $.Metadata.Name }}-telemetrystore-user-scripts:/var/lib/clickhouse/user_scripts:ro
     configs:
       - source: telemetrystore-config-{{ $shardIdx }}-{{ $replicaIdx }}
-        target: /etc/clickhouse-server/config.yaml
+        target: /etc/clickhouse-server/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml
       - source: telemetrystore-functions
         target: /etc/clickhouse-server/functions.yaml
     deploy:

--- a/internal/casting/ecsterraformcasting/templates/module/telemetrystore.tf.json.gotmpl
+++ b/internal/casting/ecsterraformcasting/templates/module/telemetrystore.tf.json.gotmpl
@@ -42,6 +42,8 @@
         {{- $env = append $env (dict "name" $key "value" $value) }}
         {{- end }}
         "environment": {{ toJson $env }},
+        "entryPoint": ["/bin/sh", "-c"],
+        "command": ["ln -sf /etc/clickhouse-server/config.d/config-0-0.yaml /etc/clickhouse-server/config-0-0.yaml && exec /entrypoint.sh"],
         "portMappings": [
           {"name": "native", "containerPort": 9000, "protocol": "tcp"},
           {"name": "http", "containerPort": 8123, "protocol": "tcp", "appProtocol": "http"},

--- a/internal/casting/kuberneteskustomizecasting/templates/telemetrystore/clickhouse/clickhouseinstallation.yaml.gotmpl
+++ b/internal/casting/kuberneteskustomizecasting/templates/telemetrystore/clickhouse/clickhouseinstallation.yaml.gotmpl
@@ -17,7 +17,7 @@ spec:
 {{- $configData := $.Spec.TelemetryStore.Spec.Config.Data }}
 {{- $config := index $configData "config-0-0.yaml" | fromYaml }}
 {{- if $config }}
-{{- $files := omit $config "profiles" "users" "quotas" "remote_servers" "zookeeper" "macros" "tcp_port" "http_port" "interserver_http_port" "listen_host" "display_name" "distributed_ddl" }}
+{{- $files := omit $config "profiles" "users" "quotas" "remote_servers" "zookeeper" "macros" "tcp_port" "http_port" "interserver_http_port" "listen_host" "display_name" "distributed_ddl" "user_directories" }}
       config.d/crash.yaml: |
 {{ pick $files "send_crash_reports" | toYaml | indent 8 }}
 {{- $files = omit $files "send_crash_reports" }}

--- a/internal/casting/kuberneteskustomizecasting/templates/telemetrystore/clickhouse/clickhouseinstallation.yaml.gotmpl
+++ b/internal/casting/kuberneteskustomizecasting/templates/telemetrystore/clickhouse/clickhouseinstallation.yaml.gotmpl
@@ -14,7 +14,7 @@ metadata:
 spec:
   configuration:
     files:
-{{- $configData := $.Spec.TelemetryStore.Status.Config.Data }}
+{{- $configData := $.Spec.TelemetryStore.Spec.Config.Data }}
 {{- $config := index $configData "config-0-0.yaml" | fromYaml }}
 {{- if $config }}
 {{- $files := omit $config "profiles" "users" "quotas" "remote_servers" "zookeeper" "macros" "tcp_port" "http_port" "interserver_http_port" "listen_host" "display_name" "distributed_ddl" }}

--- a/internal/molding/telemetrystoremolding/templates/config.clickhouse.v25125.yaml.gotmpl
+++ b/internal/molding/telemetrystoremolding/templates/config.clickhouse.v25125.yaml.gotmpl
@@ -35,7 +35,7 @@ quotas:
             result_rows: 0
 user_directories:
   users_xml:
-    path: config.yaml
+    path: config-{{ .ShardID }}-{{ .ReplicaID }}.yaml
 remote_servers:
   cluster:
     shard:

--- a/internal/molding/telemetrystoremolding/templates/config.clickhouse.v25125.yaml.gotmpl
+++ b/internal/molding/telemetrystoremolding/templates/config.clickhouse.v25125.yaml.gotmpl
@@ -35,7 +35,7 @@ quotas:
             result_rows: 0
 user_directories:
   users_xml:
-    path: users.xml
+    path: config.yaml
 remote_servers:
   cluster:
     shard:


### PR DESCRIPTION
#### Fixes
- Uses config.yaml to define both server settings as well as user/profile settings.
- Previously it was using `users.xml` which had the default settings, effectively ignoring previous sane defaults defined.

Related: https://github.com/SigNoz/platform-pod/issues/2102
