### PR TITLE
feat(casting/systemd): add zookeeper telemetrykeeper support

### DIFF
--- a/api/v1alpha1/installation/annotations.go
+++ b/api/v1alpha1/installation/annotations.go
@@ -37,6 +37,12 @@ var (
 		Mode:        v1alpha1.ModeSystemd,
 		Description: "Absolute path to the ClickHouse binary, run as `clickhouse keeper`.",
 	}
+	TelemetryKeeperZookeeperBinaryPath = v1alpha1.Annotation{
+		Key:         "foundry.signoz.io/telemetrykeeper-zookeeper-binary-path",
+		Default:     "/opt/zookeeper/bin/zkServer.sh",
+		Mode:        v1alpha1.ModeSystemd,
+		Description: "Absolute path to the Apache ZooKeeper zkServer.sh script; requires a Java runtime on the host.",
+	}
 	MCPBinaryPath = v1alpha1.Annotation{
 		Key:         "foundry.signoz.io/mcp-binary-path",
 		Default:     "/opt/mcp/bin/signoz-mcp-server",
@@ -53,6 +59,7 @@ func Annotations() []v1alpha1.Annotation {
 		MetaStorePostgresBinaryPath,
 		TelemetryStoreClickHouseBinaryPath,
 		TelemetryKeeperClickHouseKeeperBinaryPath,
+		TelemetryKeeperZookeeperBinaryPath,
 		MCPBinaryPath,
 	}
 }

--- a/docs/examples/systemd/binary/README.md
+++ b/docs/examples/systemd/binary/README.md
@@ -38,10 +38,11 @@ curl -fsSL "https://github.com/SigNoz/signoz-mcp-server/releases/latest/download
 > [!IMPORTANT]
 > Extract the **full** SigNoz tarball; do not move the `signoz` binary on its own. It loads the web UI and email/alert templates relative to itself, so `bin/`, `web/`, `templates/`, and `conf/` must stay together.
 
