### PR TITLE
fix: load histogramQuantile udf and update stale docs

### DIFF
--- a/docs/examples/coolify/stack/casting.yaml.lock
+++ b/docs/examples/coolify/stack/casting.yaml.lock
@@ -511,7 +511,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -532,7 +532,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile
@@ -631,7 +631,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -652,7 +652,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -394,7 +394,7 @@ services:
         zookeeper_log:
             ttl: "event_date + INTERVAL 1 DAY DELETE"
         tcp_port: 9000
-        user_defined_executable_functions_config: '*function.yaml'
+        user_defined_executable_functions_config: '*functions.yaml'
         user_scripts_path: /var/lib/clickhouse/user_scripts/
         users:
             default:
@@ -418,7 +418,7 @@ services:
               - name: counts
                 type: Array(Float64)
               - name: quantile
-                type: Array(Float64)
+                type: Float64
           command: ./histogramQuantile
           format: CSV
           name: histogramQuantile

--- a/docs/examples/docker/compose-mcp/casting.yaml.lock
+++ b/docs/examples/docker/compose-mcp/casting.yaml.lock
@@ -519,7 +519,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -540,7 +540,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile
@@ -639,7 +639,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -660,7 +660,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile

--- a/docs/examples/docker/compose-mcp/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/docker/compose-mcp/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -71,7 +71,7 @@ tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-user_defined_executable_functions_config: '*function.yaml'
+user_defined_executable_functions_config: '*functions.yaml'
 user_directories:
   users_xml:
     path: config-0-0.yaml

--- a/docs/examples/docker/compose-mcp/pours/deployment/telemetrystore/clickhouse/functions.yaml
+++ b/docs/examples/docker/compose-mcp/pours/deployment/telemetrystore/clickhouse/functions.yaml
@@ -5,7 +5,7 @@ functions:
   - name: counts
     type: Array(Float64)
   - name: quantile
-    type: Array(Float64)
+    type: Float64
   command: ./histogramQuantile
   format: CSV
   name: histogramQuantile

--- a/docs/examples/docker/compose/casting.yaml.lock
+++ b/docs/examples/docker/compose/casting.yaml.lock
@@ -511,7 +511,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -532,7 +532,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile
@@ -631,7 +631,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -652,7 +652,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile

--- a/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -71,7 +71,7 @@ tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-user_defined_executable_functions_config: '*function.yaml'
+user_defined_executable_functions_config: '*functions.yaml'
 user_directories:
   users_xml:
     path: config-0-0.yaml

--- a/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/functions.yaml
+++ b/docs/examples/docker/compose/pours/deployment/telemetrystore/clickhouse/functions.yaml
@@ -5,7 +5,7 @@ functions:
   - name: counts
     type: Array(Float64)
   - name: quantile
-    type: Array(Float64)
+    type: Float64
   command: ./histogramQuantile
   format: CSV
   name: histogramQuantile

--- a/docs/examples/docker/swarm/casting.yaml.lock
+++ b/docs/examples/docker/swarm/casting.yaml.lock
@@ -511,7 +511,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -532,7 +532,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile
@@ -631,7 +631,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -652,7 +652,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile

--- a/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -71,7 +71,7 @@ tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-user_defined_executable_functions_config: '*function.yaml'
+user_defined_executable_functions_config: '*functions.yaml'
 user_directories:
   users_xml:
     path: config-0-0.yaml

--- a/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/functions.yaml
+++ b/docs/examples/docker/swarm/pours/deployment/telemetrystore/clickhouse/functions.yaml
@@ -5,7 +5,7 @@ functions:
   - name: counts
     type: Array(Float64)
   - name: quantile
-    type: Array(Float64)
+    type: Float64
   command: ./histogramQuantile
   format: CSV
   name: histogramQuantile

--- a/docs/examples/ecs/ec2/terraform/casting.yaml.lock
+++ b/docs/examples/ecs/ec2/terraform/casting.yaml.lock
@@ -510,7 +510,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -531,7 +531,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile
@@ -630,7 +630,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -651,7 +651,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/config-0-0.yaml
@@ -71,7 +71,7 @@ tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-user_defined_executable_functions_config: '*function.yaml'
+user_defined_executable_functions_config: '*functions.yaml'
 user_directories:
   users_xml:
     path: config-0-0.yaml

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/functions.yaml
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore/clickhouse/functions.yaml
@@ -5,7 +5,7 @@ functions:
   - name: counts
     type: Array(Float64)
   - name: quantile
