### PR TITLE
docs: document the spec.config override merge contract

### DIFF
--- a/api/v1alpha1/molding_test.go
+++ b/api/v1alpha1/molding_test.go
@@ -29,6 +29,20 @@ func TestMergeStatus(t *testing.T) {
 			expected:   map[string]string{"config-0-0.yaml": "a: b\n", "extra.yaml": "foo: bar\n"},
 		},
 		{
+			name:       "ListOverride_ReplacesWholesale",
+			statusData: map[string]string{"agent.yaml": "service:\n  pipelines:\n    metrics:\n      receivers:\n      - otlp\n      - hostmetrics\n"},
+			specData:   map[string]string{"agent.yaml": "service:\n  pipelines:\n    metrics:\n      receivers:\n      - otlp\n"},
+			pass:       true,
+			expected:   map[string]string{"agent.yaml": "service:\n  pipelines:\n    metrics:\n      receivers:\n      - otlp\n"},
+		},
+		{
+			name:       "NullOverride_DeletesKey",
+			statusData: map[string]string{"agent.yaml": "receivers:\n  hostmetrics:\n    collection_interval: 30s\n  otlp:\n    protocols: {}\n"},
+			specData:   map[string]string{"agent.yaml": "receivers:\n  hostmetrics: null\n"},
+			pass:       true,
+			expected:   map[string]string{"agent.yaml": "receivers:\n  otlp:\n    protocols: {}\n"},
+		},
+		{
 			name:       "MalformedOverride_Invalid",
 			statusData: map[string]string{"config-0-0.yaml": "a: b\n"},
 			specData:   map[string]string{"config-0-0.yaml": "a: [b\n"},

--- a/docs/concepts/casting.md
+++ b/docs/concepts/casting.md
@@ -100,6 +100,17 @@ Patches let you customize any generated output file without Foundry needing to m
 
 See [Patches](patches.md) for the full guide.
 
+## Which override goes where
+
+| Change | Where |
+|---|---|
+| Image, version, replicas, env, enabling a component | Molding `spec` fields, see [Moldings](moldings.md) |
+| A component's config file | `config.data` under the molding's spec, see [Custom config files](moldings.md#custom-config-files) |
+| A generated platform file | `spec.patches`, see [Patches](patches.md) |
+| A parameter Foundry reads during generation | `metadata.annotations`, see [Annotations](annotations.md) |
+
+If a spec field exists, use it. `config.data` merges into the component's generated config (maps merge, lists replace). Patches apply last, on the generated output.
+
 ## Minimal example
 
 Docker Compose with all defaults:

--- a/docs/concepts/moldings.md
+++ b/docs/concepts/moldings.md
@@ -63,10 +63,24 @@ spec:
 
 ### Custom config files
 
-Use `config.data` to override a component's config files. The key is the filename; whatever you set gets merged with the config Foundry generates, so you only set what you want to change.
+Use `config.data` to override a component's config files. The key is the name of a file Foundry generates; the value is a YAML fragment with only the changes. Foundry merges the fragment onto the generated file per [JSON Merge Patch (RFC 7386)](https://datatracker.ietf.org/doc/html/rfc7386):
+
+- Scalars and maps deep-merge: your value wins, generated siblings survive.
+- Setting a key to `null` deletes it.
+- Lists are replaced wholesale: restate every member you want to keep.
+
+Run `foundryctl forge` and read the generated file under `pours/` to see what a fragment merges onto.
+
+Overriding a single value in the ingester's config:
 
 ```yaml
+apiVersion: v1alpha1
+metadata:
+  name: signoz
 spec:
+  deployment:
+    mode: docker
+    flavor: compose
   ingester:
     spec:
       config:
@@ -77,6 +91,58 @@ spec:
                 protocols:
                   grpc:
                     endpoint: 0.0.0.0:4317
+```
+
+Adding a receiver to a pipeline. `receivers` is a list, so the generated `otlp` member is restated:
+
+```yaml
+apiVersion: v1alpha1
+metadata:
+  name: signoz
+spec:
+  deployment:
+    mode: docker
+    flavor: compose
+  ingester:
+    spec:
+      config:
+        data:
+          ingester.yaml: |
+            receivers:
+              prometheus:
+                config:
+                  scrape_configs:
+                    - job_name: my-app
+                      static_configs:
+                        - targets: ["localhost:8080"]
+            service:
+              pipelines:
+                metrics:
+                  receivers: [otlp, prometheus]
+```
+
+> [!WARNING]
+> Writing `receivers: [prometheus]` above would replace the list and drop `otlp` from the pipeline.
+
+To remove something, set its definition to `null` and restate the list that references it. Disabling the ingester's `pprof` extension:
+
+```yaml
+apiVersion: v1alpha1
+metadata:
+  name: signoz
+spec:
+  deployment:
+    mode: docker
+    flavor: compose
+  ingester:
+    spec:
+      config:
+        data:
+          ingester.yaml: |
+            extensions:
+              pprof: null
+            service:
+              extensions: [signoz_health_check]
 ```
 
 > [!NOTE]


### PR DESCRIPTION
#### Tests

- Pins the `config.data` user-override merge contract in `MergeStatus`: lists replace wholesale, `null` deletes a key.

#### Chores

- Documents the `config.data` merge rules (maps merge, lists replace, `null` deletes) in the moldings concept doc, with forge-verified examples: partial override, adding a receiver to a pipeline, disabling the `pprof` extension.
- Adds a "Which override goes where" section to the casting concept doc mapping each override surface (spec fields, `config.data`, patches, annotations) to its use.

Related: SigNoz/platform-pod#2527