### PR TITLE
feat(ledger): report each casting's outcome through a reporter

### DIFF
--- a/cmd/foundryctl/cast.go
+++ b/cmd/foundryctl/cast.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"path/filepath"
 
-	"github.com/signoz/foundry/api/v1alpha1"
 	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/errors"
 	"github.com/signoz/foundry/internal/foundry"
@@ -17,22 +16,30 @@ func registerCastCmd(rootCmd *cobra.Command) {
 	castCmd := &cobra.Command{
 		Use:   "cast",
 		Short: "Cast to the target environment.",
-		RunE: recoverRunE(domain.EventCast, func(cmd *cobra.Command, args []string) (domain.Properties, error) {
+		RunE: recoverRunE(domain.EventCast, func(cmd *cobra.Command, args []string, report reporter) error {
 			ctx := cmd.Context()
 
+			// A document the inner stages pass is prepared, not cast, so
+			// only their failures report.
+			prepReport := reporter(func(props domain.Properties, err error) {
+				if err != nil {
+					report(props, err)
+				}
+			})
+
 			if !castCfg.NoGauge {
-				if props, err := runGauge(ctx, rootLogger, commonCfg.File); err != nil {
-					return props, err
+				if err := runGauge(ctx, rootLogger, commonCfg.File, prepReport); err != nil {
+					return err
 				}
 			}
 
 			if !castCfg.NoForge {
-				if props, err := runForge(ctx, rootLogger, commonCfg.File, poursCfg.Path); err != nil {
-					return props, err
+				if err := runForge(ctx, rootLogger, commonCfg.File, poursCfg.Path, prepReport); err != nil {
+					return err
 				}
 			}
 
-			return runCast(ctx, rootLogger, poursCfg.Path, commonCfg.File)
+			return runCast(ctx, rootLogger, poursCfg.Path, commonCfg.File, report)
 		}),
 	}
 
@@ -40,34 +47,30 @@ func registerCastCmd(rootCmd *cobra.Command) {
 	castCfg.RegisterFlags(castCmd)
 }
 
-func runCast(ctx context.Context, logger *slog.Logger, poursPath string, configPath string) (domain.Properties, error) {
+func runCast(ctx context.Context, logger *slog.Logger, poursPath string, configPath string, report reporter) error {
 	foundry, err := foundry.New(logger)
 	if err != nil {
-		return domain.NewProperties(), err
+		return err
 	}
 
 	poursPath, err = filepath.Abs(poursPath)
 	if err != nil {
-		return domain.NewProperties(), errors.Wrapf(err, errors.TypeInternal, "failed to resolve pours path")
+		return errors.Wrapf(err, errors.TypeInternal, "failed to resolve pours path")
 	}
 
 	machineries, err := foundry.Config.GetV1Alpha1Lock(ctx, configPath)
 	if err != nil {
-		return domain.NewProperties(), err
-	}
-
-	props := domain.NewProperties()
-	for _, machinery := range machineries {
-		if machinery.Kind() == v1alpha1.KindInstallation {
-			props = machinery.TrackableProperties()
-		}
+		return err
 	}
 
 	for _, machinery := range machineries {
 		if err := foundry.Cast(ctx, machinery, poursPath); err != nil {
-			return props, err
+			report(machinery.TrackableProperties(), err)
+			return err
 		}
+
+		report(machinery.TrackableProperties(), nil)
 	}
 
-	return props, nil
+	return nil
 }

--- a/cmd/foundryctl/catalog.go
+++ b/cmd/foundryctl/catalog.go
@@ -17,7 +17,7 @@ func registerCatalogCmd(rootCmd *cobra.Command) {
 	catalogCmd := &cobra.Command{
 		Use:   "catalog",
 		Short: "Show available castings",
-		RunE: recoverRunE(domain.EventCatalog, func(cmd *cobra.Command, args []string) (domain.Properties, error) {
+		RunE: recoverRunE(domain.EventCatalog, func(cmd *cobra.Command, args []string, _ reporter) error {
 			return runCatalog(rootLogger)
 		}),
 	}
@@ -60,7 +60,7 @@ func catalogGroup(e castingEntry) int {
 	}
 }
 
-func runCatalog(logger *slog.Logger) (domain.Properties, error) {
+func runCatalog(logger *slog.Logger) error {
 	registry := installationcasting.NewRegistry(logger)
 
 	var entries []castingEntry
@@ -81,8 +81,6 @@ func runCatalog(logger *slog.Logger) (domain.Properties, error) {
 		return entries[i].Example < entries[j].Example
 	})
 
-	props := domain.NewProperties()
-
 	if commonCfg.Format == "text" {
 		table := tablewriter.NewWriter(os.Stdout)
 		table.Header("Mode", "Flavor", "Platform", "Example")
@@ -90,17 +88,16 @@ func runCatalog(logger *slog.Logger) (domain.Properties, error) {
 			_ = table.Append(e.Mode, e.Flavor, e.Platform, e.Example)
 		}
 
-		return props, table.Render()
+		return table.Render()
 	}
 
 	data, err := json.MarshalIndent(map[string]any{"Castings": entries}, "", "  ")
 	if err != nil {
-		return props, err
+		return err
 	}
 	if catalogCfg.OutPath != "" {
-		err = os.WriteFile(catalogCfg.OutPath, data, 0644)
-		return props, err
+		return os.WriteFile(catalogCfg.OutPath, data, 0644)
 	}
 	_, err = os.Stdout.Write(data)
-	return props, err
+	return err
 }

--- a/cmd/foundryctl/forge.go
+++ b/cmd/foundryctl/forge.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/signoz/foundry/api/v1alpha1"
 	"github.com/signoz/foundry/internal/domain"
 	"github.com/signoz/foundry/internal/foundry"
 	"github.com/signoz/foundry/internal/writer"
@@ -18,46 +17,42 @@ func registerForgeCmd(rootCmd *cobra.Command) {
 		Use:   "forge",
 		Short: "Forge Configuration and Deployment Files",
 		Long:  "Generate deployment configuration files from casting.yaml",
-		RunE: recoverRunE(domain.EventForge, func(cmd *cobra.Command, args []string) (domain.Properties, error) {
-			return runForge(cmd.Context(), rootLogger, commonCfg.File, poursCfg.Path)
+		RunE: recoverRunE(domain.EventForge, func(cmd *cobra.Command, args []string, report reporter) error {
+			return runForge(cmd.Context(), rootLogger, commonCfg.File, poursCfg.Path, report)
 		}),
 	}
 
 	rootCmd.AddCommand(forgeCmd)
 }
 
-func runForge(ctx context.Context, logger *slog.Logger, path string, poursPath string) (domain.Properties, error) {
+func runForge(ctx context.Context, logger *slog.Logger, path string, poursPath string, report reporter) error {
 	foundry, err := foundry.New(logger)
 	if err != nil {
-		return domain.NewProperties(), err
+		return err
 	}
 
 	machineries, err := foundry.Config.GetV1Alpha1(ctx, path)
 	if err != nil {
-		return domain.NewProperties(), err
+		return err
 	}
 
 	if err := foundry.Config.PruneV1Alpha1Lock(ctx, machineries, path); err != nil {
-		return domain.NewProperties(), err
-	}
-
-	props := domain.NewProperties()
-	for _, machinery := range machineries {
-		if machinery.Kind() == v1alpha1.KindInstallation {
-			props = machinery.TrackableProperties()
-		}
+		return err
 	}
 
 	poursAbsPath, err := filepath.Abs(poursPath)
 	if err != nil {
-		return props, err
+		return err
 	}
 
 	for _, machinery := range machineries {
 		if err := foundry.Forge(ctx, machinery, path, &writer.Options{Output: &os.File{}, TargetDirectory: poursAbsPath}); err != nil {
-			return props, err
+			report(machinery.TrackableProperties(), err)
+			return err
 		}
+
+		report(machinery.TrackableProperties(), nil)
 	}
 
-	return props, nil
+	return nil
 }

--- a/cmd/foundryctl/gauge.go
+++ b/cmd/foundryctl/gauge.go
@@ -14,23 +14,23 @@ func registerGaugeCmd(rootCmd *cobra.Command) {
 	gaugeCmd := &cobra.Command{
 		Use:   "gauge",
 		Short: "Gauge whether required tools are available.",
-		RunE: recoverRunE(domain.EventGauge, func(cmd *cobra.Command, args []string) (domain.Properties, error) {
-			return runGauge(cmd.Context(), rootLogger, commonCfg.File)
+		RunE: recoverRunE(domain.EventGauge, func(cmd *cobra.Command, args []string, report reporter) error {
+			return runGauge(cmd.Context(), rootLogger, commonCfg.File, report)
 		}),
 	}
 
 	rootCmd.AddCommand(gaugeCmd)
 }
 
-func runGauge(ctx context.Context, logger *slog.Logger, path string) (domain.Properties, error) {
+func runGauge(ctx context.Context, logger *slog.Logger, path string, report reporter) error {
 	foundry, err := foundry.New(logger)
 	if err != nil {
-		return domain.NewProperties(), err
+		return err
 	}
 
 	machineries, err := foundry.Config.GetV1Alpha1(ctx, path)
 	if err != nil {
-		return domain.NewProperties(), err
+		return err
 	}
 
 	props := domain.NewProperties()
@@ -41,5 +41,6 @@ func runGauge(ctx context.Context, logger *slog.Logger, path string) (domain.Pro
 	}
 
 	err = foundry.Gauge(ctx, machineries)
-	return props, err
+	report(props, err)
+	return err
 }

--- a/cmd/foundryctl/gen.go
+++ b/cmd/foundryctl/gen.go
@@ -91,7 +91,7 @@ func runGenExamples(ctx context.Context, logger *slog.Logger) error {
 			return err
 		}
 
-		if _, err := runForge(ctx, logger, filepath.Join(rootPath, "casting.yaml"), filepath.Join(rootPath, "pours")); err != nil {
+		if err := runForge(ctx, logger, filepath.Join(rootPath, "casting.yaml"), filepath.Join(rootPath, "pours"), func(domain.Properties, error) {}); err != nil {
 			logger.ErrorContext(ctx, "failed to forge casting", slog.Any("deployment", deployment), foundryerrors.LogAttr(err))
 			continue
 		}

--- a/cmd/foundryctl/root.go
+++ b/cmd/foundryctl/root.go
@@ -55,13 +55,32 @@ func closeRoot() {
 	}
 }
 
+// reporter records one casting document's outcome, called once per document
+// as it completes; err is nil when the document succeeded.
+type reporter func(props domain.Properties, err error)
+
+// recoverRunE hands the runner a reporter that tracks every reported outcome
+// as one event. An error the runner never reported tracks without document
+// properties; a clean return that reported nothing tracks the lone success.
 func recoverRunE(
 	event domain.Event,
-	runE func(cmd *cobra.Command, args []string) (domain.Properties, error),
+	runE func(cmd *cobra.Command, args []string, report reporter) error,
 ) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) (err error) {
 		ctx := cmd.Context()
-		props := domain.NewProperties()
+		reported, failureReported := false, false
+
+		report := func(props domain.Properties, reportErr error) {
+			reported = true
+
+			if reportErr != nil {
+				failureReported = true
+				rootTracker.Track(ctx, event.Failed(), props.WithError(reportErr))
+				return
+			}
+
+			rootTracker.Track(ctx, event.Succeeded(), props.WithSuccess())
+		}
 
 		defer func() {
 			if r := recover(); r != nil {
@@ -74,7 +93,9 @@ func recoverRunE(
 
 			if err != nil {
 				rootLogger.ErrorContext(ctx, event.String()+" failed", foundryerrors.LogAttr(err))
-				rootTracker.Track(ctx, event.Failed(), props.WithError(err))
+				if !failureReported {
+					rootTracker.Track(ctx, event.Failed(), domain.NewProperties().WithError(err))
+				}
 				if commonCfg.Format == "json" {
 					_ = writer.WriteOutput(os.Stdout, foundryerrors.EnvelopeOf(err))
 					cmd.SilenceErrors = true
@@ -82,10 +103,12 @@ func recoverRunE(
 				return
 			}
 
-			rootTracker.Track(ctx, event.Succeeded(), props.WithSuccess())
+			if !reported {
+				rootTracker.Track(ctx, event.Succeeded(), domain.NewProperties().WithSuccess())
+			}
 		}()
 
-		props, err = runE(cmd, args)
+		err = runE(cmd, args, report)
 		return err
 	}
 }


### PR DESCRIPTION
Stacked on #181.

Usage reporting was one event per command, and its properties were read only when the document was an Installation. With multi-document files that breaks in two ways: a run forging an Installation and a CollectionAgent reports a single event that names neither, and a CollectionAgent run reports no kind at all. A failure hides which document broke.

#### Features

- Reports one event per casting document: `forge` and `cast` emit a succeeded event for each document that landed and a failed event carrying the kind that broke. Documents past the failing one report nothing.
- The command wrapper alone stamps outcomes and tracks; a failure no document owns keeps the bare per-command event.

#### Refactors

- A `cast` run's inner gauge and forge stages report under the cast event only: a document those stages pass is prepared, not cast, so only their failures report.

Related: https://github.com/SigNoz/platform-pod/issues/2966