-    type: Array(Float64)
+    type: Float64
   command: ./histogramQuantile
   format: CSV
   name: histogramQuantile

--- a/docs/examples/kubernetes/helm/casting.yaml.lock
+++ b/docs/examples/kubernetes/helm/casting.yaml.lock
@@ -508,7 +508,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -529,7 +529,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile
@@ -628,7 +628,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -649,7 +649,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile

--- a/docs/examples/kubernetes/kustomize/casting.yaml.lock
+++ b/docs/examples/kubernetes/kustomize/casting.yaml.lock
@@ -584,7 +584,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile
@@ -758,7 +758,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile

--- a/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/configmap.yaml
+++ b/docs/examples/kubernetes/kustomize/pours/deployment/telemetrystore/clickhouse/configmap.yaml
@@ -8,7 +8,7 @@ data:
           - name: counts
             type: Array(Float64)
           - name: quantile
-            type: Array(Float64)
+            type: Float64
       command: ./histogramQuantile
       format: CSV
       name: histogramQuantile

--- a/docs/examples/railway/template/casting.yaml.lock
+++ b/docs/examples/railway/template/casting.yaml.lock
@@ -516,7 +516,7 @@ spec:
             trace_log:
               flush_interval_milliseconds: 30000
               ttl: event_date + INTERVAL 1 DAY DELETE
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_directories:
               users_xml:
                 path: config-0-0.yaml
@@ -547,7 +547,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile
@@ -636,7 +636,7 @@ spec:
             trace_log:
               flush_interval_milliseconds: 30000
               ttl: event_date + INTERVAL 1 DAY DELETE
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_directories:
               users_xml:
                 path: config-0-0.yaml
@@ -667,7 +667,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile

--- a/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config-0-0.yaml
+++ b/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/config-0-0.yaml
@@ -71,7 +71,7 @@ tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-user_defined_executable_functions_config: '*function.yaml'
+user_defined_executable_functions_config: '*functions.yaml'
 user_directories:
   users_xml:
     path: config-0-0.yaml

--- a/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/functions.yaml
+++ b/docs/examples/railway/template/pours/deployment/telemetrystore/config.d/functions.yaml
@@ -5,7 +5,7 @@ functions:
   - name: counts
     type: Array(Float64)
   - name: quantile
-    type: Array(Float64)
+    type: Float64
   command: ./histogramQuantile
   format: CSV
   name: histogramQuantile

--- a/docs/examples/render/blueprint/casting.yaml.lock
+++ b/docs/examples/render/blueprint/casting.yaml.lock
@@ -509,7 +509,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -530,7 +530,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile
@@ -629,7 +629,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -650,7 +650,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config-0-0.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/config-0-0.yaml
@@ -71,7 +71,7 @@ tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-user_defined_executable_functions_config: '*function.yaml'
+user_defined_executable_functions_config: '*functions.yaml'
 user_directories:
   users_xml:
     path: config-0-0.yaml

--- a/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/functions.yaml
+++ b/docs/examples/render/blueprint/pours/deployment/configs/telemetrystore/config.d/functions.yaml
@@ -5,7 +5,7 @@ functions:
   - name: counts
     type: Array(Float64)
   - name: quantile
-    type: Array(Float64)
+    type: Float64
   command: ./histogramQuantile
   format: CSV
   name: histogramQuantile

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -7,7 +7,6 @@ metadata:
     foundry.signoz.io/metastore-postgres-binary-path: /usr/bin/postgres
     foundry.signoz.io/signoz-binary-path: /opt/signoz/bin/signoz
     foundry.signoz.io/telemetrykeeper-clickhousekeeper-binary-path: /usr/bin/clickhouse
-    foundry.signoz.io/telemetrykeeper-zookeeper-binary-path: /opt/zookeeper/bin/zkServer.sh
     foundry.signoz.io/telemetrystore-clickhouse-binary-path: /usr/bin/clickhouse
   name: signoz
 spec:

