### PR TITLE
fix(release): link release binaries statically

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,6 +32,8 @@ builds:
       - -X github.com/signoz/foundry/internal/updater.repository=SigNoz/foundry
     tags:
       - timetzdata
+    env:
+      - CGO_ENABLED=0
 
 archives:
   - formats:


### PR DESCRIPTION
#### Fixes

- Builds release binaries with `CGO_ENABLED=0`, so they are statically linked and run on any glibc version.

#### Evidence

1. Go enables cgo by default for native builds when a C compiler is present ([cmd/cgo docs](https://pkg.go.dev/cmd/cgo)). The release job runs on `ubuntu-latest`, which has gcc , so the linux/amd64 build got cgo and linked the runner's glibc.
2. GoReleaser sets no cgo default; builds inherit the runner's environment ([builds docs](https://goreleaser.com/customization/builds/go/)).
3. `go version -m` on the v0.2.17 artifacts: linux/amd64 embeds `CGO_ENABLED=1`, darwin/arm64 embeds `CGO_ENABLED=0`, the split only a default produces.


Related https://github.com/SigNoz/foundry/issues/184