### PR TITLE
fix(installation): correct mcp health checks for the distroless image

### DIFF
--- a/docs/examples/docker/compose-mcp/README.md
+++ b/docs/examples/docker/compose-mcp/README.md
@@ -53,8 +53,6 @@ The compose file gains a `signoz-mcp` service on port `8000`, with its env fille
     - SIGNOZ_URL=http://signoz-signoz-0:8080   # the in-network SigNoz apiserver
     ports:
     - "8000:8000"
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8000/livez"]
 ```
 
 Verify it is up:

--- a/docs/examples/docker/compose-mcp/pours/deployment/compose.yaml
+++ b/docs/examples/docker/compose-mcp/pours/deployment/compose.yaml
@@ -32,17 +32,6 @@ services:
     - MCP_SERVER_PORT=8000
     - SIGNOZ_URL=http://signoz-signoz-0:8080
     - TRANSPORT_MODE=http
-    healthcheck:
-      interval: 10s
-      retries: 5
-      start_period: 10s
-      test:
-      - CMD
-      - wget
-      - --spider
-      - -q
-      - http://localhost:8000/livez
-      timeout: 1s
     image: signoz/signoz-mcp-server:latest
     networks:
     - signoz-network

--- a/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
+++ b/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
@@ -219,17 +219,6 @@ services:
       - {{ $key }}={{ $value }}
       {{- end }}
     {{- end }}
-    healthcheck:
-      test:
-        - CMD
-        - wget
-        - --spider
-        - -q
-        - http://localhost:8000/livez
-      interval: 10s
-      timeout: 1s
-      retries: 5
-      start_period: 10s
     logging:
       options:
         max-size: 50m

--- a/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl
@@ -228,17 +228,6 @@ services:
     {{- end }}
     ports:
       - "8000:8000"
-    healthcheck:
-      test:
-      - "CMD"
-      - "wget"
-      - "--spider"
-      - "-q"
-      - "http://localhost:8000/livez"
-      interval: 10s
-      timeout: 1s
-      retries: 5
-      start_period: 10s
   {{- end }}
   {{ $.Metadata.Name }}-telemetrystore-migrator:
     container_name: {{ $.Metadata.Name }}-telemetrystore-migrator

--- a/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
+++ b/internal/casting/dockerswarmcasting/templates/compose.yaml.gotmpl
@@ -231,17 +231,6 @@ services:
       replicas: {{ int $.Spec.MCP.Spec.Cluster.Replicas }}
       restart_policy:
         condition: on-failure
-    healthcheck:
-      test:
-      - "CMD"
-      - "wget"
-      - "--spider"
-      - "-q"
-      - "http://localhost:8000/livez"
-      interval: 10s
-      timeout: 1s
-      retries: 5
-      start_period: 10s
   {{- end }}
   {{ $.Metadata.Name }}-telemetrystore-migrator:
     image: {{ $.Spec.Ingester.Spec.Image }}


### PR DESCRIPTION
#### Fixes

- Removes the mcp `wget` healthcheck from the compose, swarm and coolify templates; the image is distroless (no wget or shell), so the check can never pass and marks a healthy server unhealthy
- Re-forges the compose-mcp example pours and README snippet accordingly

Related: SigNoz/signoz-mcp-server#246, https://github.com/SigNoz/platform-pod/issues/2417