-ClickHouse and PostgreSQL are installed from their own packages:
+ClickHouse, PostgreSQL, and ZooKeeper are installed from their own packages:
 
 - [ClickHouse](https://clickhouse.com/docs/install): one `clickhouse` binary serves both the telemetry store and the keeper
 - [PostgreSQL](https://www.postgresql.org/download/): only when `metastore.kind` is `postgres`
+- [Apache ZooKeeper](https://zookeeper.apache.org/releases.html): only when `telemetrykeeper.kind` is `zookeeper`; extract the release to `/opt/zookeeper` and install a Java runtime
 
 ## Configuration
 
@@ -135,6 +136,7 @@ Set an annotation only when a binary is installed outside its default location.
 | `foundry.signoz.io/metastore-postgres-binary-path` | `/usr/bin/postgres` | PostgreSQL (its directory must also hold `initdb`) |
 | `foundry.signoz.io/telemetrystore-clickhouse-binary-path` | `/usr/bin/clickhouse` | ClickHouse, run as `clickhouse server` |
 | `foundry.signoz.io/telemetrykeeper-clickhousekeeper-binary-path` | `/usr/bin/clickhouse` | ClickHouse, run as `clickhouse keeper` |
+| `foundry.signoz.io/telemetrykeeper-zookeeper-binary-path` | `/opt/zookeeper/bin/zkServer.sh` | Apache ZooKeeper, run as `zkServer.sh start-foreground` (needs Java) |
 | `foundry.signoz.io/mcp-binary-path` | `/opt/mcp/bin/signoz-mcp-server` | SigNoz MCP server |
 
 ```yaml

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -7,6 +7,7 @@ metadata:
     foundry.signoz.io/metastore-postgres-binary-path: /usr/bin/postgres
     foundry.signoz.io/signoz-binary-path: /opt/signoz/bin/signoz
     foundry.signoz.io/telemetrykeeper-clickhousekeeper-binary-path: /usr/bin/clickhouse
+    foundry.signoz.io/telemetrykeeper-zookeeper-binary-path: /opt/zookeeper/bin/zkServer.sh
     foundry.signoz.io/telemetrystore-clickhouse-binary-path: /usr/bin/clickhouse
   name: signoz
 spec:

--- a/docs/examples/systemd/binary/pours/deployment/signoz-telemetrystore-clickhouse-0-0.service
+++ b/docs/examples/systemd/binary/pours/deployment/signoz-telemetrystore-clickhouse-0-0.service
@@ -10,6 +10,7 @@ LimitNOFILE=500000
 Restart=always
 RestartSec=30
 RuntimeDirectory=clickhouse
+StateDirectory=clickhouse
 Type=simple
 User=clickhouse
 

--- a/internal/casting/systemdcasting/casting.go
+++ b/internal/casting/systemdcasting/casting.go
@@ -81,6 +81,9 @@ func (c *systemdCasting) Cast(ctx context.Context, config installation.Casting, 
 	if err := c.initializeMetaStore(ctx, &config); err != nil {
 		return err
 	}
+	if err := c.initializeTelemetryKeeper(ctx, &config); err != nil {
+		return err
+	}
 	if err := c.startUnits(ctx, units); err != nil {
 		return err
 	}
@@ -92,6 +95,10 @@ func (c *systemdCasting) Cast(ctx context.Context, config installation.Casting, 
 func (c *systemdCasting) forgeTelemetryKeeper(cfg *installation.Casting) ([]domain.Material, error) {
 	if !cfg.Spec.TelemetryKeeper.Spec.IsEnabled() {
 		return nil, nil
+	}
+
+	if cfg.Spec.TelemetryKeeper.Kind == installation.TelemetryKeeperKindZookeeper {
+		return c.forgeZookeeper(cfg)
 	}
 
 	spec := &cfg.Spec.TelemetryKeeper
@@ -121,6 +128,25 @@ func (c *systemdCasting) forgeTelemetryKeeper(cfg *installation.Casting) ([]doma
 	}
 
 	return append(materials, cfgMats...), nil
+}
+
+// forgeZookeeper renders the zookeeper unit and its zoo.cfg. The config file is
+// part of the unit's materialization (the unit's ExecStart points at it), not
+// molding config, so it is tuned via patches rather than spec.config.
+func (c *systemdCasting) forgeZookeeper(cfg *installation.Casting) ([]domain.Material, error) {
+	kind := cfg.Spec.TelemetryKeeper.Kind.String()
+
+	svcMat, err := c.renderTemplate(zookeeperServiceTemplate, cfg, fmt.Sprintf("%s-telemetrykeeper-%s-0%s", cfg.Metadata.Name, kind, svcSuffix))
+	if err != nil {
+		return nil, err
+	}
+
+	cfgMat, err := c.renderTemplate(zookeeperConfigTemplate, cfg, filepath.Join("telemetrykeeper", kind, "zoo.cfg"))
+	if err != nil {
+		return nil, err
+	}
+
+	return []domain.Material{svcMat, cfgMat}, nil
 }
 
 func (c *systemdCasting) forgeTelemetryStore(cfg *installation.Casting) ([]domain.Material, error) {
@@ -296,8 +322,12 @@ func (c *systemdCasting) provision(ctx context.Context, config *installation.Cas
 	}
 	if config.Spec.TelemetryKeeper.Spec.IsEnabled() {
 		src := filepath.Join(poursPath, rootcasting.DeploymentDir, "telemetrykeeper", config.Spec.TelemetryKeeper.Kind.String())
-		if err := c.copyDir(src, "/etc/clickhouse-keeper/"); err != nil {
-			return errors.Wrapf(err, errors.TypeInternal, "failed to copy clickhouse-keeper configs")
+		dst := "/etc/clickhouse-keeper/"
+		if config.Spec.TelemetryKeeper.Kind == installation.TelemetryKeeperKindZookeeper {
+			dst = "/etc/zookeeper/"
+		}
+		if err := c.copyDir(src, dst); err != nil {
+			return errors.Wrapf(err, errors.TypeInternal, "failed to copy telemetrykeeper configs")
 		}
 	}
 
@@ -353,6 +383,9 @@ func (c *systemdCasting) validateBinaries(ctx context.Context, config *installat
 	if config.Spec.TelemetryKeeper.Spec.IsEnabled() && config.Spec.TelemetryKeeper.Kind == installation.TelemetryKeeperKindClickhouseKeeper {
 		binaries = append(binaries, binarytooler.New("clickhouse-keeper", installation.TelemetryKeeperClickHouseKeeperBinaryPath.Resolve(annotations)))
 	}
+	if config.Spec.TelemetryKeeper.Spec.IsEnabled() && config.Spec.TelemetryKeeper.Kind == installation.TelemetryKeeperKindZookeeper {
+		binaries = append(binaries, binarytooler.New("zookeeper", installation.TelemetryKeeperZookeeperBinaryPath.Resolve(annotations)))
+	}
 	if config.Spec.TelemetryStore.Spec.IsEnabled() {
 		binaries = append(binaries, binarytooler.New("clickhouse", installation.TelemetryStoreClickHouseBinaryPath.Resolve(annotations)))
 	}
@@ -396,6 +429,22 @@ func (c *systemdCasting) initializeMetaStore(ctx context.Context, config *instal
 			return errors.Wrapf(err, errors.TypeInternal, "failed to create sqlite data directory")
 		}
 		_ = c.execCommand(ctx, "chown", "-R", "signoz:signoz", "/var/lib/signoz") // best effort
+	}
+	return nil
+}
+
+// initializeTelemetryKeeper creates the zookeeper service user; the data and
+// log directories are created by systemd via StateDirectory/LogsDirectory.
+func (c *systemdCasting) initializeTelemetryKeeper(ctx context.Context, config *installation.Casting) error {
+	if !config.Spec.TelemetryKeeper.Spec.IsEnabled() || config.Spec.TelemetryKeeper.Kind != installation.TelemetryKeeperKindZookeeper {
+		return nil
+	}
+
+	if _, err := user.Lookup("zookeeper"); err != nil {
+		c.logger.InfoContext(ctx, "creating zookeeper user")
+		if err := c.execCommand(ctx, "useradd", "-r", "-s", "/sbin/nologin", "zookeeper"); err != nil {
+			return errors.Wrapf(err, errors.TypeInternal, "failed to create zookeeper user")
+		}
 	}
 	return nil
 }

--- a/internal/casting/systemdcasting/casting.go
+++ b/internal/casting/systemdcasting/casting.go
@@ -84,6 +84,9 @@ func (c *systemdCasting) Cast(ctx context.Context, config installation.Casting, 
 	if err := c.initializeTelemetryKeeper(ctx, &config); err != nil {
 		return err
 	}
+	if err := c.initializeTelemetryStore(ctx, &config); err != nil {
+		return err
+	}
 	if err := c.startUnits(ctx, units); err != nil {
 		return err
 	}
@@ -433,18 +436,40 @@ func (c *systemdCasting) initializeMetaStore(ctx context.Context, config *instal
 	return nil
 }
 
-// initializeTelemetryKeeper creates the zookeeper service user; the data and
+// initializeTelemetryKeeper creates the keeper's service user; the data and
 // log directories are created by systemd via StateDirectory/LogsDirectory.
 func (c *systemdCasting) initializeTelemetryKeeper(ctx context.Context, config *installation.Casting) error {
 	if !config.Spec.TelemetryKeeper.Spec.IsEnabled() || config.Spec.TelemetryKeeper.Kind != installation.TelemetryKeeperKindZookeeper {
 		return nil
 	}
 
-	if _, err := user.Lookup("zookeeper"); err != nil {
-		c.logger.InfoContext(ctx, "creating zookeeper user")
-		if err := c.execCommand(ctx, "useradd", "-r", "-s", "/sbin/nologin", "zookeeper"); err != nil {
-			return errors.Wrapf(err, errors.TypeInternal, "failed to create zookeeper user")
-		}
+	switch config.Spec.TelemetryKeeper.Kind {
+	case installation.TelemetryKeeperKindZookeeper:
+		return c.ensureSystemUser(ctx, "zookeeper")
+	case installation.TelemetryKeeperKindClickhouseKeeper:
+		return c.ensureSystemUser(ctx, "clickhouse")
+	}
+	return nil
+}
+
+// initializeTelemetryStore creates the clickhouse service user: binary-only
+// ClickHouse installs (tgz) do not create it. The data directory is created by
+// systemd via StateDirectory.
+func (c *systemdCasting) initializeTelemetryStore(ctx context.Context, config *installation.Casting) error {
+	if !config.Spec.TelemetryStore.Spec.IsEnabled() {
+		return nil
+	}
+	return c.ensureSystemUser(ctx, "clickhouse")
+}
+
+// ensureSystemUser creates a system user if it does not exist.
+func (c *systemdCasting) ensureSystemUser(ctx context.Context, name string) error {
+	if _, err := user.Lookup(name); err == nil {
+		return nil
+	}
+	c.logger.InfoContext(ctx, "creating user", slog.String("user", name))
+	if err := c.execCommand(ctx, "useradd", "-r", "-s", "/sbin/nologin", name); err != nil {
+		return errors.Wrapf(err, errors.TypeInternal, "failed to create %s user", name)
 	}
 	return nil
 }
@@ -472,11 +497,8 @@ func (c *systemdCasting) initializePostgres(ctx context.Context, config *install
 
 	// A binary/tarball postgres install does not create the `postgres` system
 	// user, so the chown and `su - postgres` steps below would fail. Create it.
-	if _, err := user.Lookup("postgres"); err != nil {
-		c.logger.InfoContext(ctx, "creating postgres user")
-		if err := c.execCommand(ctx, "useradd", "-r", "-s", "/sbin/nologin", "postgres"); err != nil {
-			return errors.Wrapf(err, errors.TypeInternal, "failed to create postgres user")
-		}
+	if err := c.ensureSystemUser(ctx, "postgres"); err != nil {
+		return err
 	}
 
 	if err := c.execCommand(ctx, "chown", "-R", "postgres:postgres", filepath.Dir(pgDataDir)); err != nil {

--- a/internal/casting/systemdcasting/embed.go
+++ b/internal/casting/systemdcasting/embed.go
@@ -14,6 +14,8 @@ var (
 	ingesterServiceTemplate               *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/ingester.service.gotmpl", domain.FormatINI)
 	telemetryStoreServiceTemplate         *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhouse.telemetrystore.v25125.service.gotmpl", domain.FormatINI)
 	telemetryKeeperServiceTemplate        *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/clickhousekeeper.telemetrykeeper.v25125.service.gotmpl", domain.FormatINI)
+	zookeeperServiceTemplate              *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/zookeeper.telemetrykeeper.v371.service.gotmpl", domain.FormatINI)
+	zookeeperConfigTemplate               *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/zookeeper.telemetrykeeper.v371.cfg.gotmpl", domain.FormatINI)
 	metaStoreServiceTemplate              *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/postgres.metastore.service.gotmpl", domain.FormatINI)
 	telemetryStoreMigratorServiceTemplate *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/migrator.telemetrystore.service.gotmpl", domain.FormatINI)
 	mcpServiceTemplate                    *domain.Template = domain.MustNewTemplateFromFS(templates, "templates/mcp.service.gotmpl", domain.FormatINI)

--- a/internal/casting/systemdcasting/embed_test.go
+++ b/internal/casting/systemdcasting/embed_test.go
@@ -12,6 +12,8 @@ func TestNotEmptyAndValid(t *testing.T) {
 	serviceTemplates := map[string]*domain.Template{
 		"telemetryStoreServiceTemplate":  telemetryStoreServiceTemplate,
 		"telemetryKeeperServiceTemplate": telemetryKeeperServiceTemplate,
+		"zookeeperServiceTemplate":       zookeeperServiceTemplate,
+		"zookeeperConfigTemplate":        zookeeperConfigTemplate,
 		"metaStoreServiceTemplate":       metaStoreServiceTemplate,
 		"signozServiceTemplate":          signozServiceTemplate,
 		"ingesterServiceTemplate":        ingesterServiceTemplate,

--- a/internal/casting/systemdcasting/enricher.go
+++ b/internal/casting/systemdcasting/enricher.go
@@ -14,10 +14,12 @@ import (
 var _ molding.MoldingEnricher = (*systemdMoldingEnricher)(nil)
 
 const (
-	baseTelemetryKeeperClientPort = 9181
-	baseTelemetryKeeperRaftPort   = 9234
-	baseTelemetryStoreClusterPort = 9000
-	baseMetaStorePostgresPort     = 5432
+	baseTelemetryKeeperClientPort          = 9181
+	baseTelemetryKeeperRaftPort            = 9234
+	baseTelemetryKeeperZookeeperClientPort = 2181
+	baseTelemetryKeeperZookeeperRaftPort   = 2888
+	baseTelemetryStoreClusterPort          = 9000
+	baseMetaStorePostgresPort              = 5432
 )
 
 type systemdMoldingEnricher struct {
@@ -54,10 +56,6 @@ func (e *systemdMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alpha1
 }
 
 func (e *systemdMoldingEnricher) enrichTelemetryKeeper(config *installation.Casting) error {
-	if config.Spec.TelemetryKeeper.Kind == installation.TelemetryKeeperKindZookeeper {
-		return errors.Newf(errors.TypeUnsupported, "telemetrykeeper kind %q is not supported by the systemd casting yet", config.Spec.TelemetryKeeper.Kind)
-	}
-
 	spec := &config.Spec.TelemetryKeeper
 	cluster := spec.Spec.Cluster
 
@@ -70,10 +68,15 @@ func (e *systemdMoldingEnricher) enrichTelemetryKeeper(config *installation.Cast
 		return errors.Newf(errors.TypeUnsupported, "deployment mode '%s' does not support Distributed Clickhouse Setup, raise an issue at https://github.com/signoz/foundry/issues", config.Spec.Deployment.Mode)
 	}
 
+	clientPort, raftPort := baseTelemetryKeeperClientPort, baseTelemetryKeeperRaftPort
+	if spec.Kind == installation.TelemetryKeeperKindZookeeper {
+		clientPort, raftPort = baseTelemetryKeeperZookeeperClientPort, baseTelemetryKeeperZookeeperRaftPort
+	}
+
 	var clientAddresses, raftAddresses []string
 	for r := 0; r < replicas; r++ {
-		clientAddresses = append(clientAddresses, domain.MustNewAddress("tcp", "localhost", baseTelemetryKeeperClientPort+r).String())
-		raftAddresses = append(raftAddresses, domain.MustNewAddress("tcp", "localhost", baseTelemetryKeeperRaftPort+r).String())
+		clientAddresses = append(clientAddresses, domain.MustNewAddress("tcp", "localhost", clientPort+r).String())
+		raftAddresses = append(raftAddresses, domain.MustNewAddress("tcp", "localhost", raftPort+r).String())
 	}
 
 	config.Spec.TelemetryKeeper.Status.Addresses.Client = clientAddresses

--- a/internal/casting/systemdcasting/templates/clickhouse.telemetrystore.v25125.service.gotmpl
+++ b/internal/casting/systemdcasting/templates/clickhouse.telemetrystore.v25125.service.gotmpl
@@ -11,6 +11,7 @@ Group=clickhouse
 Restart=always
 RestartSec=30
 RuntimeDirectory=clickhouse
+StateDirectory=clickhouse
 {{- if and $.Metadata.Annotations (index $.Metadata.Annotations "foundry.signoz.io/telemetrystore-clickhouse-binary-path") }}
 {{- $clickhouseBinary := index $.Metadata.Annotations "foundry.signoz.io/telemetrystore-clickhouse-binary-path" }}
 ExecStart={{ $clickhouseBinary }} server --config=/etc/clickhouse-server/config-0-0.yaml --pid-file=/run/clickhouse/clickhouse.pid

--- a/internal/casting/systemdcasting/templates/zookeeper.telemetrykeeper.v371.cfg.gotmpl
+++ b/internal/casting/systemdcasting/templates/zookeeper.telemetrykeeper.v371.cfg.gotmpl
@@ -1,0 +1,31 @@
+{{- /* Translates the molding's env into zoo.cfg form: mapped keys are written
+when present, absent keys are omitted so ZooKeeper's own defaults apply.
+dataDir and the admin port are the casting's platform decisions. */ -}}
+dataDir=/var/lib/zookeeper
+admin.serverPort=3181
+{{- with $.Spec.TelemetryKeeper.Status.Addresses.Client }}
+clientPort={{ last (splitList ":" (first .)) }}
+{{- end }}
+{{- with $env := $.Spec.TelemetryKeeper.Spec.Env }}
+{{- range $envKey, $cfgKey := dict
+	"ZOO_TICK_TIME" "tickTime"
+	"ZOO_INIT_LIMIT" "initLimit"
+	"ZOO_SYNC_LIMIT" "syncLimit"
+	"ZOO_PRE_ALLOC_SIZE" "preAllocSize"
+	"ZOO_SNAPCOUNT" "snapCount"
+	"ZOO_MAX_CLIENT_CNXNS" "maxClientCnxns"
+	"ZOO_MAX_SESSION_TIMEOUT" "maxSessionTimeout"
+	"ZOO_AUTOPURGE_RETAIN_COUNT" "autopurge.snapRetainCount"
+	"ZOO_AUTOPURGE_INTERVAL" "autopurge.purgeInterval"
+	"ZOO_4LW_COMMANDS_WHITELIST" "4lw.commands.whitelist" }}
+{{- with index $env $envKey }}
+{{ $cfgKey }}={{ . }}
+{{- end }}
+{{- end }}
+{{- if eq (index $env "ZOO_ENABLE_PROMETHEUS_METRICS") "yes" }}
+metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider
+{{- with index $env "ZOO_PROMETHEUS_METRICS_PORT_NUMBER" }}
+metricsProvider.httpPort={{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/internal/casting/systemdcasting/templates/zookeeper.telemetrykeeper.v371.service.gotmpl
+++ b/internal/casting/systemdcasting/templates/zookeeper.telemetrykeeper.v371.service.gotmpl
@@ -1,0 +1,30 @@
+[Unit]
+Description=Apache ZooKeeper (v3.7.1)
+Requires=network-online.target
+After=time-sync.target network-online.target
+Wants=time-sync.target
+
+[Service]
+Type=simple
+User=zookeeper
+Group=zookeeper
+Restart=always
+RestartSec=30
+StateDirectory=zookeeper
+LogsDirectory=zookeeper
+Environment=ZOO_LOG_DIR=/var/log/zookeeper
+{{- with $.Spec.TelemetryKeeper.Spec.Env }}
+{{- with index . "ZOO_HEAP_SIZE" }}
+Environment=ZK_SERVER_HEAP={{ . }}
+{{- end }}
+{{- with index . "ZOO_LOG_LEVEL" }}
+Environment=ZOO_LOG4J_PROP={{ . }},CONSOLE
+{{- end }}
+{{- end }}
+{{- if $.Metadata.Annotations }}
+ExecStart={{ index $.Metadata.Annotations "foundry.signoz.io/telemetrykeeper-zookeeper-binary-path" }} start-foreground /etc/zookeeper/zoo.cfg
+{{- end }}
+LimitNOFILE=500000
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/molding/telemetrykeepermolding/telemetrykeeper.go
+++ b/internal/molding/telemetrykeepermolding/telemetrykeeper.go
@@ -82,10 +82,6 @@ func (molding *telemetrykeeper) moldZookeeper(_ context.Context, config *install
 		config.Spec.TelemetryKeeper.Status.Env = make(map[string]string)
 	}
 
-	// The production zookeeper settings, matching the signoz helm chart and the
-	// deprecated deploy/ compose (which set the first five and left the rest at
-	// the same bitnami defaults). Castings translate these to their platform's
-	// form; bitnami images consume them directly.
 	env := config.Spec.TelemetryKeeper.Status.Env
 	env["ALLOW_ANONYMOUS_LOGIN"] = "yes"
 	env["ZOO_AUTOPURGE_INTERVAL"] = "1"

--- a/internal/molding/telemetrykeepermolding/telemetrykeeper.go
+++ b/internal/molding/telemetrykeepermolding/telemetrykeeper.go
@@ -82,10 +82,26 @@ func (molding *telemetrykeeper) moldZookeeper(_ context.Context, config *install
 		config.Spec.TelemetryKeeper.Status.Env = make(map[string]string)
 	}
 
-	config.Spec.TelemetryKeeper.Status.Env["ALLOW_ANONYMOUS_LOGIN"] = "yes"
-	config.Spec.TelemetryKeeper.Status.Env["ZOO_AUTOPURGE_INTERVAL"] = "1"
-	config.Spec.TelemetryKeeper.Status.Env["ZOO_ENABLE_PROMETHEUS_METRICS"] = "yes"
-	config.Spec.TelemetryKeeper.Status.Env["ZOO_PROMETHEUS_METRICS_PORT_NUMBER"] = "9141"
+	// The production zookeeper settings, matching the signoz helm chart and the
+	// deprecated deploy/ compose (which set the first five and left the rest at
+	// the same bitnami defaults). Castings translate these to their platform's
+	// form; bitnami images consume them directly.
+	env := config.Spec.TelemetryKeeper.Status.Env
+	env["ALLOW_ANONYMOUS_LOGIN"] = "yes"
+	env["ZOO_AUTOPURGE_INTERVAL"] = "1"
+	env["ZOO_AUTOPURGE_RETAIN_COUNT"] = "3"
+	env["ZOO_ENABLE_PROMETHEUS_METRICS"] = "yes"
+	env["ZOO_PROMETHEUS_METRICS_PORT_NUMBER"] = "9141"
+	env["ZOO_TICK_TIME"] = "2000"
+	env["ZOO_INIT_LIMIT"] = "10"
+	env["ZOO_SYNC_LIMIT"] = "5"
+	env["ZOO_PRE_ALLOC_SIZE"] = "65536"
+	env["ZOO_SNAPCOUNT"] = "100000"
+	env["ZOO_MAX_CLIENT_CNXNS"] = "60"
+	env["ZOO_MAX_SESSION_TIMEOUT"] = "40000"
+	env["ZOO_4LW_COMMANDS_WHITELIST"] = "srvr, mntr, ruok"
+	env["ZOO_HEAP_SIZE"] = "1024"
+	env["ZOO_LOG_LEVEL"] = "INFO"
 
 	return nil
 }


### PR DESCRIPTION
Adds ZooKeeper as a telemetrykeeper kind for the systemd (Linux binary) casting, the setup the manual Linux install runs today. Single replica for now, same as the rest of the casting. Verified with a full `cast`: all units active, ClickHouse coordinating through ZooKeeper, a trace ingested end to end.

#### Features

- Add `telemetrykeeper.kind: zookeeper` to the systemd casting: forges a `zoo.cfg` and a ZooKeeper unit, copies the config to `/etc/zookeeper`, and validates the binary via the new `foundry.signoz.io/telemetrykeeper-zookeeper-binary-path` annotation (default `/opt/zookeeper/bin/zkServer.sh`).
- Set the production ZooKeeper settings in the telemetrykeeper molding, matching the helm chart and the deprecated `deploy/` compose. Container castings keep consuming them as env; the systemd casting translates them into `zoo.cfg`.

Related: https://github.com/SigNoz/signoz/issues/10924

Note: **Part of the migration from the older installation method to foundry for linux installs**