--- a/docs/examples/systemd/binary/casting.yaml.lock
+++ b/docs/examples/systemd/binary/casting.yaml.lock
@@ -7,6 +7,7 @@ metadata:
     foundry.signoz.io/metastore-postgres-binary-path: /usr/bin/postgres
     foundry.signoz.io/signoz-binary-path: /opt/signoz/bin/signoz
     foundry.signoz.io/telemetrykeeper-clickhousekeeper-binary-path: /usr/bin/clickhouse
+    foundry.signoz.io/telemetrykeeper-zookeeper-binary-path: /opt/zookeeper/bin/zkServer.sh
     foundry.signoz.io/telemetrystore-clickhouse-binary-path: /usr/bin/clickhouse
   name: signoz
 spec:
@@ -523,7 +524,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -544,7 +545,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile
@@ -643,7 +644,7 @@ spec:
             zookeeper_log:
                 ttl: "event_date + INTERVAL 1 DAY DELETE"
             tcp_port: 9000
-            user_defined_executable_functions_config: '*function.yaml'
+            user_defined_executable_functions_config: '*functions.yaml'
             user_scripts_path: /var/lib/clickhouse/user_scripts/
             users:
                 default:
@@ -664,7 +665,7 @@ spec:
                   - name: counts
                     type: Array(Float64)
                   - name: quantile
-                    type: Array(Float64)
+                    type: Float64
               command: ./histogramQuantile
               format: CSV
               name: histogramQuantile

--- a/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/config-0-0.yaml
@@ -71,7 +71,7 @@ tmp_path: /var/lib/clickhouse/tmp/
 trace_log:
   flush_interval_milliseconds: 30000
   ttl: event_date + INTERVAL 1 DAY DELETE
-user_defined_executable_functions_config: '*function.yaml'
+user_defined_executable_functions_config: '*functions.yaml'
 user_directories:
   users_xml:
     path: config-0-0.yaml

--- a/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/functions.yaml
+++ b/docs/examples/systemd/binary/pours/deployment/telemetrystore/clickhouse/functions.yaml
@@ -5,7 +5,7 @@ functions:
   - name: counts
     type: Array(Float64)
   - name: quantile
-    type: Array(Float64)
+    type: Float64
   command: ./histogramQuantile
   format: CSV
   name: histogramQuantile

--- a/docs/reference/casting-file.md
+++ b/docs/reference/casting-file.md
@@ -195,4 +195,4 @@ Required when using `platform: ecs`, `mode: ec2`, `flavor: terraform`.
 
 ## Schema
 
-The full JSON Schema for `casting.yaml` is available at [`docs/schemas/v1alpha1.yaml`](../schemas/v1alpha1.yaml).
+The full JSON Schema for `casting.yaml` is available at [`docs/schemas/v1alpha1.yaml`](../../api/v1alpha1/casting.schema.json)

--- a/internal/molding/telemetrystoremolding/templates/config.clickhouse.v25125.yaml.gotmpl
+++ b/internal/molding/telemetrystoremolding/templates/config.clickhouse.v25125.yaml.gotmpl
@@ -89,7 +89,7 @@ text_log:
 zookeeper_log:
     ttl: "event_date + INTERVAL 1 DAY DELETE"
 tcp_port: 9000
-user_defined_executable_functions_config: '*function.yaml'
+user_defined_executable_functions_config: '*functions.yaml'
 user_scripts_path: /var/lib/clickhouse/user_scripts/
 users:
     default:

--- a/internal/molding/telemetrystoremolding/templates/functions.clickhouse.v25125.yaml.gotmpl
+++ b/internal/molding/telemetrystoremolding/templates/functions.clickhouse.v25125.yaml.gotmpl
@@ -5,7 +5,7 @@ functions:
       - name: counts
         type: Array(Float64)
       - name: quantile
-        type: Array(Float64)
+        type: Float64
   command: ./histogramQuantile
   format: CSV
   name: histogramQuantile


### PR DESCRIPTION
#### Fixes

- Load the `histogramQuantile` function definition: the ClickHouse config glob never matched the generated `functions.yaml`, so every histogram quantile query failed with `UNKNOWN_FUNCTION`. The quantile argument is now `Float64`, matching what signoz passes. Related #161

#### Chores
- Fix the casting schema link in the reference docs, it pointed at a file that does not exist. Related #162