### PR TITLE
fix(issue-template): remove duplicate render option in bug.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -100,7 +100,6 @@ body:
         - render
         - kubernetes
         - railway
-        - render
     validations:
       required: false
 


### PR DESCRIPTION
Remove the duplicate `render` option from the "Deployment mode" dropdown in the Bug issue-form template, so the form validates and returns to the New Issue chooser. Closes #158.

#### Fixes

- `bug.yml`: dedupe the "Deployment mode" dropdown. GitHub rejects the form with `body[9]: options must be unique` (shown as a Critical banner on the file) because `render` is listed twice, which omits the Bug template from the New Issue chooser. With the duplicate removed the options are unique and the form loads.