### PR TITLE
feat(collectionagent): add the ecs ec2 daemon terraform casting

### DIFF
--- a/api/v1alpha1/collectionagent/annotations.go
+++ b/api/v1alpha1/collectionagent/annotations.go
@@ -1,0 +1,37 @@
+package collectionagent
+
+import "github.com/signoz/foundry/api/v1alpha1"
+
+// Cluster annotations for the ECS/EC2 deployment of the CollectionAgent Kind.
+// The two roles die with the stack, so an absent one is created, not looked up.
+var (
+	ECSRegion = v1alpha1.Annotation{
+		Key:         "foundry.signoz.io/ecs-region",
+		Mode:        v1alpha1.ModeEC2,
+		Description: "AWS region holding the cluster.",
+	}
+	ECSClusterARN = v1alpha1.Annotation{
+		Key:         "foundry.signoz.io/ecs-cluster-arn",
+		Mode:        v1alpha1.ModeEC2,
+		Description: "ARN of the ECS cluster to run the agent on.",
+	}
+	ECSTaskRoleARN = v1alpha1.Annotation{
+		Key:         "foundry.signoz.io/ecs-task-role-arn",
+		Mode:        v1alpha1.ModeEC2,
+		Description: "IAM role ARN assumed by the agent task; needs read access to AWS AppConfig. Created when absent.",
+	}
+	ECSTaskExecutionRoleARN = v1alpha1.Annotation{
+		Key:         "foundry.signoz.io/ecs-task-execution-role-arn",
+		Mode:        v1alpha1.ModeEC2,
+		Description: "IAM role ARN the ECS agent assumes to pull images and start tasks. Created when absent.",
+	}
+)
+
+func Annotations() []v1alpha1.Annotation {
+	return []v1alpha1.Annotation{
+		ECSRegion,
+		ECSClusterARN,
+		ECSTaskRoleARN,
+		ECSTaskExecutionRoleARN,
+	}
+}

--- a/docs/examples/collectionagent/ecs/ec2/terraform/README.md
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/README.md
@@ -1,0 +1,168 @@
+# ECS EC2 Collection Agent
+
+| Field | Value |
+| --- | --- |
+| **Kind** | `CollectionAgent` |
+| **Platform** | `ecs` |
+| **Mode** | `ec2` |
+| **Flavor** | `terraform` |
+
+## Overview
+
+Deploys a SigNoz Collection Agent onto an existing Amazon ECS cluster as a daemon service: one agent task on every EC2 container instance registered to the cluster. The agent runs the OpenTelemetry Collector and exports to any SigNoz: Self-Hosted Community, Self-Hosted Enterprise, or SigNoz Cloud.
+
+It collects:
+
+- Container metrics from the instance's Docker Engine API through the `docker_stats` receiver
+- Instance metrics from the mounted host filesystem through the `hostmetrics` receiver
+- Container logs from the Docker JSON log files, and the instance's own `/var/log` messages, secure and ECS agent logs, through the `filelog` receivers
+- Instance identity through the `resourcedetection` processor's `env` and `ec2` detectors
+
+The task uses the `host` network mode, so OTLP intake is on the instance's own `localhost:4317` (gRPC) and `localhost:4318` (HTTP). Tasks on that instance using the `host` network mode reach the agent there. Tasks using `awsvpc` have their own loopback and must address the instance's private IP instead.
+
+Containers using the `awslogs` log driver write nothing to the instance, so the agent does not read their logs.
+
+Foundry generates Terraform. It does not create the cluster.
+
+## Prerequisites
+
+- An ECS cluster with registered EC2 container instances. Fargate has no host to run a daemon on.
+- [Terraform](https://developer.hashicorp.com/terraform/install) 1.4 or newer
+- AWS credentials in the environment Terraform runs in, with permission to create AppConfig applications, IAM roles, task definitions and services
+- A running SigNoz to receive the telemetry: [Self-Hosted Community](../../../../docker/compose/README.md), Self-Hosted Enterprise, or [SigNoz Cloud](https://signoz.io/teams/)
+
+## Configuration
+
+The default casting (this directory's `casting.yaml`):
+
+```yaml
+apiVersion: v1alpha1
+kind: CollectionAgent
+metadata:
+  name: signoz
+  annotations:
+    foundry.signoz.io/ecs-region: us-east-1
+    foundry.signoz.io/ecs-cluster-arn: arn:aws:ecs:us-east-1:123456789012:cluster/signoz
+spec:
+  deployment:
+    platform: ecs
+    mode: ec2
+    flavor: terraform
+  collector:
+    kind: agent
+    spec:
+      env:
+        SIGNOZ_INGESTION_ENDPOINT: "https://ingest.us.signoz.cloud:443"
+```
+
+| Annotation | Meaning |
+| --- | --- |
+| `foundry.signoz.io/ecs-region` | AWS region holding the cluster. Required. |
+| `foundry.signoz.io/ecs-cluster-arn` | ARN of the ECS cluster to run the agent on. Required. |
+| `foundry.signoz.io/ecs-task-role-arn` | IAM role the agent task assumes. Created when absent. |
+| `foundry.signoz.io/ecs-task-execution-role-arn` | IAM role the ECS agent assumes to pull images. Created when absent. |
+
+Terraform validates the region and the cluster ARN at plan. State a role ARN and nothing is created; that role needs `appconfig:StartConfigurationSession` and `appconfig:GetLatestConfiguration`. Leave it out and the role is created as `signoz-collectionagent-iam-task` or `signoz-collectionagent-iam-exec`. For the full annotation table, see the [casting file reference](../../../../../reference/casting-file.md).
+
+### Point the agent at your SigNoz
+
+Set the endpoint through `spec.collector.spec.env`, which becomes the task's container environment. For SigNoz Cloud or Self-Hosted Enterprise, add the [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/) as an exporter header through `spec.collector.spec.config.data`:
+
+```yaml
+  collector:
+    kind: agent
+    spec:
+      env:
+        SIGNOZ_INGESTION_ENDPOINT: "https://ingest.us.signoz.cloud:443"
+        SIGNOZ_INGESTION_KEY: "<your-ingestion-key>"
+        OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production"
+      config:
+        data:
+          collector/agent/agent.yaml: |
+            exporters:
+              otlphttp/signoz:
+                headers:
+                  signoz-ingestion-key: ${env:SIGNOZ_INGESTION_KEY}
+```
+
+`spec.collector.spec.env` values land in the task definition in plain text. For a Self-Hosted Community installation the OTLP HTTP ingest is port `4318` on the SigNoz host and there is no ingestion key.
+
+The collector config is delivered through [AWS AppConfig](https://docs.aws.amazon.com/appconfig/): a sidecar in the task fetches it and writes it to `/conf/agent.yaml`, and the collector starts once the sidecar is healthy. A changed config replaces the task.
+
+## Deploy
+
+```bash
+foundryctl cast -f casting.yaml
+```
+
+Or step by step:
+
+```bash
+foundryctl gauge -f casting.yaml
+foundryctl forge -f casting.yaml
+cd pours/collectionagent
+terraform init
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+`cast` runs the same three terraform steps.
+
+## Generated output
+
+```text
+pours/collectionagent/
+  versions.tf.json          # required terraform and provider versions
+  providers.tf.json         # the aws provider, in var.aws_region
+  backend.tf.json           # local state, beside the pours
+  variables.tf.json         # every identifier the root declares, each validated
+  terraform.tfvars.json     # the values the casting resolved
+  main.tf.json              # AppConfig application, environment, strategy; the two roles
+  collector.tf.json         # config profile and deployment, task definition, daemon service
+  collector/
+    agent/
+      agent.yaml            # the collector config, uploaded from here
+```
+
+Terraform keeps its state file beside the pours. Keep it: `terraform destroy` needs it to know what to remove. To hold state remotely instead, patch `backend.tf.json`.
+
+Host networking means these are the instance's own ports:
+
+| Port | Bound by |
+| --- | --- |
+| 4317 | OTLP intake, gRPC |
+| 4318 | OTLP intake, HTTP |
+| 13133 | the collector's health check endpoint |
+
+## After deployment
+
+```bash
+# One task per container instance
+aws ecs describe-services --cluster <cluster> --services signoz-collector-agent
+
+# Agent health, from the instance
+curl -fsS localhost:13133/healthz && echo " OK"
+
+# Remove the daemon service, its task definition and its AppConfig application
+cd pours/collectionagent && terraform destroy
+```
+
+Point [instrumented applications](https://signoz.io/docs/instrumentation/) at `http://localhost:4317` (gRPC) or `http://localhost:4318` (HTTP). In SigNoz, the instances appear under [Infrastructure Monitoring](https://signoz.io/docs/infrastructure-monitoring/hostmetrics/) and per-container metrics under [Docker container metrics](https://signoz.io/docs/metrics-management/docker-container-metrics/).
+
+## Customization
+
+Override any collector setting through `spec.collector.spec.config.data`; user keys win over generated ones, and the merged result is what AppConfig delivers. For changes to the generated Terraform itself, use [patches](../../../../../concepts/patches.md). For example, to hold the state in S3:
+
+```yaml
+spec:
+  patches:
+    - target: "collectionagent/backend.tf.json"
+      operations:
+        - op: replace
+          path: /terraform/backend
+          value:
+            s3:
+              bucket: my-terraform-state
+              key: signoz/collectionagent.tfstate
+              region: us-east-1
+```

--- a/docs/examples/collectionagent/ecs/ec2/terraform/README.md
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/README.md
@@ -20,7 +20,7 @@ It collects:
 
 The task uses the `host` network mode, so OTLP intake is on the instance's own `localhost:4317` (gRPC) and `localhost:4318` (HTTP). Tasks on that instance using the `host` network mode reach the agent there. Tasks using `awsvpc` have their own loopback and must address the instance's private IP instead.
 
-Containers using the `awslogs` log driver write nothing to the instance, so the agent does not read their logs.
+Containers using the `awslogs` log driver write nothing to the instance, so the agent does not read their logs. The agent's own containers log through `json-file` on the instance, readable with `docker logs`, and the agent drops its own lines from what it ships.
 
 Foundry generates Terraform. It does not create the cluster.
 

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/casting.yaml
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/casting.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1alpha1
+kind: CollectionAgent
+metadata:
+  name: signoz
+  annotations:
+    foundry.signoz.io/ecs-region: us-east-1
+    foundry.signoz.io/ecs-cluster-arn: arn:aws:ecs:us-east-1:123456789012:cluster/signoz
+spec:
+  deployment:
+    platform: ecs
+    mode: ec2
+    flavor: terraform
+  collector:
+    kind: agent
+    spec:
+      env:
+        SIGNOZ_INGESTION_ENDPOINT: "https://ingest.us.signoz.cloud:443"

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/casting.yaml.lock
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/casting.yaml.lock
@@ -1,0 +1,471 @@
+apiVersion: v1alpha1
+kind: CollectionAgent
+metadata:
+  annotations:
+    foundry.signoz.io/ecs-cluster-arn: arn:aws:ecs:us-east-1:123456789012:cluster/signoz
+    foundry.signoz.io/ecs-region: us-east-1
+  name: signoz
+spec:
+  collector:
+    kind: agent
+    spec:
+      cluster:
+        replicas: 1
+      config:
+        data:
+          collector/agent/agent.yaml: |
+            exporters:
+              otlphttp/signoz:
+                endpoint: ${env:SIGNOZ_INGESTION_ENDPOINT}
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+                path: /healthz
+            processors:
+              batch:
+                send_batch_max_size: 2048
+                send_batch_size: 1000
+                timeout: 10s
+              memory_limiter:
+                check_interval: 5s
+                limit_mib: 4000
+                spike_limit_mib: 800
+              resourcedetection:
+                detectors:
+                - env
+                - ec2
+                timeout: 5s
+            receivers:
+              docker_stats:
+                api_version: "1.44"
+                collection_interval: 60s
+                container_labels_to_metric_labels:
+                  com.amazonaws.ecs.cluster: aws.ecs.cluster.name
+                  com.amazonaws.ecs.task-arn: aws.ecs.task.arn
+                  com.amazonaws.ecs.task-definition-family: aws.ecs.task.family
+                  com.amazonaws.ecs.task-definition-version: aws.ecs.task.revision
+                endpoint: unix:///var/run/docker.sock
+                metrics:
+                  container.blockio.io_service_bytes_recursive:
+                    enabled: true
+                  container.cpu.utilization:
+                    enabled: true
+                  container.memory.percent:
+                    enabled: true
+                  container.memory.usage.limit:
+                    enabled: true
+                  container.memory.usage.total:
+                    enabled: true
+                  container.network.io.usage.rx_bytes:
+                    enabled: true
+                  container.network.io.usage.rx_dropped:
+                    enabled: true
+                  container.network.io.usage.tx_bytes:
+                    enabled: true
+                  container.network.io.usage.tx_dropped:
+                    enabled: true
+                timeout: 20s
+              filelog:
+                include:
+                - /var/lib/docker/containers/*/*-json.log
+                include_file_name: false
+                include_file_path: true
+                operators:
+                - on_error: send
+                  parse_to: body
+                  timestamp:
+                    layout: 2006-01-02T15:04:05.999999999Z07:00
+                    layout_type: gotime
+                    parse_from: body.time
+                  type: json_parser
+                - combine_field: body.log
+                  combine_with: ""
+                  force_flush_period: 5s
+                  is_last_entry: body.log endsWith "\n"
+                  on_error: send
+                  source_identifier: attributes["log.file.path"]
+                  type: recombine
+                - from: body.attrs["com.amazonaws.ecs.task-definition-family"]
+                  on_error: send_quiet
+                  to: resource["service.name"]
+                  type: move
+                - from: body.attrs["com.amazonaws.ecs.container-name"]
+                  on_error: send_quiet
+                  to: resource["aws.ecs.container.name"]
+                  type: move
+                - from: body.attrs["com.amazonaws.ecs.task-arn"]
+                  on_error: send_quiet
+                  to: resource["aws.ecs.task.arn"]
+                  type: move
+                - from: body.attrs["com.amazonaws.ecs.cluster"]
+                  on_error: send_quiet
+                  to: resource["aws.ecs.cluster.name"]
+                  type: move
+                - field: body.attrs
+                  on_error: send_quiet
+                  type: remove
+                - on_error: send
+                  parse_from: attributes["log.file.path"]
+                  regex: /var/lib/docker/containers/(?P<container_id>[a-f0-9]{64})/
+                  type: regex_parser
+                - from: attributes.container_id
+                  on_error: send_quiet
+                  to: resource["container.id"]
+                  type: move
+                - from: attributes["log.file.path"]
+                  to: resource["log.file.path"]
+                  type: move
+                - from: body.stream
+                  to: attributes["log.iostream"]
+                  type: move
+                - field: body.time
+                  type: remove
+                - from: body.log
+                  to: body
+                  type: move
+                start_at: end
+              filelog/host:
+                include:
+                - /hostfs/var/log/messages
+                - /hostfs/var/log/secure
+                - /hostfs/var/log/ecs/*.log
+                include_file_name: true
+                include_file_path: true
+                resource:
+                  service.name: ecs-host
+                start_at: end
+              hostmetrics:
+                collection_interval: 60s
+                root_path: /hostfs
+                scrapers:
+                  cpu: {}
+                  disk: {}
+                  filesystem:
+                    exclude_fs_types:
+                      fs_types:
+                      - autofs
+                      - binfmt_misc
+                      - bpf
+                      - cgroup2
+                      - configfs
+                      - debugfs
+                      - devpts
+                      - devtmpfs
+                      - fusectl
+                      - hugetlbfs
+                      - iso9660
+                      - mqueue
+                      - nsfs
+                      - overlay
+                      - proc
+                      - procfs
+                      - pstore
+                      - rpc_pipefs
+                      - securityfs
+                      - selinuxfs
+                      - squashfs
+                      - sysfs
+                      - tracefs
+                      match_type: strict
+                    exclude_mount_points:
+                      match_type: regexp
+                      mount_points:
+                      - /dev/*
+                      - /proc/*
+                      - /sys/*
+                      - /run/*
+                      - /var/lib/docker/*
+                  load: {}
+                  memory: {}
+                  network: {}
+                  paging: {}
+                  process:
+                    mute_process_exe_error: true
+                    mute_process_io_error: true
+                    mute_process_name_error: true
+                    mute_process_user_error: true
+                  processes: {}
+                  system: {}
+              otlp/grpc:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    max_recv_msg_size_mib: 16
+              otlp/http:
+                protocols:
+                  http:
+                    endpoint: 0.0.0.0:4318
+            service:
+              extensions:
+              - health_check
+              pipelines:
+                logs:
+                  exporters:
+                  - otlphttp/signoz
+                  processors:
+                  - memory_limiter
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - otlp/http
+                  - otlp/grpc
+                  - filelog
+                  - filelog/host
+                metrics:
+                  exporters:
+                  - otlphttp/signoz
+                  processors:
+                  - memory_limiter
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - otlp/http
+                  - otlp/grpc
+                  - docker_stats
+                  - hostmetrics
+                traces:
+                  exporters:
+                  - otlphttp/signoz
+                  processors:
+                  - memory_limiter
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - otlp/http
+                  - otlp/grpc
+      enabled: true
+      env:
+        OTEL_COLLECTOR_ROLE: agent
+        SIGNOZ_INGESTION_ENDPOINT: https://ingest.us.signoz.cloud:443
+      image: otel/opentelemetry-collector-contrib:0.139.0
+      version: 0.139.0
+    status:
+      config:
+        data:
+          collector/agent/agent.yaml: |
+            exporters:
+              otlphttp/signoz:
+                endpoint: ${env:SIGNOZ_INGESTION_ENDPOINT}
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+                path: /healthz
+            processors:
+              batch:
+                send_batch_max_size: 2048
+                send_batch_size: 1000
+                timeout: 10s
+              memory_limiter:
+                check_interval: 5s
+                limit_mib: 4000
+                spike_limit_mib: 800
+              resourcedetection:
+                detectors:
+                - env
+                - ec2
+                timeout: 5s
+            receivers:
+              docker_stats:
+                api_version: "1.44"
+                collection_interval: 60s
+                container_labels_to_metric_labels:
+                  com.amazonaws.ecs.cluster: aws.ecs.cluster.name
+                  com.amazonaws.ecs.task-arn: aws.ecs.task.arn
+                  com.amazonaws.ecs.task-definition-family: aws.ecs.task.family
+                  com.amazonaws.ecs.task-definition-version: aws.ecs.task.revision
+                endpoint: unix:///var/run/docker.sock
+                metrics:
+                  container.blockio.io_service_bytes_recursive:
+                    enabled: true
+                  container.cpu.utilization:
+                    enabled: true
+                  container.memory.percent:
+                    enabled: true
+                  container.memory.usage.limit:
+                    enabled: true
+                  container.memory.usage.total:
+                    enabled: true
+                  container.network.io.usage.rx_bytes:
+                    enabled: true
+                  container.network.io.usage.rx_dropped:
+                    enabled: true
+                  container.network.io.usage.tx_bytes:
+                    enabled: true
+                  container.network.io.usage.tx_dropped:
+                    enabled: true
+                timeout: 20s
+              filelog:
+                include:
+                - /var/lib/docker/containers/*/*-json.log
+                include_file_name: false
+                include_file_path: true
+                operators:
+                - on_error: send
+                  parse_to: body
+                  timestamp:
+                    layout: 2006-01-02T15:04:05.999999999Z07:00
+                    layout_type: gotime
+                    parse_from: body.time
+                  type: json_parser
+                - combine_field: body.log
+                  combine_with: ""
+                  force_flush_period: 5s
+                  is_last_entry: body.log endsWith "\n"
+                  on_error: send
+                  source_identifier: attributes["log.file.path"]
+                  type: recombine
+                - from: body.attrs["com.amazonaws.ecs.task-definition-family"]
+                  on_error: send_quiet
+                  to: resource["service.name"]
+                  type: move
+                - from: body.attrs["com.amazonaws.ecs.container-name"]
+                  on_error: send_quiet
+                  to: resource["aws.ecs.container.name"]
+                  type: move
+                - from: body.attrs["com.amazonaws.ecs.task-arn"]
+                  on_error: send_quiet
+                  to: resource["aws.ecs.task.arn"]
+                  type: move
+                - from: body.attrs["com.amazonaws.ecs.cluster"]
+                  on_error: send_quiet
+                  to: resource["aws.ecs.cluster.name"]
+                  type: move
+                - field: body.attrs
+                  on_error: send_quiet
+                  type: remove
+                - on_error: send
+                  parse_from: attributes["log.file.path"]
+                  regex: /var/lib/docker/containers/(?P<container_id>[a-f0-9]{64})/
+                  type: regex_parser
+                - from: attributes.container_id
+                  on_error: send_quiet
+                  to: resource["container.id"]
+                  type: move
+                - from: attributes["log.file.path"]
+                  to: resource["log.file.path"]
+                  type: move
+                - from: body.stream
+                  to: attributes["log.iostream"]
+                  type: move
+                - field: body.time
+                  type: remove
+                - from: body.log
+                  to: body
+                  type: move
+                start_at: end
+              filelog/host:
+                include:
+                - /hostfs/var/log/messages
+                - /hostfs/var/log/secure
+                - /hostfs/var/log/ecs/*.log
+                include_file_name: true
+                include_file_path: true
+                resource:
+                  service.name: ecs-host
+                start_at: end
+              hostmetrics:
+                collection_interval: 60s
+                root_path: /hostfs
+                scrapers:
+                  cpu: {}
+                  disk: {}
+                  filesystem:
+                    exclude_fs_types:
+                      fs_types:
+                      - autofs
+                      - binfmt_misc
+                      - bpf
+                      - cgroup2
+                      - configfs
+                      - debugfs
+                      - devpts
+                      - devtmpfs
+                      - fusectl
+                      - hugetlbfs
+                      - iso9660
+                      - mqueue
+                      - nsfs
+                      - overlay
+                      - proc
+                      - procfs
+                      - pstore
+                      - rpc_pipefs
+                      - securityfs
+                      - selinuxfs
+                      - squashfs
+                      - sysfs
+                      - tracefs
+                      match_type: strict
+                    exclude_mount_points:
+                      match_type: regexp
+                      mount_points:
+                      - /dev/*
+                      - /proc/*
+                      - /sys/*
+                      - /run/*
+                      - /var/lib/docker/*
+                  load: {}
+                  memory: {}
+                  network: {}
+                  paging: {}
+                  process:
+                    mute_process_exe_error: true
+                    mute_process_io_error: true
+                    mute_process_name_error: true
+                    mute_process_user_error: true
+                  processes: {}
+                  system: {}
+              otlp/grpc:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    max_recv_msg_size_mib: 16
+              otlp/http:
+                protocols:
+                  http:
+                    endpoint: 0.0.0.0:4318
+            service:
+              extensions:
+              - health_check
+              pipelines:
+                logs:
+                  exporters:
+                  - otlphttp/signoz
+                  processors:
+                  - memory_limiter
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - otlp/http
+                  - otlp/grpc
+                  - filelog
+                  - filelog/host
+                metrics:
+                  exporters:
+                  - otlphttp/signoz
+                  processors:
+                  - memory_limiter
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - otlp/http
+                  - otlp/grpc
+                  - docker_stats
+                  - hostmetrics
+                traces:
+                  exporters:
+                  - otlphttp/signoz
+                  processors:
+                  - memory_limiter
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - otlp/http
+                  - otlp/grpc
+      env:
+        OTEL_COLLECTOR_ROLE: agent
+        SIGNOZ_INGESTION_ENDPOINT: https://ingest.us.signoz.cloud:443
+  deployment:
+    flavor: terraform
+    mode: ec2
+    platform: ecs

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/casting.yaml.lock
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/casting.yaml.lock
@@ -78,6 +78,9 @@ spec:
                     layout_type: gotime
                     parse_from: body.time
                   type: json_parser
+                - expr: body.attrs["com.amazonaws.ecs.task-definition-family"] == "signoz-collector-agent"
+                  on_error: send
+                  type: filter
                 - combine_field: body.log
                   combine_with: ""
                   force_flush_period: 5s
@@ -307,6 +310,9 @@ spec:
                     layout_type: gotime
                     parse_from: body.time
                   type: json_parser
+                - expr: body.attrs["com.amazonaws.ecs.task-definition-family"] == "signoz-collector-agent"
+                  on_error: send
+                  type: filter
                 - combine_field: body.log
                   combine_with: ""
                   force_flush_period: 5s

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/casting.yaml.lock
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/casting.yaml.lock
@@ -78,7 +78,8 @@ spec:
                     layout_type: gotime
                     parse_from: body.time
                   type: json_parser
-                - expr: body.attrs["com.amazonaws.ecs.task-definition-family"] == "signoz-collector-agent"
+                - expr: body.attrs != nil && body.attrs["com.amazonaws.ecs.task-definition-family"]
+                    == "signoz-collector-agent"
                   on_error: send
                   type: filter
                 - combine_field: body.log
@@ -89,22 +90,27 @@ spec:
                   source_identifier: attributes["log.file.path"]
                   type: recombine
                 - from: body.attrs["com.amazonaws.ecs.task-definition-family"]
+                  if: body.attrs != nil
                   on_error: send_quiet
                   to: resource["service.name"]
                   type: move
                 - from: body.attrs["com.amazonaws.ecs.container-name"]
+                  if: body.attrs != nil
                   on_error: send_quiet
                   to: resource["aws.ecs.container.name"]
                   type: move
                 - from: body.attrs["com.amazonaws.ecs.task-arn"]
+                  if: body.attrs != nil
                   on_error: send_quiet
                   to: resource["aws.ecs.task.arn"]
                   type: move
                 - from: body.attrs["com.amazonaws.ecs.cluster"]
+                  if: body.attrs != nil
                   on_error: send_quiet
                   to: resource["aws.ecs.cluster.name"]
                   type: move
                 - field: body.attrs
+                  if: body.attrs != nil
                   on_error: send_quiet
                   type: remove
                 - on_error: send
@@ -310,7 +316,8 @@ spec:
                     layout_type: gotime
                     parse_from: body.time
                   type: json_parser
-                - expr: body.attrs["com.amazonaws.ecs.task-definition-family"] == "signoz-collector-agent"
+                - expr: body.attrs != nil && body.attrs["com.amazonaws.ecs.task-definition-family"]
+                    == "signoz-collector-agent"
                   on_error: send
                   type: filter
                 - combine_field: body.log
@@ -321,22 +328,27 @@ spec:
                   source_identifier: attributes["log.file.path"]
                   type: recombine
                 - from: body.attrs["com.amazonaws.ecs.task-definition-family"]
+                  if: body.attrs != nil
                   on_error: send_quiet
                   to: resource["service.name"]
                   type: move
                 - from: body.attrs["com.amazonaws.ecs.container-name"]
+                  if: body.attrs != nil
                   on_error: send_quiet
                   to: resource["aws.ecs.container.name"]
                   type: move
                 - from: body.attrs["com.amazonaws.ecs.task-arn"]
+                  if: body.attrs != nil
                   on_error: send_quiet
                   to: resource["aws.ecs.task.arn"]
                   type: move
                 - from: body.attrs["com.amazonaws.ecs.cluster"]
+                  if: body.attrs != nil
                   on_error: send_quiet
                   to: resource["aws.ecs.cluster.name"]
                   type: move
                 - field: body.attrs
+                  if: body.attrs != nil
                   on_error: send_quiet
                   type: remove
                 - on_error: send

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/backend.tf.json
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/backend.tf.json
@@ -1,0 +1,9 @@
+{
+  "terraform": {
+    "backend": {
+      "local": {
+        "path": "terraform.tfstate"
+      }
+    }
+  }
+}

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/casting.yaml.lock
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/casting.yaml.lock
@@ -1,0 +1,471 @@
+apiVersion: v1alpha1
+kind: CollectionAgent
+metadata:
+  annotations:
+    foundry.signoz.io/ecs-cluster-arn: arn:aws:ecs:us-east-1:123456789012:cluster/signoz
+    foundry.signoz.io/ecs-region: us-east-1
+  name: signoz
+spec:
+  collector:
+    kind: agent
+    spec:
+      cluster:
+        replicas: 1
+      config:
+        data:
+          collector/agent/agent.yaml: |
+            exporters:
+              otlphttp/signoz:
+                endpoint: ${env:SIGNOZ_INGESTION_ENDPOINT}
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+                path: /healthz
+            processors:
+              batch:
+                send_batch_max_size: 2048
+                send_batch_size: 1000
+                timeout: 10s
+              memory_limiter:
+                check_interval: 5s
+                limit_mib: 4000
+                spike_limit_mib: 800
+              resourcedetection:
+                detectors:
+                - env
+                - ec2
+                timeout: 5s
+            receivers:
+              docker_stats:
+                api_version: "1.44"
+                collection_interval: 60s
+                container_labels_to_metric_labels:
+                  com.amazonaws.ecs.cluster: aws.ecs.cluster.name
+                  com.amazonaws.ecs.task-arn: aws.ecs.task.arn
+                  com.amazonaws.ecs.task-definition-family: aws.ecs.task.family
+                  com.amazonaws.ecs.task-definition-version: aws.ecs.task.revision
+                endpoint: unix:///var/run/docker.sock
+                metrics:
+                  container.blockio.io_service_bytes_recursive:
+                    enabled: true
+                  container.cpu.utilization:
+                    enabled: true
+                  container.memory.percent:
+                    enabled: true
+                  container.memory.usage.limit:
+                    enabled: true
+                  container.memory.usage.total:
+                    enabled: true
+                  container.network.io.usage.rx_bytes:
+                    enabled: true
+                  container.network.io.usage.rx_dropped:
+                    enabled: true
+                  container.network.io.usage.tx_bytes:
+                    enabled: true
+                  container.network.io.usage.tx_dropped:
+                    enabled: true
+                timeout: 20s
+              filelog:
+                include:
+                - /var/lib/docker/containers/*/*-json.log
+                include_file_name: false
+                include_file_path: true
+                operators:
+                - on_error: send
+                  parse_to: body
+                  timestamp:
+                    layout: 2006-01-02T15:04:05.999999999Z07:00
+                    layout_type: gotime
+                    parse_from: body.time
+                  type: json_parser
+                - combine_field: body.log
+                  combine_with: ""
+                  force_flush_period: 5s
+                  is_last_entry: body.log endsWith "\n"
+                  on_error: send
+                  source_identifier: attributes["log.file.path"]
+                  type: recombine
+                - from: body.attrs["com.amazonaws.ecs.task-definition-family"]
+                  on_error: send_quiet
+                  to: resource["service.name"]
+                  type: move
+                - from: body.attrs["com.amazonaws.ecs.container-name"]
+                  on_error: send_quiet
+                  to: resource["aws.ecs.container.name"]
+                  type: move
+                - from: body.attrs["com.amazonaws.ecs.task-arn"]
+                  on_error: send_quiet
+                  to: resource["aws.ecs.task.arn"]
+                  type: move
+                - from: body.attrs["com.amazonaws.ecs.cluster"]
+                  on_error: send_quiet
+                  to: resource["aws.ecs.cluster.name"]
+                  type: move
+                - field: body.attrs
+                  on_error: send_quiet
+                  type: remove
+                - on_error: send
+                  parse_from: attributes["log.file.path"]
+                  regex: /var/lib/docker/containers/(?P<container_id>[a-f0-9]{64})/
+                  type: regex_parser
+                - from: attributes.container_id
+                  on_error: send_quiet
+                  to: resource["container.id"]
+                  type: move
+                - from: attributes["log.file.path"]
+                  to: resource["log.file.path"]
+                  type: move
+                - from: body.stream
+                  to: attributes["log.iostream"]
+                  type: move
+                - field: body.time
+                  type: remove
+                - from: body.log
+                  to: body
+                  type: move
+                start_at: end
+              filelog/host:
+                include:
+                - /hostfs/var/log/messages
+                - /hostfs/var/log/secure
+                - /hostfs/var/log/ecs/*.log
+                include_file_name: true
+                include_file_path: true
+                resource:
+                  service.name: ecs-host
+                start_at: end
+              hostmetrics:
+                collection_interval: 60s
+                root_path: /hostfs
+                scrapers:
+                  cpu: {}
+                  disk: {}
+                  filesystem:
+                    exclude_fs_types:
+                      fs_types:
+                      - autofs
+                      - binfmt_misc
+                      - bpf
+                      - cgroup2
+                      - configfs
+                      - debugfs
+                      - devpts
+                      - devtmpfs
+                      - fusectl
+                      - hugetlbfs
+                      - iso9660
+                      - mqueue
+                      - nsfs
+                      - overlay
+                      - proc
+                      - procfs
+                      - pstore
+                      - rpc_pipefs
+                      - securityfs
+                      - selinuxfs
+                      - squashfs
+                      - sysfs
+                      - tracefs
+                      match_type: strict
+                    exclude_mount_points:
+                      match_type: regexp
+                      mount_points:
+                      - /dev/*
+                      - /proc/*
+                      - /sys/*
+                      - /run/*
+                      - /var/lib/docker/*
+                  load: {}
+                  memory: {}
+                  network: {}
+                  paging: {}
+                  process:
+                    mute_process_exe_error: true
+                    mute_process_io_error: true
+                    mute_process_name_error: true
+                    mute_process_user_error: true
+                  processes: {}
+                  system: {}
+              otlp/grpc:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    max_recv_msg_size_mib: 16
+              otlp/http:
+                protocols:
+                  http:
+                    endpoint: 0.0.0.0:4318
+            service:
+              extensions:
+              - health_check
+              pipelines:
+                logs:
+                  exporters:
+                  - otlphttp/signoz
+                  processors:
+                  - memory_limiter
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - otlp/http
+                  - otlp/grpc
+                  - filelog
+                  - filelog/host
+                metrics:
+                  exporters:
+                  - otlphttp/signoz
+                  processors:
+                  - memory_limiter
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - otlp/http
+                  - otlp/grpc
+                  - docker_stats
+                  - hostmetrics
+                traces:
+                  exporters:
+                  - otlphttp/signoz
+                  processors:
+                  - memory_limiter
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - otlp/http
+                  - otlp/grpc
+      enabled: true
+      env:
+        OTEL_COLLECTOR_ROLE: agent
+        SIGNOZ_INGESTION_ENDPOINT: https://ingest.us.signoz.cloud:443
+      image: otel/opentelemetry-collector-contrib:0.139.0
+      version: 0.139.0
+    status:
+      config:
+        data:
+          collector/agent/agent.yaml: |
+            exporters:
+              otlphttp/signoz:
+                endpoint: ${env:SIGNOZ_INGESTION_ENDPOINT}
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+                path: /healthz
+            processors:
+              batch:
+                send_batch_max_size: 2048
+                send_batch_size: 1000
+                timeout: 10s
+              memory_limiter:
+                check_interval: 5s
+                limit_mib: 4000
+                spike_limit_mib: 800
+              resourcedetection:
+                detectors:
+                - env
+                - ec2
+                timeout: 5s
+            receivers:
+              docker_stats:
+                api_version: "1.44"
+                collection_interval: 60s
+                container_labels_to_metric_labels:
+                  com.amazonaws.ecs.cluster: aws.ecs.cluster.name
+                  com.amazonaws.ecs.task-arn: aws.ecs.task.arn
+                  com.amazonaws.ecs.task-definition-family: aws.ecs.task.family
+                  com.amazonaws.ecs.task-definition-version: aws.ecs.task.revision
+                endpoint: unix:///var/run/docker.sock
+                metrics:
+                  container.blockio.io_service_bytes_recursive:
+                    enabled: true
+                  container.cpu.utilization:
+                    enabled: true
+                  container.memory.percent:
+                    enabled: true
+                  container.memory.usage.limit:
+                    enabled: true
+                  container.memory.usage.total:
+                    enabled: true
+                  container.network.io.usage.rx_bytes:
+                    enabled: true
+                  container.network.io.usage.rx_dropped:
+                    enabled: true
+                  container.network.io.usage.tx_bytes:
+                    enabled: true
+                  container.network.io.usage.tx_dropped:
+                    enabled: true
+                timeout: 20s
+              filelog:
+                include:
+                - /var/lib/docker/containers/*/*-json.log
+                include_file_name: false
+                include_file_path: true
+                operators:
+                - on_error: send
+                  parse_to: body
+                  timestamp:
+                    layout: 2006-01-02T15:04:05.999999999Z07:00
+                    layout_type: gotime
+                    parse_from: body.time
+                  type: json_parser
+                - combine_field: body.log
+                  combine_with: ""
+                  force_flush_period: 5s
+                  is_last_entry: body.log endsWith "\n"
+                  on_error: send
+                  source_identifier: attributes["log.file.path"]
+                  type: recombine
+                - from: body.attrs["com.amazonaws.ecs.task-definition-family"]
+                  on_error: send_quiet
+                  to: resource["service.name"]
+                  type: move
+                - from: body.attrs["com.amazonaws.ecs.container-name"]
+                  on_error: send_quiet
+                  to: resource["aws.ecs.container.name"]
+                  type: move
+                - from: body.attrs["com.amazonaws.ecs.task-arn"]
+                  on_error: send_quiet
+                  to: resource["aws.ecs.task.arn"]
+                  type: move
+                - from: body.attrs["com.amazonaws.ecs.cluster"]
+                  on_error: send_quiet
+                  to: resource["aws.ecs.cluster.name"]
+                  type: move
+                - field: body.attrs
+                  on_error: send_quiet
+                  type: remove
+                - on_error: send
+                  parse_from: attributes["log.file.path"]
+                  regex: /var/lib/docker/containers/(?P<container_id>[a-f0-9]{64})/
+                  type: regex_parser
+                - from: attributes.container_id
+                  on_error: send_quiet
+                  to: resource["container.id"]
+                  type: move
+                - from: attributes["log.file.path"]
+                  to: resource["log.file.path"]
+                  type: move
+                - from: body.stream
+                  to: attributes["log.iostream"]
+                  type: move
+                - field: body.time
+                  type: remove
+                - from: body.log
+                  to: body
+                  type: move
+                start_at: end
+              filelog/host:
+                include:
+                - /hostfs/var/log/messages
+                - /hostfs/var/log/secure
+                - /hostfs/var/log/ecs/*.log
+                include_file_name: true
+                include_file_path: true
+                resource:
+                  service.name: ecs-host
+                start_at: end
+              hostmetrics:
+                collection_interval: 60s
+                root_path: /hostfs
+                scrapers:
+                  cpu: {}
+                  disk: {}
+                  filesystem:
+                    exclude_fs_types:
+                      fs_types:
+                      - autofs
+                      - binfmt_misc
+                      - bpf
+                      - cgroup2
+                      - configfs
+                      - debugfs
+                      - devpts
+                      - devtmpfs
+                      - fusectl
+                      - hugetlbfs
+                      - iso9660
+                      - mqueue
+                      - nsfs
+                      - overlay
+                      - proc
+                      - procfs
+                      - pstore
+                      - rpc_pipefs
+                      - securityfs
+                      - selinuxfs
+                      - squashfs
+                      - sysfs
+                      - tracefs
+                      match_type: strict
+                    exclude_mount_points:
+                      match_type: regexp
+                      mount_points:
+                      - /dev/*
+                      - /proc/*
+                      - /sys/*
+                      - /run/*
+                      - /var/lib/docker/*
+                  load: {}
+                  memory: {}
+                  network: {}
+                  paging: {}
+                  process:
+                    mute_process_exe_error: true
+                    mute_process_io_error: true
+                    mute_process_name_error: true
+                    mute_process_user_error: true
+                  processes: {}
+                  system: {}
+              otlp/grpc:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    max_recv_msg_size_mib: 16
+              otlp/http:
+                protocols:
+                  http:
+                    endpoint: 0.0.0.0:4318
+            service:
+              extensions:
+              - health_check
+              pipelines:
+                logs:
+                  exporters:
+                  - otlphttp/signoz
+                  processors:
+                  - memory_limiter
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - otlp/http
+                  - otlp/grpc
+                  - filelog
+                  - filelog/host
+                metrics:
+                  exporters:
+                  - otlphttp/signoz
+                  processors:
+                  - memory_limiter
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - otlp/http
+                  - otlp/grpc
+                  - docker_stats
+                  - hostmetrics
+                traces:
+                  exporters:
+                  - otlphttp/signoz
+                  processors:
+                  - memory_limiter
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - otlp/http
+                  - otlp/grpc
+      env:
+        OTEL_COLLECTOR_ROLE: agent
+        SIGNOZ_INGESTION_ENDPOINT: https://ingest.us.signoz.cloud:443
+  deployment:
+    flavor: terraform
+    mode: ec2
+    platform: ecs

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/collector.tf.json
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/collector.tf.json
@@ -40,7 +40,7 @@
         "essential": true,
         "user": "0",
         "command": ["--config=/conf/agent.yaml"],
-        "environment": [{"name":"FOUNDRY_CONFIG_DIGEST","value":"503dd4857ebd4ec7c2378c9c670c764f92194354f58c0913dbe79fd17a349d3e"},{"name":"OTEL_COLLECTOR_ROLE","value":"agent"},{"name":"SIGNOZ_INGESTION_ENDPOINT","value":"https://ingest.us.signoz.cloud:443"}],
+        "environment": [{"name":"FOUNDRY_CONFIG_DIGEST","value":"af899eeb0726da9874899aa1db8a72381743b8a5053eb78472b565c4a012fd0c"},{"name":"OTEL_COLLECTOR_ROLE","value":"agent"},{"name":"SIGNOZ_INGESTION_ENDPOINT","value":"https://ingest.us.signoz.cloud:443"}],
         "portMappings": [
           {"containerPort": 4317, "hostPort": 4317, "protocol": "tcp"},
           {"containerPort": 4318, "hostPort": 4318, "protocol": "tcp"}

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/collector.tf.json
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/collector.tf.json
@@ -24,7 +24,14 @@
           "retries": 10,
           "startPeriod": 30
         },
-        "logConfiguration": {"logDriver": "none"},
+        "logConfiguration": {
+          "logDriver": "json-file",
+          "options": {
+            "max-size": "10m",
+            "max-file": "3",
+            "labels": "com.amazonaws.ecs.task-definition-family,com.amazonaws.ecs.container-name,com.amazonaws.ecs.task-arn,com.amazonaws.ecs.cluster"
+          }
+        },
         "memoryReservation": 102
       },
       {
@@ -33,7 +40,7 @@
         "essential": true,
         "user": "0",
         "command": ["--config=/conf/agent.yaml"],
-        "environment": [{"name":"FOUNDRY_CONFIG_DIGEST","value":"19e7f29008b5eceb0379c293cb5b46481879df97ad66be91de2c34364e3efcc6"},{"name":"OTEL_COLLECTOR_ROLE","value":"agent"},{"name":"SIGNOZ_INGESTION_ENDPOINT","value":"https://ingest.us.signoz.cloud:443"}],
+        "environment": [{"name":"FOUNDRY_CONFIG_DIGEST","value":"503dd4857ebd4ec7c2378c9c670c764f92194354f58c0913dbe79fd17a349d3e"},{"name":"OTEL_COLLECTOR_ROLE","value":"agent"},{"name":"SIGNOZ_INGESTION_ENDPOINT","value":"https://ingest.us.signoz.cloud:443"}],
         "portMappings": [
           {"containerPort": 4317, "hostPort": 4317, "protocol": "tcp"},
           {"containerPort": 4318, "hostPort": 4318, "protocol": "tcp"}
@@ -63,7 +70,14 @@
         "dependsOn": [
           {"containerName": "signoz-collector-appconfig-agent", "condition": "HEALTHY"}
         ],
-        "logConfiguration": {"logDriver": "none"},
+        "logConfiguration": {
+          "logDriver": "json-file",
+          "options": {
+            "max-size": "10m",
+            "max-file": "3",
+            "labels": "com.amazonaws.ecs.task-definition-family,com.amazonaws.ecs.container-name,com.amazonaws.ecs.task-arn,com.amazonaws.ecs.cluster"
+          }
+        },
         "cpu": 256,
         "memoryReservation": 512
       }

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/collector.tf.json
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/collector.tf.json
@@ -1,0 +1,149 @@
+{
+  "locals": {
+    "containers_collector_agent": [
+      {
+        "name": "signoz-collector-appconfig-agent",
+        "image": "public.ecr.aws/aws-appconfig/aws-appconfig-agent:2.x",
+        "essential": true,
+        "user": "0",
+        "environment": [
+          {"name": "PREFETCH_LIST", "value": "signoz-collectionagent-appconfig:default:collector-agent"},
+          {"name": "POLL_INTERVAL", "value": "45s"},
+          {"name": "MANIFEST", "value": "{\"signoz-collectionagent-appconfig:default:collector-agent\":{\"writeTo\":{\"path\":\"/conf/agent.yaml\"}}}"}
+        ],
+        "mountPoints": [
+          {
+            "sourceVolume": "collector-config",
+            "containerPath": "/conf"
+          }
+        ],
+        "healthCheck": {
+          "command": ["CMD-SHELL", "test -s /conf/agent.yaml"],
+          "interval": 5,
+          "timeout": 3,
+          "retries": 10,
+          "startPeriod": 30
+        },
+        "logConfiguration": {"logDriver": "none"},
+        "memoryReservation": 102
+      },
+      {
+        "name": "signoz-collector-agent",
+        "image": "otel/opentelemetry-collector-contrib:0.139.0",
+        "essential": true,
+        "user": "0",
+        "command": ["--config=/conf/agent.yaml"],
+        "environment": [{"name":"FOUNDRY_CONFIG_DIGEST","value":"19e7f29008b5eceb0379c293cb5b46481879df97ad66be91de2c34364e3efcc6"},{"name":"OTEL_COLLECTOR_ROLE","value":"agent"},{"name":"SIGNOZ_INGESTION_ENDPOINT","value":"https://ingest.us.signoz.cloud:443"}],
+        "portMappings": [
+          {"containerPort": 4317, "hostPort": 4317, "protocol": "tcp"},
+          {"containerPort": 4318, "hostPort": 4318, "protocol": "tcp"}
+        ],
+        "mountPoints": [
+          {
+            "sourceVolume": "collector-config",
+            "containerPath": "/conf",
+            "readOnly": true
+          },
+          {
+            "sourceVolume": "docker-socket",
+            "containerPath": "/var/run/docker.sock",
+            "readOnly": true
+          },
+          {
+            "sourceVolume": "docker-containers",
+            "containerPath": "/var/lib/docker/containers",
+            "readOnly": true
+          },
+          {
+            "sourceVolume": "hostfs",
+            "containerPath": "/hostfs",
+            "readOnly": true
+          }
+        ],
+        "dependsOn": [
+          {"containerName": "signoz-collector-appconfig-agent", "condition": "HEALTHY"}
+        ],
+        "logConfiguration": {"logDriver": "none"},
+        "cpu": 256,
+        "memoryReservation": 512
+      }
+    ]
+  },
+  "resource": {
+    "aws_appconfig_configuration_profile": {
+      "collector_agent": {
+        "application_id": "${aws_appconfig_application.main.id}",
+        "name": "collector-agent",
+        "location_uri": "hosted",
+        "type": "AWS.Freeform",
+        "tags": {"foundry.signoz.io/kind":"CollectionAgent","foundry.signoz.io/managed-by":"foundry","foundry.signoz.io/name":"signoz"}
+      }
+    },
+    "aws_appconfig_hosted_configuration_version": {
+      "collector_agent": {
+        "application_id": "${aws_appconfig_application.main.id}",
+        "configuration_profile_id": "${aws_appconfig_configuration_profile.collector_agent.configuration_profile_id}",
+        "content_type": "application/x-yaml",
+        "content": "${file(\"${path.module}/collector/agent/agent.yaml\")}"
+      }
+    },
+    "aws_appconfig_deployment": {
+      "collector_agent": {
+        "application_id": "${aws_appconfig_application.main.id}",
+        "environment_id": "${aws_appconfig_environment.main.environment_id}",
+        "configuration_profile_id": "${aws_appconfig_configuration_profile.collector_agent.configuration_profile_id}",
+        "configuration_version": "${aws_appconfig_hosted_configuration_version.collector_agent.version_number}",
+        "deployment_strategy_id": "${aws_appconfig_deployment_strategy.main.id}",
+        "tags": {"foundry.signoz.io/kind":"CollectionAgent","foundry.signoz.io/managed-by":"foundry","foundry.signoz.io/name":"signoz"}
+      }
+    },
+    "aws_ecs_task_definition": {
+      "collector_agent": {
+        "family": "signoz-collector-agent",
+        "tags": {"foundry.signoz.io/kind":"CollectionAgent","foundry.signoz.io/managed-by":"foundry","foundry.signoz.io/name":"signoz"},
+        "network_mode": "host",
+        "requires_compatibilities": ["EC2"],
+        "task_role_arn": "${local.task_role_arn}",
+        "execution_role_arn": "${local.execution_role_arn}",
+        "container_definitions": "${jsonencode(local.containers_collector_agent)}",
+        "volume": [
+          {
+            "name": "collector-config",
+            "docker_volume_configuration": {
+              "scope": "task",
+              "driver": "local"
+            }
+          },
+          {
+            "name": "docker-socket",
+            "host_path": "/var/run/docker.sock"
+          },
+          {
+            "name": "docker-containers",
+            "host_path": "/var/lib/docker/containers"
+          },
+          {
+            "name": "hostfs",
+            "host_path": "/"
+          }
+        ],
+        "depends_on": ["aws_appconfig_deployment.collector_agent"]
+      }
+    },
+    "aws_ecs_service": {
+      "collector_agent": {
+        "name": "signoz-collector-agent",
+        "cluster": "${local.cluster_arn}",
+        "task_definition": "${aws_ecs_task_definition.collector_agent.arn}",
+        "scheduling_strategy": "DAEMON",
+        "deployment_minimum_healthy_percent": 0,
+        "launch_type": "EC2",
+        "deployment_circuit_breaker": {
+          "enable": true,
+          "rollback": true
+        },
+        "tags": {"foundry.signoz.io/kind":"CollectionAgent","foundry.signoz.io/managed-by":"foundry","foundry.signoz.io/name":"signoz"}
+      }
+    }
+  }
+}

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/collector/agent/agent.yaml
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/collector/agent/agent.yaml
@@ -1,0 +1,219 @@
+exporters:
+  otlphttp/signoz:
+    endpoint: ${env:SIGNOZ_INGESTION_ENDPOINT}
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+    path: /healthz
+processors:
+  batch:
+    send_batch_max_size: 2048
+    send_batch_size: 1000
+    timeout: 10s
+  memory_limiter:
+    check_interval: 5s
+    limit_mib: 4000
+    spike_limit_mib: 800
+  resourcedetection:
+    detectors:
+    - env
+    - ec2
+    timeout: 5s
+receivers:
+  docker_stats:
+    api_version: "1.44"
+    collection_interval: 60s
+    container_labels_to_metric_labels:
+      com.amazonaws.ecs.cluster: aws.ecs.cluster.name
+      com.amazonaws.ecs.task-arn: aws.ecs.task.arn
+      com.amazonaws.ecs.task-definition-family: aws.ecs.task.family
+      com.amazonaws.ecs.task-definition-version: aws.ecs.task.revision
+    endpoint: unix:///var/run/docker.sock
+    metrics:
+      container.blockio.io_service_bytes_recursive:
+        enabled: true
+      container.cpu.utilization:
+        enabled: true
+      container.memory.percent:
+        enabled: true
+      container.memory.usage.limit:
+        enabled: true
+      container.memory.usage.total:
+        enabled: true
+      container.network.io.usage.rx_bytes:
+        enabled: true
+      container.network.io.usage.rx_dropped:
+        enabled: true
+      container.network.io.usage.tx_bytes:
+        enabled: true
+      container.network.io.usage.tx_dropped:
+        enabled: true
+    timeout: 20s
+  filelog:
+    include:
+    - /var/lib/docker/containers/*/*-json.log
+    include_file_name: false
+    include_file_path: true
+    operators:
+    - on_error: send
+      parse_to: body
+      timestamp:
+        layout: 2006-01-02T15:04:05.999999999Z07:00
+        layout_type: gotime
+        parse_from: body.time
+      type: json_parser
+    - combine_field: body.log
+      combine_with: ""
+      force_flush_period: 5s
+      is_last_entry: body.log endsWith "\n"
+      on_error: send
+      source_identifier: attributes["log.file.path"]
+      type: recombine
+    - from: body.attrs["com.amazonaws.ecs.task-definition-family"]
+      on_error: send_quiet
+      to: resource["service.name"]
+      type: move
+    - from: body.attrs["com.amazonaws.ecs.container-name"]
+      on_error: send_quiet
+      to: resource["aws.ecs.container.name"]
+      type: move
+    - from: body.attrs["com.amazonaws.ecs.task-arn"]
+      on_error: send_quiet
+      to: resource["aws.ecs.task.arn"]
+      type: move
+    - from: body.attrs["com.amazonaws.ecs.cluster"]
+      on_error: send_quiet
+      to: resource["aws.ecs.cluster.name"]
+      type: move
+    - field: body.attrs
+      on_error: send_quiet
+      type: remove
+    - on_error: send
+      parse_from: attributes["log.file.path"]
+      regex: /var/lib/docker/containers/(?P<container_id>[a-f0-9]{64})/
+      type: regex_parser
+    - from: attributes.container_id
+      on_error: send_quiet
+      to: resource["container.id"]
+      type: move
+    - from: attributes["log.file.path"]
+      to: resource["log.file.path"]
+      type: move
+    - from: body.stream
+      to: attributes["log.iostream"]
+      type: move
+    - field: body.time
+      type: remove
+    - from: body.log
+      to: body
+      type: move
+    start_at: end
+  filelog/host:
+    include:
+    - /hostfs/var/log/messages
+    - /hostfs/var/log/secure
+    - /hostfs/var/log/ecs/*.log
+    include_file_name: true
+    include_file_path: true
+    resource:
+      service.name: ecs-host
+    start_at: end
+  hostmetrics:
+    collection_interval: 60s
+    root_path: /hostfs
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem:
+        exclude_fs_types:
+          fs_types:
+          - autofs
+          - binfmt_misc
+          - bpf
+          - cgroup2
+          - configfs
+          - debugfs
+          - devpts
+          - devtmpfs
+          - fusectl
+          - hugetlbfs
+          - iso9660
+          - mqueue
+          - nsfs
+          - overlay
+          - proc
+          - procfs
+          - pstore
+          - rpc_pipefs
+          - securityfs
+          - selinuxfs
+          - squashfs
+          - sysfs
+          - tracefs
+          match_type: strict
+        exclude_mount_points:
+          match_type: regexp
+          mount_points:
+          - /dev/*
+          - /proc/*
+          - /sys/*
+          - /run/*
+          - /var/lib/docker/*
+      load: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process:
+        mute_process_exe_error: true
+        mute_process_io_error: true
+        mute_process_name_error: true
+        mute_process_user_error: true
+      processes: {}
+      system: {}
+  otlp/grpc:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        max_recv_msg_size_mib: 16
+  otlp/http:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+service:
+  extensions:
+  - health_check
+  pipelines:
+    logs:
+      exporters:
+      - otlphttp/signoz
+      processors:
+      - memory_limiter
+      - resourcedetection
+      - batch
+      receivers:
+      - otlp/http
+      - otlp/grpc
+      - filelog
+      - filelog/host
+    metrics:
+      exporters:
+      - otlphttp/signoz
+      processors:
+      - memory_limiter
+      - resourcedetection
+      - batch
+      receivers:
+      - otlp/http
+      - otlp/grpc
+      - docker_stats
+      - hostmetrics
+    traces:
+      exporters:
+      - otlphttp/signoz
+      processors:
+      - memory_limiter
+      - resourcedetection
+      - batch
+      receivers:
+      - otlp/http
+      - otlp/grpc

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/collector/agent/agent.yaml
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/collector/agent/agent.yaml
@@ -62,6 +62,9 @@ receivers:
         layout_type: gotime
         parse_from: body.time
       type: json_parser
+    - expr: body.attrs["com.amazonaws.ecs.task-definition-family"] == "signoz-collector-agent"
+      on_error: send
+      type: filter
     - combine_field: body.log
       combine_with: ""
       force_flush_period: 5s

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/collector/agent/agent.yaml
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/collector/agent/agent.yaml
@@ -62,7 +62,8 @@ receivers:
         layout_type: gotime
         parse_from: body.time
       type: json_parser
-    - expr: body.attrs["com.amazonaws.ecs.task-definition-family"] == "signoz-collector-agent"
+    - expr: body.attrs != nil && body.attrs["com.amazonaws.ecs.task-definition-family"]
+        == "signoz-collector-agent"
       on_error: send
       type: filter
     - combine_field: body.log
@@ -73,22 +74,27 @@ receivers:
       source_identifier: attributes["log.file.path"]
       type: recombine
     - from: body.attrs["com.amazonaws.ecs.task-definition-family"]
+      if: body.attrs != nil
       on_error: send_quiet
       to: resource["service.name"]
       type: move
     - from: body.attrs["com.amazonaws.ecs.container-name"]
+      if: body.attrs != nil
       on_error: send_quiet
       to: resource["aws.ecs.container.name"]
       type: move
     - from: body.attrs["com.amazonaws.ecs.task-arn"]
+      if: body.attrs != nil
       on_error: send_quiet
       to: resource["aws.ecs.task.arn"]
       type: move
     - from: body.attrs["com.amazonaws.ecs.cluster"]
+      if: body.attrs != nil
       on_error: send_quiet
       to: resource["aws.ecs.cluster.name"]
       type: move
     - field: body.attrs
+      if: body.attrs != nil
       on_error: send_quiet
       type: remove
     - on_error: send

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/main.tf.json
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/main.tf.json
@@ -1,0 +1,58 @@
+{
+  "locals": {
+    "cluster_arn": "${var.cluster_arn}",
+    "task_role_arn": "${aws_iam_role.task.arn}",
+    "execution_role_arn": "${aws_iam_role.exec.arn}"
+  },
+  "resource": {
+    "aws_iam_role": {
+      "task": {
+        "name": "${var.task_role_name}",
+        "assume_role_policy": "${jsonencode({\"Version\" = \"2012-10-17\", \"Statement\" = [{\"Action\" = \"sts:AssumeRole\", \"Effect\" = \"Allow\", \"Principal\" = {\"Service\" = \"ecs-tasks.amazonaws.com\"}}]})}",
+        "tags": {"foundry.signoz.io/kind":"CollectionAgent","foundry.signoz.io/managed-by":"foundry","foundry.signoz.io/name":"signoz"}
+      },
+      "exec": {
+        "name": "${var.execution_role_name}",
+        "assume_role_policy": "${jsonencode({\"Version\" = \"2012-10-17\", \"Statement\" = [{\"Action\" = \"sts:AssumeRole\", \"Effect\" = \"Allow\", \"Principal\" = {\"Service\" = \"ecs-tasks.amazonaws.com\"}}]})}",
+        "tags": {"foundry.signoz.io/kind":"CollectionAgent","foundry.signoz.io/managed-by":"foundry","foundry.signoz.io/name":"signoz"}
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "exec": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+        "role": "${aws_iam_role.exec.name}"
+      }
+    },
+    "aws_iam_role_policy": {
+      "task_appconfig_read": {
+        "name": "${var.task_role_name}-appconfig-read",
+        "role": "${aws_iam_role.task.id}",
+        "policy": "${jsonencode({\"Version\" = \"2012-10-17\", \"Statement\" = [{\"Effect\" = \"Allow\", \"Action\" = [\"appconfig:StartConfigurationSession\"], \"Resource\" = [format(\"%s/environment/*/configuration/*\", aws_appconfig_application.main.arn)]}, {\"Effect\" = \"Allow\", \"Action\" = [\"appconfig:GetLatestConfiguration\"], \"Resource\" = \"*\"}]})}"
+      }
+    },
+    "aws_appconfig_application": {
+      "main": {
+        "name": "signoz-collectionagent-appconfig",
+        "description": "SigNoz collection agent configuration",
+        "tags": {"foundry.signoz.io/kind":"CollectionAgent","foundry.signoz.io/managed-by":"foundry","foundry.signoz.io/name":"signoz"}
+      }
+    },
+    "aws_appconfig_environment": {
+      "main": {
+        "name": "default",
+        "application_id": "${aws_appconfig_application.main.id}",
+        "tags": {"foundry.signoz.io/kind":"CollectionAgent","foundry.signoz.io/managed-by":"foundry","foundry.signoz.io/name":"signoz"}
+      }
+    },
+    "aws_appconfig_deployment_strategy": {
+      "main": {
+        "name": "signoz-collectionagent-appconfig-strategy",
+        "deployment_duration_in_minutes": 0,
+        "final_bake_time_in_minutes": 0,
+        "growth_factor": 100,
+        "replicate_to": "NONE",
+        "tags": {"foundry.signoz.io/kind":"CollectionAgent","foundry.signoz.io/managed-by":"foundry","foundry.signoz.io/name":"signoz"}
+      }
+    }
+  }
+}

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/providers.tf.json
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/providers.tf.json
@@ -1,0 +1,7 @@
+{
+  "provider": {
+    "aws": {
+      "region": "${var.aws_region}"
+    }
+  }
+}

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/terraform.tfvars.json
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/terraform.tfvars.json
@@ -1,0 +1,6 @@
+{
+  "aws_region": "us-east-1",
+  "cluster_arn": "arn:aws:ecs:us-east-1:123456789012:cluster/signoz",
+  "task_role_name": "signoz-collectionagent-iam-task",
+  "execution_role_name": "signoz-collectionagent-iam-exec"
+}

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/variables.tf.json
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/variables.tf.json
@@ -1,0 +1,32 @@
+{
+  "variable": {
+    "aws_region": {
+      "nullable": false,
+      "validation": {
+        "condition": "${can(regex(\"^[a-z]{2}(-gov)?-[a-z]+-[0-9]$\", var.aws_region))}",
+        "error_message": "aws_region must be a region identifier such as us-east-1."
+      },
+      "description": "AWS region holding the cluster",
+      "type": "string"
+    },
+    "cluster_arn": {
+      "nullable": false,
+      "validation": {
+        "condition": "${can(regex(\"^arn:aws:ecs:\", var.cluster_arn))}",
+        "error_message": "cluster_arn must be the ARN of an ECS cluster."
+      },
+      "description": "ARN of the ECS cluster the agent runs a task on every instance of",
+      "type": "string"
+    },
+    "task_role_name": {
+      "nullable": false,
+      "description": "Name of the IAM role this stack creates for its task",
+      "type": "string"
+    },
+    "execution_role_name": {
+      "nullable": false,
+      "description": "Name of the IAM role this stack creates for the ECS agent to pull images and write logs",
+      "type": "string"
+    }
+  }
+}

--- a/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/versions.tf.json
+++ b/docs/examples/collectionagent/ecs/ec2/terraform/agent/pours/collectionagent/versions.tf.json
@@ -1,0 +1,11 @@
+{
+  "terraform": {
+    "required_version": ">= 1.4.0",
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "~> 5.0"
+      }
+    }
+  }
+}

--- a/internal/casting/collectionagent/ecsterraformcasting/casting.go
+++ b/internal/casting/collectionagent/ecsterraformcasting/casting.go
@@ -1,0 +1,167 @@
+package ecsterraformcasting
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/signoz/foundry/api/v1alpha1/collectionagent"
+	"github.com/signoz/foundry/internal/domain"
+	foundryerrors "github.com/signoz/foundry/internal/errors"
+	collectionagentmolding "github.com/signoz/foundry/internal/molding/collectionagent"
+	"github.com/signoz/foundry/internal/pourer"
+)
+
+// The sidecar writes the config here and the collector reads it.
+const configMount = "/conf"
+
+type ecsCasting struct {
+	logger *slog.Logger
+}
+
+func New(logger *slog.Logger) *ecsCasting {
+	return &ecsCasting{logger: logger}
+}
+
+func (c *ecsCasting) Enricher(ctx context.Context, config *collectionagent.Casting) (collectionagentmolding.MoldingEnricher, error) {
+	return newEcsMoldingEnricher(), nil
+}
+
+func (c *ecsCasting) Forge(ctx context.Context, config collectionagent.Casting, p *pourer.Pourer) error {
+	data := c.templateData(config)
+
+	for _, tmpl := range []*domain.Template{versionsTF, providersTF, backendTF, variablesTF, tfvarsTF, mainTF, collectorTF} {
+		material, err := tmpl.Render(data, strings.TrimSuffix(tmpl.Name(), ".gotmpl"))
+		if err != nil {
+			return err
+		}
+
+		p.AddJSON(material.FmtContents(), material.Path())
+	}
+
+	// AppConfig reads the config off disk at plan time, so the pour is the
+	// source the hosted configuration version is built from.
+	for path, content := range config.Spec.Collector.Spec.Config.Data {
+		p.AddYAML([]byte(content), path)
+	}
+
+	return nil
+}
+
+const planFile = "tfplan"
+
+func (c *ecsCasting) Cast(ctx context.Context, config collectionagent.Casting, outputPath string, p *pourer.Pourer) error {
+	root := filepath.Join(outputPath, p.Dir())
+
+	if err := c.terraform(ctx, root, "init"); err != nil {
+		return err
+	}
+
+	if err := c.terraform(ctx, root, "plan", "-out="+planFile); err != nil {
+		return err
+	}
+
+	return c.terraform(ctx, root, "apply", planFile)
+}
+
+func (c *ecsCasting) terraform(ctx context.Context, root, verb string, args ...string) error {
+	argv := append([]string{"-chdir=" + root, verb}, args...)
+
+	c.logger.DebugContext(ctx, "Running command", slog.String("command", "terraform "+strings.Join(argv, " ")))
+
+	// Stdout is foundry's own contract, so the tool's output goes to stderr.
+	cmd := exec.CommandContext(ctx, "terraform", argv...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return foundryerrors.Wrapf(err, foundryerrors.TypeInternal, "failed to run terraform %s", verb)
+	}
+
+	return nil
+}
+
+// Resolves the annotation-derived identifiers the templates render.
+func (c *ecsCasting) templateData(config collectionagent.Casting) templateData {
+	annotations := config.Metadata.Annotations
+
+	// Several workloads share one cluster, so a cluster-derived name collides on
+	// the second apply.
+	workload := config.Metadata.Name + "-" + strings.ToLower(config.Kind().String())
+
+	configKey := config.Spec.Collector.Kind.ConfigKey()
+
+	return templateData{
+		Casting: config,
+		Region:  collectionagent.ECSRegion.Resolve(annotations),
+		Cluster: Reference{Stated: collectionagent.ECSClusterARN.Resolve(annotations)},
+		TaskRole: Reference{
+			Stated: collectionagent.ECSTaskRoleARN.Resolve(annotations),
+			Name:   workload + "-iam-task",
+		},
+		ExecutionRole: Reference{
+			Stated: collectionagent.ECSTaskExecutionRoleARN.Resolve(annotations),
+			Name:   workload + "-iam-exec",
+		},
+		Application: workload + "-appconfig",
+		Environment: "default",
+		Profile:     strings.ReplaceAll(filepath.Dir(configKey), "/", "-"),
+		Source:      configKey,
+		Target:      filepath.Join(configMount, filepath.Base(configKey)),
+		Digest:      digest(config.Spec.Collector.Spec.Config.Data[configKey]),
+		ConfigMount: configMount,
+	}
+}
+
+func digest(content string) string {
+	sum := sha256.Sum256([]byte(content))
+
+	return hex.EncodeToString(sum[:])
+}
+
+// Reference is one identifier, stated by an operator or created under the
+// workload's own name. Exactly one side is populated.
+type Reference struct {
+	Stated string
+	Name   string
+}
+
+func (r Reference) IsStated() bool {
+	return r.Stated != ""
+}
+
+// Embeds the casting so .Spec and .Metadata stay reachable from templates.
+type templateData struct {
+	collectionagent.Casting
+
+	Region string
+
+	Cluster Reference
+
+	// The roles are the workload's own identity, created and destroyed with
+	// this stack.
+	TaskRole      Reference
+	ExecutionRole Reference
+
+	// Application carries the Kind, so a CollectionAgent and an Installation of
+	// the same metadata.name do not collide on one account.
+	Application string
+	Environment string
+
+	// Source is where the pour keeps the config, relative to the root; Target is
+	// where the sidecar writes it in the task.
+	Profile string
+	Source  string
+	Target  string
+
+	// The collector reads its config once at start, so a changed config has to
+	// replace the task.
+	Digest string
+
+	ConfigMount string
+}

--- a/internal/casting/collectionagent/ecsterraformcasting/embed.go
+++ b/internal/casting/collectionagent/ecsterraformcasting/embed.go
@@ -1,0 +1,22 @@
+package ecsterraformcasting
+
+import (
+	"embed"
+
+	"github.com/signoz/foundry/internal/domain"
+)
+
+//go:embed templates/*.gotmpl
+var templates embed.FS
+
+var (
+	versionsTF  = domain.MustNewTemplateFromFS(templates, "templates/versions.tf.json.gotmpl", domain.FormatJSON)
+	providersTF = domain.MustNewTemplateFromFS(templates, "templates/providers.tf.json.gotmpl", domain.FormatJSON)
+	backendTF   = domain.MustNewTemplateFromFS(templates, "templates/backend.tf.json.gotmpl", domain.FormatJSON)
+	variablesTF = domain.MustNewTemplateFromFS(templates, "templates/variables.tf.json.gotmpl", domain.FormatJSON)
+	tfvarsTF    = domain.MustNewTemplateFromFS(templates, "templates/terraform.tfvars.json.gotmpl", domain.FormatJSON)
+	mainTF      = domain.MustNewTemplateFromFS(templates, "templates/main.tf.json.gotmpl", domain.FormatJSON)
+	collectorTF = domain.MustNewTemplateFromFS(templates, "templates/collector.tf.json.gotmpl", domain.FormatJSON)
+
+	agentYAMLTemplate = domain.MustNewTemplateFromFS(templates, "templates/agent.yaml.gotmpl", domain.FormatYAML)
+)

--- a/internal/casting/collectionagent/ecsterraformcasting/embed_test.go
+++ b/internal/casting/collectionagent/ecsterraformcasting/embed_test.go
@@ -209,6 +209,8 @@ func TestAgentConfig(t *testing.T) {
 				Operators []struct {
 					Type    string `json:"type"`
 					From    string `json:"from"`
+					Field   string `json:"field"`
+					If      string `json:"if"`
 					Expr    string `json:"expr"`
 					OnError string `json:"on_error"`
 				} `json:"operators"`
@@ -245,10 +247,37 @@ func TestAgentConfig(t *testing.T) {
 		assert.Equal(t, 5, guarded, "four ecs label lifts plus the carved container id")
 	})
 
+	// send_quiet still hands the error back to the file reader, so the operators
+	// that read body.attrs must not run at all on a line that carries none.
+	t.Run("AttrsOperatorsGuarded_Valid", func(t *testing.T) {
+		guarded := 0
+
+		for _, operator := range config.Receivers.Filelog.Operators {
+			subject := operator.From
+			if operator.Type == "remove" {
+				subject = operator.Field
+			}
+
+			if operator.Type != "move" && operator.Type != "remove" {
+				continue
+			}
+
+			if !strings.HasPrefix(subject, "body.attrs") {
+				continue
+			}
+
+			guarded++
+
+			assert.Equal(t, "body.attrs != nil", operator.If, "%q must be skipped without attrs", subject)
+		}
+
+		assert.Equal(t, 5, guarded, "four ecs label lifts plus the attrs removal")
+	})
+
 	// The agent's own containers log through json-file, so it would otherwise
 	// ship its own lines back to itself.
 	t.Run("OwnFamilyFiltered_Valid", func(t *testing.T) {
-		expectedExpr := `body.attrs["com.amazonaws.ecs.task-definition-family"] == "signoz-collector-agent"`
+		expectedExpr := `body.attrs != nil && body.attrs["com.amazonaws.ecs.task-definition-family"] == "signoz-collector-agent"`
 
 		filtered := 0
 
@@ -260,6 +289,7 @@ func TestAgentConfig(t *testing.T) {
 			filtered++
 
 			assert.Equal(t, expectedExpr, operator.Expr)
+			assert.Empty(t, operator.If, "stanza's filter never evaluates if")
 			assert.Equal(t, "send", operator.OnError)
 		}
 

--- a/internal/casting/collectionagent/ecsterraformcasting/embed_test.go
+++ b/internal/casting/collectionagent/ecsterraformcasting/embed_test.go
@@ -1,0 +1,246 @@
+package ecsterraformcasting
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/signoz/foundry/api/v1alpha1/collectionagent"
+	"github.com/signoz/foundry/internal/domain"
+	"github.com/signoz/foundry/internal/pourer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const clusterARN = "arn:aws:ecs:us-east-1:123456789012:cluster/signoz"
+
+// statedCasting states every annotation, so no role is created.
+func statedCasting(t *testing.T) *collectionagent.Casting {
+	t.Helper()
+
+	config := collectionagent.Default()
+	config.Metadata.Annotations = map[string]string{
+		collectionagent.ECSRegion.Key:               "us-east-1",
+		collectionagent.ECSClusterARN.Key:           clusterARN,
+		collectionagent.ECSTaskRoleARN.Key:          "arn:aws:iam::123456789012:role/task",
+		collectionagent.ECSTaskExecutionRoleARN.Key: "arn:aws:iam::123456789012:role/exec",
+	}
+
+	return config
+}
+
+// derivedCasting leaves the roles unstated, so the stack creates them.
+func derivedCasting(t *testing.T) *collectionagent.Casting {
+	t.Helper()
+
+	config := collectionagent.Default()
+	config.Metadata.Annotations = map[string]string{
+		collectionagent.ECSRegion.Key:     "us-east-1",
+		collectionagent.ECSClusterARN.Key: clusterARN,
+	}
+
+	return config
+}
+
+func templateDataFor(t *testing.T, config *collectionagent.Casting) templateData {
+	t.Helper()
+
+	return New(slog.New(slog.DiscardHandler)).templateData(*config)
+}
+
+func TestTemplatesRender(t *testing.T) {
+	data := templateDataFor(t, statedCasting(t))
+
+	for name, test := range map[string]struct {
+		template *domain.Template
+		data     any
+	}{
+		"Versions_Valid":  {versionsTF, data},
+		"Providers_Valid": {providersTF, data},
+		"Backend_Valid":   {backendTF, data},
+		"Variables_Valid": {variablesTF, data},
+		"Tfvars_Valid":    {tfvarsTF, data},
+		"Main_Valid":      {mainTF, data},
+		"Collector_Valid": {collectorTF, data},
+		"Agent_Valid":     {agentYAMLTemplate, nil},
+	} {
+		t.Run(name, func(t *testing.T) {
+			material, err := test.template.Render(test.data, strings.TrimSuffix(test.template.Name(), ".gotmpl"))
+
+			require.NoError(t, err)
+			assert.NotEmpty(t, material.FmtContents())
+		})
+	}
+}
+
+func TestTemplateData(t *testing.T) {
+	for _, test := range []struct {
+		name                string
+		annotations         map[string]string
+		expectedRegion      string
+		expectedCluster     string
+		expectedRolesStated bool
+	}{
+		{"AllStated_Valid", statedCasting(t).Metadata.Annotations, "us-east-1", clusterARN, true},
+		{"RolesUnstated_Valid", derivedCasting(t).Metadata.Annotations, "us-east-1", clusterARN, false},
+		{"NothingStated_Valid", nil, "", "", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config := collectionagent.Default()
+			config.Metadata.Annotations = test.annotations
+
+			data := templateDataFor(t, config)
+
+			assert.Equal(t, test.expectedRegion, data.Region)
+			assert.Equal(t, test.expectedCluster, data.Cluster.Stated)
+
+			assert.Equal(t, "signoz-collectionagent-iam-task", data.TaskRole.Name)
+			assert.Equal(t, "signoz-collectionagent-iam-exec", data.ExecutionRole.Name)
+
+			assert.Equal(t, test.expectedRolesStated, data.TaskRole.IsStated())
+			assert.Equal(t, test.expectedRolesStated, data.ExecutionRole.IsStated())
+		})
+	}
+}
+
+// Terraform judges the platform inputs at plan, so an annotation-free casting
+// still forges.
+func TestUnstatedCastingForges(t *testing.T) {
+	p := pourer.New("collectionagent")
+	require.NoError(t, New(slog.New(slog.DiscardHandler)).Forge(context.Background(), *collectionagent.Default(), p))
+
+	materials, err := p.Pour()
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, materials)
+}
+
+// A default in the variables would race the tfvars, so the root declares no
+// variable the tfvars leaves unstated and none carries a default.
+func TestVariablesAndTfvars(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		config       *collectionagent.Casting
+		expectedVars []string
+	}{
+		{"RolesUnstated_Valid", derivedCasting(t), []string{"aws_region", "cluster_arn", "task_role_name", "execution_role_name"}},
+		{"RolesStated_Valid", statedCasting(t), []string{"aws_region", "cluster_arn", "task_role_arn", "execution_role_arn"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			data := templateDataFor(t, test.config)
+
+			tfvars := bytes.NewBuffer(nil)
+			require.NoError(t, tfvarsTF.Execute(tfvars, data))
+
+			stated := map[string]string{}
+			require.NoError(t, json.Unmarshal(tfvars.Bytes(), &stated))
+
+			assert.ElementsMatch(t, test.expectedVars, slices.Collect(maps.Keys(stated)))
+
+			for name, value := range stated {
+				assert.NotEmpty(t, value, "%q is stated with no value", name)
+			}
+
+			variables := bytes.NewBuffer(nil)
+			require.NoError(t, variablesTF.Execute(variables, data))
+
+			var root struct {
+				Variable map[string]map[string]any `json:"variable"`
+			}
+			require.NoError(t, json.Unmarshal(variables.Bytes(), &root))
+
+			assert.ElementsMatch(t, test.expectedVars, slices.Collect(maps.Keys(root.Variable)))
+
+			for name, variable := range root.Variable {
+				assert.NotContains(t, variable, "default", "%q must carry no default", name)
+
+				if strings.HasSuffix(name, "_name") {
+					continue
+				}
+
+				assert.Contains(t, variable, "validation", "%q must carry a validation", name)
+			}
+		})
+	}
+}
+
+func TestMainRoleOwnership(t *testing.T) {
+	for _, test := range []struct {
+		name                 string
+		config               *collectionagent.Casting
+		expectedRolesCreated bool
+	}{
+		{"RolesUnstated_Created", derivedCasting(t), true},
+		{"RolesStated_Reused", statedCasting(t), false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			require.NoError(t, mainTF.Execute(buf, templateDataFor(t, test.config)))
+
+			material, err := domain.NewJSONMaterial(buf.Bytes(), "main.tf.json")
+			require.NoError(t, err)
+
+			_, err = material.GetBytes("resource.aws_iam_role")
+			assert.Equal(t, test.expectedRolesCreated, err == nil)
+		})
+	}
+}
+
+func TestAgentConfig(t *testing.T) {
+	material, err := agentYAMLTemplate.Render(nil, "agent.yaml")
+	require.NoError(t, err)
+
+	structured, ok := material.(domain.StructuredMaterial)
+	require.True(t, ok)
+
+	var config struct {
+		Processors struct {
+			Resourcedetection struct {
+				Detectors []string `json:"detectors"`
+			} `json:"resourcedetection"`
+		} `json:"processors"`
+		Receivers struct {
+			Filelog struct {
+				Operators []struct {
+					Type    string `json:"type"`
+					From    string `json:"from"`
+					OnError string `json:"on_error"`
+				} `json:"operators"`
+			} `json:"filelog"`
+		} `json:"receivers"`
+	}
+	require.NoError(t, json.Unmarshal(structured.JSONContents(), &config))
+
+	// The ecs and docker detectors answer for the collector's own task, so on a
+	// DAEMON they would stamp every container's telemetry with it.
+	t.Run("Detectors_Valid", func(t *testing.T) {
+		assert.Equal(t, []string{"env", "ec2"}, config.Processors.Resourcedetection.Detectors)
+	})
+
+	// A task without the labels option writes no attrs, and the miss must not be
+	// logged once per operator per line.
+	t.Run("MoveOperators_Valid", func(t *testing.T) {
+		guarded := 0
+
+		for _, operator := range config.Receivers.Filelog.Operators {
+			if operator.Type != "move" {
+				continue
+			}
+
+			if !strings.HasPrefix(operator.From, "body.attrs") && operator.From != "attributes.container_id" {
+				continue
+			}
+
+			guarded++
+
+			assert.Equal(t, "send_quiet", operator.OnError, "%q must tolerate a miss", operator.From)
+		}
+
+		assert.Equal(t, 5, guarded, "four ecs label lifts plus the carved container id")
+	})
+}

--- a/internal/casting/collectionagent/ecsterraformcasting/embed_test.go
+++ b/internal/casting/collectionagent/ecsterraformcasting/embed_test.go
@@ -67,7 +67,7 @@ func TestTemplatesRender(t *testing.T) {
 		"Tfvars_Valid":    {tfvarsTF, data},
 		"Main_Valid":      {mainTF, data},
 		"Collector_Valid": {collectorTF, data},
-		"Agent_Valid":     {agentYAMLTemplate, nil},
+		"Agent_Valid":     {agentYAMLTemplate, agentTemplateDataFor(*statedCasting(t))},
 	} {
 		t.Run(name, func(t *testing.T) {
 			material, err := test.template.Render(test.data, strings.TrimSuffix(test.template.Name(), ".gotmpl"))
@@ -192,7 +192,7 @@ func TestMainRoleOwnership(t *testing.T) {
 }
 
 func TestAgentConfig(t *testing.T) {
-	material, err := agentYAMLTemplate.Render(nil, "agent.yaml")
+	material, err := agentYAMLTemplate.Render(agentTemplateDataFor(*statedCasting(t)), "agent.yaml")
 	require.NoError(t, err)
 
 	structured, ok := material.(domain.StructuredMaterial)
@@ -209,6 +209,7 @@ func TestAgentConfig(t *testing.T) {
 				Operators []struct {
 					Type    string `json:"type"`
 					From    string `json:"from"`
+					Expr    string `json:"expr"`
 					OnError string `json:"on_error"`
 				} `json:"operators"`
 			} `json:"filelog"`
@@ -242,5 +243,26 @@ func TestAgentConfig(t *testing.T) {
 		}
 
 		assert.Equal(t, 5, guarded, "four ecs label lifts plus the carved container id")
+	})
+
+	// The agent's own containers log through json-file, so it would otherwise
+	// ship its own lines back to itself.
+	t.Run("OwnFamilyFiltered_Valid", func(t *testing.T) {
+		expectedExpr := `body.attrs["com.amazonaws.ecs.task-definition-family"] == "signoz-collector-agent"`
+
+		filtered := 0
+
+		for _, operator := range config.Receivers.Filelog.Operators {
+			if operator.Type != "filter" {
+				continue
+			}
+
+			filtered++
+
+			assert.Equal(t, expectedExpr, operator.Expr)
+			assert.Equal(t, "send", operator.OnError)
+		}
+
+		assert.Equal(t, 1, filtered, "the agent's own family is dropped once")
 	})
 }

--- a/internal/casting/collectionagent/ecsterraformcasting/enricher.go
+++ b/internal/casting/collectionagent/ecsterraformcasting/enricher.go
@@ -1,0 +1,38 @@
+package ecsterraformcasting
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/signoz/foundry/api/v1alpha1"
+	"github.com/signoz/foundry/api/v1alpha1/collectionagent"
+	foundryerrors "github.com/signoz/foundry/internal/errors"
+	collectionagentmolding "github.com/signoz/foundry/internal/molding/collectionagent"
+)
+
+var _ collectionagentmolding.MoldingEnricher = (*ecsMoldingEnricher)(nil)
+
+type ecsMoldingEnricher struct{}
+
+func newEcsMoldingEnricher() *ecsMoldingEnricher {
+	return &ecsMoldingEnricher{}
+}
+
+func (e *ecsMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alpha1.MoldingKind, config *collectionagent.Casting) error {
+	if kind != v1alpha1.MoldingKindCollector {
+		return nil
+	}
+
+	if config.Spec.Collector.Kind != collectionagent.CollectorKindAgent {
+		return nil
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if err := agentYAMLTemplate.Execute(buf, nil); err != nil {
+		return foundryerrors.Wrapf(err, foundryerrors.TypeInternal, "failed to execute agent template")
+	}
+
+	config.Spec.Collector.Status.Config.Set(config.Spec.Collector.Kind.ConfigKey(), buf.Bytes())
+
+	return nil
+}

--- a/internal/casting/collectionagent/ecsterraformcasting/enricher.go
+++ b/internal/casting/collectionagent/ecsterraformcasting/enricher.go
@@ -28,11 +28,20 @@ func (e *ecsMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alpha1.Mol
 	}
 
 	buf := bytes.NewBuffer(nil)
-	if err := agentYAMLTemplate.Execute(buf, nil); err != nil {
+	if err := agentYAMLTemplate.Execute(buf, agentTemplateDataFor(*config)); err != nil {
 		return foundryerrors.Wrapf(err, foundryerrors.TypeInternal, "failed to execute agent template")
 	}
 
 	config.Spec.Collector.Status.Config.Set(config.Spec.Collector.Kind.ConfigKey(), buf.Bytes())
 
 	return nil
+}
+
+// Family is the agent's own ECS task family, which its filelog pipeline drops.
+type agentTemplateData struct {
+	Family string
+}
+
+func agentTemplateDataFor(config collectionagent.Casting) agentTemplateData {
+	return agentTemplateData{Family: config.Metadata.Name + "-collector-" + config.Spec.Collector.Kind.String()}
 }

--- a/internal/casting/collectionagent/ecsterraformcasting/templates/agent.yaml.gotmpl
+++ b/internal/casting/collectionagent/ecsterraformcasting/templates/agent.yaml.gotmpl
@@ -1,0 +1,173 @@
+receivers:
+  docker_stats:
+    endpoint: unix:///var/run/docker.sock
+    api_version: "1.44"
+    collection_interval: 60s
+    timeout: 20s
+    container_labels_to_metric_labels:
+      com.amazonaws.ecs.cluster: aws.ecs.cluster.name
+      com.amazonaws.ecs.task-arn: aws.ecs.task.arn
+      com.amazonaws.ecs.task-definition-family: aws.ecs.task.family
+      com.amazonaws.ecs.task-definition-version: aws.ecs.task.revision
+    metrics:
+      container.cpu.utilization:
+        enabled: true
+      container.memory.percent:
+        enabled: true
+      container.memory.usage.limit:
+        enabled: true
+      container.memory.usage.total:
+        enabled: true
+      container.network.io.usage.rx_bytes:
+        enabled: true
+      container.network.io.usage.tx_bytes:
+        enabled: true
+      container.network.io.usage.rx_dropped:
+        enabled: true
+      container.network.io.usage.tx_dropped:
+        enabled: true
+      container.blockio.io_service_bytes_recursive:
+        enabled: true
+  hostmetrics:
+    collection_interval: 60s
+    root_path: /hostfs
+    scrapers:
+      cpu: {}
+      memory: {}
+      disk: {}
+      filesystem:
+        exclude_fs_types:
+          match_type: strict
+          fs_types:
+            - autofs
+            - binfmt_misc
+            - bpf
+            - cgroup2
+            - configfs
+            - debugfs
+            - devpts
+            - devtmpfs
+            - fusectl
+            - hugetlbfs
+            - iso9660
+            - mqueue
+            - nsfs
+            - overlay
+            - proc
+            - procfs
+            - pstore
+            - rpc_pipefs
+            - securityfs
+            - selinuxfs
+            - squashfs
+            - sysfs
+            - tracefs
+        exclude_mount_points:
+          match_type: regexp
+          mount_points:
+            - /dev/*
+            - /proc/*
+            - /sys/*
+            - /run/*
+            - /var/lib/docker/*
+      network: {}
+      load: {}
+      paging: {}
+      process:
+        mute_process_name_error: true
+        mute_process_exe_error: true
+        mute_process_io_error: true
+        mute_process_user_error: true
+      processes: {}
+      system: {}
+  filelog:
+    include:
+      - /var/lib/docker/containers/*/*-json.log
+    start_at: end
+    include_file_name: false
+    include_file_path: true
+    operators:
+      # json-file's shape is always present, so a failure means the input changed.
+      # Without the timestamp the record carries the collector's read time.
+      - type: json_parser
+        parse_to: body
+        on_error: send
+        timestamp:
+          parse_from: body.time
+          layout_type: gotime
+          layout: '2006-01-02T15:04:05.999999999Z07:00'
+      - type: recombine
+        combine_field: body.log
+        combine_with: ""
+        is_last_entry: body.log endsWith "\n"
+        source_identifier: attributes["log.file.path"]
+        force_flush_period: 5s
+        on_error: send
+      # Anything foundry did not generate carries no labels and so no attrs;
+      # send_quiet keeps the record instead of logging per operator per line.
+      - type: move
+        from: body.attrs["com.amazonaws.ecs.task-definition-family"]
+        to: resource["service.name"]
+        on_error: send_quiet
+      - type: move
+        from: body.attrs["com.amazonaws.ecs.container-name"]
+        to: resource["aws.ecs.container.name"]
+        on_error: send_quiet
+      - type: move
+        from: body.attrs["com.amazonaws.ecs.task-arn"]
+        to: resource["aws.ecs.task.arn"]
+        on_error: send_quiet
+      - type: move
+        from: body.attrs["com.amazonaws.ecs.cluster"]
+        to: resource["aws.ecs.cluster.name"]
+        on_error: send_quiet
+      - type: remove
+        field: body.attrs
+        on_error: send_quiet
+      - type: regex_parser
+        parse_from: attributes["log.file.path"]
+        regex: '/var/lib/docker/containers/(?P<container_id>[a-f0-9]{64})/'
+        on_error: send
+      - type: move
+        from: attributes.container_id
+        to: resource["container.id"]
+        on_error: send_quiet
+      - type: move
+        from: attributes["log.file.path"]
+        to: resource["log.file.path"]
+      - type: move
+        from: body.stream
+        to: attributes["log.iostream"]
+      - type: remove
+        field: body.time
+      - type: move
+        from: body.log
+        to: body
+
+  # The task already mounts / at /hostfs, so these paths need no second mount.
+  filelog/host:
+    include:
+      - /hostfs/var/log/messages
+      - /hostfs/var/log/secure
+      - /hostfs/var/log/ecs/*.log
+    start_at: end
+    include_file_path: true
+    # All three sources share one service.name, so the file name separates them.
+    include_file_name: true
+    resource:
+      service.name: ecs-host
+
+processors:
+  # Never ecs or docker: on a DAEMON both answer for the collector's own task.
+  resourcedetection:
+    detectors:
+      - env
+      - ec2
+    timeout: 5s
+
+service:
+  pipelines:
+    metrics:
+      receivers: [docker_stats, hostmetrics]
+    logs:
+      receivers: [filelog, filelog/host]

--- a/internal/casting/collectionagent/ecsterraformcasting/templates/agent.yaml.gotmpl
+++ b/internal/casting/collectionagent/ecsterraformcasting/templates/agent.yaml.gotmpl
@@ -96,6 +96,10 @@ receivers:
           parse_from: body.time
           layout_type: gotime
           layout: '2006-01-02T15:04:05.999999999Z07:00'
+      # The agent tails its own json-file log, so its own family is dropped here.
+      - type: filter
+        expr: 'body.attrs["com.amazonaws.ecs.task-definition-family"] == "{{ .Family }}"'
+        on_error: send
       - type: recombine
         combine_field: body.log
         combine_with: ""

--- a/internal/casting/collectionagent/ecsterraformcasting/templates/agent.yaml.gotmpl
+++ b/internal/casting/collectionagent/ecsterraformcasting/templates/agent.yaml.gotmpl
@@ -97,8 +97,9 @@ receivers:
           layout_type: gotime
           layout: '2006-01-02T15:04:05.999999999Z07:00'
       # The agent tails its own json-file log, so its own family is dropped here.
+      # stanza's filter never evaluates `if`, so this guard has to live in expr.
       - type: filter
-        expr: 'body.attrs["com.amazonaws.ecs.task-definition-family"] == "{{ .Family }}"'
+        expr: 'body.attrs != nil && body.attrs["com.amazonaws.ecs.task-definition-family"] == "{{ .Family }}"'
         on_error: send
       - type: recombine
         combine_field: body.log
@@ -107,25 +108,29 @@ receivers:
         source_identifier: attributes["log.file.path"]
         force_flush_period: 5s
         on_error: send
-      # Anything foundry did not generate carries no labels and so no attrs;
-      # send_quiet keeps the record instead of logging per operator per line.
+      # A line from a container without labels carries no attrs, so it skips the label lifts.
       - type: move
+        if: 'body.attrs != nil'
         from: body.attrs["com.amazonaws.ecs.task-definition-family"]
         to: resource["service.name"]
         on_error: send_quiet
       - type: move
+        if: 'body.attrs != nil'
         from: body.attrs["com.amazonaws.ecs.container-name"]
         to: resource["aws.ecs.container.name"]
         on_error: send_quiet
       - type: move
+        if: 'body.attrs != nil'
         from: body.attrs["com.amazonaws.ecs.task-arn"]
         to: resource["aws.ecs.task.arn"]
         on_error: send_quiet
       - type: move
+        if: 'body.attrs != nil'
         from: body.attrs["com.amazonaws.ecs.cluster"]
         to: resource["aws.ecs.cluster.name"]
         on_error: send_quiet
       - type: remove
+        if: 'body.attrs != nil'
         field: body.attrs
         on_error: send_quiet
       - type: regex_parser

--- a/internal/casting/collectionagent/ecsterraformcasting/templates/backend.tf.json.gotmpl
+++ b/internal/casting/collectionagent/ecsterraformcasting/templates/backend.tf.json.gotmpl
@@ -1,0 +1,9 @@
+{
+  "terraform": {
+    "backend": {
+      "local": {
+        "path": "terraform.tfstate"
+      }
+    }
+  }
+}

--- a/internal/casting/collectionagent/ecsterraformcasting/templates/collector.tf.json.gotmpl
+++ b/internal/casting/collectionagent/ecsterraformcasting/templates/collector.tf.json.gotmpl
@@ -32,9 +32,16 @@
           "retries": 10,
           "startPeriod": 30
         },
-        {{- /* json-file makes the collector tail its own log through the
-               docker-containers mount. */}}
-        "logConfiguration": {"logDriver": "none"},
+        {{- /* The collector tails this file through the docker-containers
+               mount, so agent.yaml drops this task family. */}}
+        "logConfiguration": {
+          "logDriver": "json-file",
+          "options": {
+            "max-size": "10m",
+            "max-file": "3",
+            "labels": "com.amazonaws.ecs.task-definition-family,com.amazonaws.ecs.container-name,com.amazonaws.ecs.task-arn,com.amazonaws.ecs.cluster"
+          }
+        },
         "memoryReservation": 102
       },
       {
@@ -77,7 +84,14 @@
         "dependsOn": [
           {"containerName": "{{ $sidecar }}", "condition": "HEALTHY"}
         ],
-        "logConfiguration": {"logDriver": "none"},
+        "logConfiguration": {
+          "logDriver": "json-file",
+          "options": {
+            "max-size": "10m",
+            "max-file": "3",
+            "labels": "com.amazonaws.ecs.task-definition-family,com.amazonaws.ecs.container-name,com.amazonaws.ecs.task-arn,com.amazonaws.ecs.cluster"
+          }
+        },
         "cpu": 256,
         "memoryReservation": 512
       }

--- a/internal/casting/collectionagent/ecsterraformcasting/templates/collector.tf.json.gotmpl
+++ b/internal/casting/collectionagent/ecsterraformcasting/templates/collector.tf.json.gotmpl
@@ -1,0 +1,168 @@
+{{- $name := $.Metadata.Name -}}
+{{- $kind := $.Spec.Collector.Kind -}}
+{{- $label := printf "collector_%s" $kind.String -}}
+{{- $service := printf "%s-collector-%s" $name $kind.String -}}
+{{- $sidecar := printf "%s-collector-appconfig-agent" $name -}}
+{{- $profile := printf "%s:%s:%s" $.Application $.Environment $.Profile -}}
+{
+  "locals": {
+    "containers_{{ $label }}": [
+      {{- /* The agent writes 0600 and writeTo has no mode setting, so only
+             root reads what it wrote. */}}
+      {
+        "name": "{{ $sidecar }}",
+        "image": "public.ecr.aws/aws-appconfig/aws-appconfig-agent:2.x",
+        "essential": true,
+        "user": "0",
+        "environment": [
+          {"name": "PREFETCH_LIST", "value": "{{ $profile }}"},
+          {"name": "POLL_INTERVAL", "value": "45s"},
+          {"name": "MANIFEST", "value": "{\"{{ $profile }}\":{\"writeTo\":{\"path\":\"{{ $.Target }}\"}}}"}
+        ],
+        "mountPoints": [
+          {
+            "sourceVolume": "collector-config",
+            "containerPath": "{{ $.ConfigMount }}"
+          }
+        ],
+        "healthCheck": {
+          "command": ["CMD-SHELL", "test -s {{ $.Target }}"],
+          "interval": 5,
+          "timeout": 3,
+          "retries": 10,
+          "startPeriod": 30
+        },
+        {{- /* json-file makes the collector tail its own log through the
+               docker-containers mount. */}}
+        "logConfiguration": {"logDriver": "none"},
+        "memoryReservation": 102
+      },
+      {
+        "name": "{{ $service }}",
+        "image": "{{ $.Spec.Collector.Spec.Image }}",
+        "essential": true,
+        "user": "0",
+        "command": ["--config={{ $.Target }}"],
+        {{- $env := list (dict "name" "FOUNDRY_CONFIG_DIGEST" "value" $.Digest) }}
+        {{- range $key, $value := $.Spec.Collector.Spec.Env }}
+        {{- $env = append $env (dict "name" $key "value" $value) }}
+        {{- end }}
+        "environment": {{ toJson $env }},
+        "portMappings": [
+          {"containerPort": 4317, "hostPort": 4317, "protocol": "tcp"},
+          {"containerPort": 4318, "hostPort": 4318, "protocol": "tcp"}
+        ],
+        "mountPoints": [
+          {
+            "sourceVolume": "collector-config",
+            "containerPath": "{{ $.ConfigMount }}",
+            "readOnly": true
+          },
+          {
+            "sourceVolume": "docker-socket",
+            "containerPath": "/var/run/docker.sock",
+            "readOnly": true
+          },
+          {
+            "sourceVolume": "docker-containers",
+            "containerPath": "/var/lib/docker/containers",
+            "readOnly": true
+          },
+          {
+            "sourceVolume": "hostfs",
+            "containerPath": "/hostfs",
+            "readOnly": true
+          }
+        ],
+        "dependsOn": [
+          {"containerName": "{{ $sidecar }}", "condition": "HEALTHY"}
+        ],
+        "logConfiguration": {"logDriver": "none"},
+        "cpu": 256,
+        "memoryReservation": 512
+      }
+    ]
+  },
+  "resource": {
+    "aws_appconfig_configuration_profile": {
+      "{{ $label }}": {
+        "application_id": "${aws_appconfig_application.main.id}",
+        "name": "{{ $.Profile }}",
+        "location_uri": "hosted",
+        "type": "AWS.Freeform",
+        "tags": {{ toJson $.Labels }}
+      }
+    },
+    "aws_appconfig_hosted_configuration_version": {
+      "{{ $label }}": {
+        "application_id": "${aws_appconfig_application.main.id}",
+        "configuration_profile_id": "${aws_appconfig_configuration_profile.{{ $label }}.configuration_profile_id}",
+        "content_type": "application/x-yaml",
+        "content": "${file(\"${path.module}/{{ $.Source }}\")}"
+      }
+    },
+    "aws_appconfig_deployment": {
+      "{{ $label }}": {
+        "application_id": "${aws_appconfig_application.main.id}",
+        "environment_id": "${aws_appconfig_environment.main.environment_id}",
+        "configuration_profile_id": "${aws_appconfig_configuration_profile.{{ $label }}.configuration_profile_id}",
+        "configuration_version": "${aws_appconfig_hosted_configuration_version.{{ $label }}.version_number}",
+        "deployment_strategy_id": "${aws_appconfig_deployment_strategy.main.id}",
+        "tags": {{ toJson $.Labels }}
+      }
+    },
+    "aws_ecs_task_definition": {
+      "{{ $label }}": {
+        "family": "{{ $service }}",
+        "tags": {{ toJson $.Labels }},
+        {{- /* The OTLP ports are the instance's own, so a task on it reaches
+               the agent on localhost. */}}
+        "network_mode": "host",
+        "requires_compatibilities": ["EC2"],
+        "task_role_arn": "${local.task_role_arn}",
+        "execution_role_arn": "${local.execution_role_arn}",
+        "container_definitions": "${jsonencode(local.containers_{{ $label }})}",
+        "volume": [
+          {
+            "name": "collector-config",
+            "docker_volume_configuration": {
+              "scope": "task",
+              "driver": "local"
+            }
+          },
+          {
+            "name": "docker-socket",
+            "host_path": "/var/run/docker.sock"
+          },
+          {
+            "name": "docker-containers",
+            "host_path": "/var/lib/docker/containers"
+          },
+          {
+            "name": "hostfs",
+            "host_path": "/"
+          }
+        ],
+        "depends_on": ["aws_appconfig_deployment.{{ $label }}"]
+      }
+    },
+    "aws_ecs_service": {
+      "{{ $label }}": {
+        "name": "{{ $service }}",
+        "cluster": "${local.cluster_arn}",
+        "task_definition": "${aws_ecs_task_definition.{{ $label }}.arn}",
+        {{- /* A daemon takes no desired count and no maximum percent; the
+               minimum is what lets ECS replace the task on an instance. */}}
+        "scheduling_strategy": "DAEMON",
+        "deployment_minimum_healthy_percent": 0,
+        "launch_type": "EC2",
+        {{- /* A bad revision would otherwise reach every instance and stay. */}}
+        "deployment_circuit_breaker": {
+          "enable": true,
+          "rollback": true
+        },
+        "tags": {{ toJson $.Labels }}
+      }
+    }
+  }
+}

--- a/internal/casting/collectionagent/ecsterraformcasting/templates/main.tf.json.gotmpl
+++ b/internal/casting/collectionagent/ecsterraformcasting/templates/main.tf.json.gotmpl
@@ -1,0 +1,73 @@
+{
+  "locals": {
+    "cluster_arn": "${var.cluster_arn}",
+    "task_role_arn": "{{ if $.TaskRole.IsStated }}${var.task_role_arn}{{ else }}${aws_iam_role.task.arn}{{ end }}",
+    "execution_role_arn": "{{ if $.ExecutionRole.IsStated }}${var.execution_role_arn}{{ else }}${aws_iam_role.exec.arn}{{ end }}"
+  },
+  "resource": {
+    {{- if or (not $.TaskRole.IsStated) (not $.ExecutionRole.IsStated) }}
+    "aws_iam_role": {
+      {{- $first := true }}
+      {{- if not $.TaskRole.IsStated }}{{ if not $first }},{{ end }}{{ $first = false }}
+      "task": {
+        "name": "${var.task_role_name}",
+        "assume_role_policy": "${jsonencode({\"Version\" = \"2012-10-17\", \"Statement\" = [{\"Action\" = \"sts:AssumeRole\", \"Effect\" = \"Allow\", \"Principal\" = {\"Service\" = \"ecs-tasks.amazonaws.com\"}}]})}",
+        "tags": {{ toJson $.Labels }}
+      }
+      {{- end }}
+      {{- if not $.ExecutionRole.IsStated }}{{ if not $first }},{{ end }}{{ $first = false }}
+      "exec": {
+        "name": "${var.execution_role_name}",
+        "assume_role_policy": "${jsonencode({\"Version\" = \"2012-10-17\", \"Statement\" = [{\"Action\" = \"sts:AssumeRole\", \"Effect\" = \"Allow\", \"Principal\" = {\"Service\" = \"ecs-tasks.amazonaws.com\"}}]})}",
+        "tags": {{ toJson $.Labels }}
+      }
+      {{- end }}
+    },
+    {{- end }}
+    {{- if not $.ExecutionRole.IsStated }}
+    "aws_iam_role_policy_attachment": {
+      "exec": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+        "role": "${aws_iam_role.exec.name}"
+      }
+    },
+    {{- end }}
+    {{- if not $.TaskRole.IsStated }}
+    {{- /* GetLatestConfiguration acts on a session token and cannot be
+           scoped to the application. */}}
+    "aws_iam_role_policy": {
+      "task_appconfig_read": {
+        "name": "${var.task_role_name}-appconfig-read",
+        "role": "${aws_iam_role.task.id}",
+        "policy": "${jsonencode({\"Version\" = \"2012-10-17\", \"Statement\" = [{\"Effect\" = \"Allow\", \"Action\" = [\"appconfig:StartConfigurationSession\"], \"Resource\" = [format(\"%s/environment/*/configuration/*\", aws_appconfig_application.main.arn)]}, {\"Effect\" = \"Allow\", \"Action\" = [\"appconfig:GetLatestConfiguration\"], \"Resource\" = \"*\"}]})}"
+      }
+    },
+    {{- end }}
+    {{- /* The application name carries the Kind, so an Installation of the
+           same name holds its own. */}}
+    "aws_appconfig_application": {
+      "main": {
+        "name": "{{ $.Application }}",
+        "description": "SigNoz collection agent configuration",
+        "tags": {{ toJson $.Labels }}
+      }
+    },
+    "aws_appconfig_environment": {
+      "main": {
+        "name": "{{ $.Environment }}",
+        "application_id": "${aws_appconfig_application.main.id}",
+        "tags": {{ toJson $.Labels }}
+      }
+    },
+    "aws_appconfig_deployment_strategy": {
+      "main": {
+        "name": "{{ $.Application }}-strategy",
+        "deployment_duration_in_minutes": 0,
+        "final_bake_time_in_minutes": 0,
+        "growth_factor": 100,
+        "replicate_to": "NONE",
+        "tags": {{ toJson $.Labels }}
+      }
+    }
+  }
+}

--- a/internal/casting/collectionagent/ecsterraformcasting/templates/providers.tf.json.gotmpl
+++ b/internal/casting/collectionagent/ecsterraformcasting/templates/providers.tf.json.gotmpl
@@ -1,0 +1,7 @@
+{
+  "provider": {
+    "aws": {
+      "region": "${var.aws_region}"
+    }
+  }
+}

--- a/internal/casting/collectionagent/ecsterraformcasting/templates/terraform.tfvars.json.gotmpl
+++ b/internal/casting/collectionagent/ecsterraformcasting/templates/terraform.tfvars.json.gotmpl
@@ -1,0 +1,14 @@
+{
+  "aws_region": "{{ $.Region }}",
+  "cluster_arn": "{{ $.Cluster.Stated }}",
+  {{- if $.TaskRole.IsStated }}
+  "task_role_arn": "{{ $.TaskRole.Stated }}",
+  {{- else }}
+  "task_role_name": "{{ $.TaskRole.Name }}",
+  {{- end }}
+  {{- if $.ExecutionRole.IsStated }}
+  "execution_role_arn": "{{ $.ExecutionRole.Stated }}"
+  {{- else }}
+  "execution_role_name": "{{ $.ExecutionRole.Name }}"
+  {{- end }}
+}

--- a/internal/casting/collectionagent/ecsterraformcasting/templates/variables.tf.json.gotmpl
+++ b/internal/casting/collectionagent/ecsterraformcasting/templates/variables.tf.json.gotmpl
@@ -1,0 +1,56 @@
+{
+  "variable": {
+    "aws_region": {
+      "nullable": false,
+      "validation": {
+        "condition": "${can(regex(\"^[a-z]{2}(-gov)?-[a-z]+-[0-9]$\", var.aws_region))}",
+        "error_message": "aws_region must be a region identifier such as us-east-1."
+      },
+      "description": "AWS region holding the cluster",
+      "type": "string"
+    },
+    "cluster_arn": {
+      "nullable": false,
+      "validation": {
+        "condition": "${can(regex(\"^arn:aws:ecs:\", var.cluster_arn))}",
+        "error_message": "cluster_arn must be the ARN of an ECS cluster."
+      },
+      "description": "ARN of the ECS cluster the agent runs a task on every instance of",
+      "type": "string"
+    },
+    {{- if $.TaskRole.IsStated }}
+    "task_role_arn": {
+      "nullable": false,
+      "validation": {
+        "condition": "${can(regex(\"^arn:aws:iam::\", var.task_role_arn))}",
+        "error_message": "task_role_arn must be the ARN of an IAM role."
+      },
+      "description": "ARN of the IAM role the agent task assumes",
+      "type": "string"
+    },
+    {{- else }}
+    "task_role_name": {
+      "nullable": false,
+      "description": "Name of the IAM role this stack creates for its task",
+      "type": "string"
+    },
+    {{- end }}
+    {{- if $.ExecutionRole.IsStated }}
+    "execution_role_arn": {
+      "nullable": false,
+      "validation": {
+        "condition": "${can(regex(\"^arn:aws:iam::\", var.execution_role_arn))}",
+        "error_message": "execution_role_arn must be the ARN of an IAM role."
+      },
+      "description": "ARN of the IAM role the ECS agent assumes",
+      "type": "string"
+    }
+    {{- else }}
+    "execution_role_name": {
+      "nullable": false,
+      "description": "Name of the IAM role this stack creates for the ECS agent to pull images and write logs",
+      "type": "string"
+    }
+    {{- end }}
+  }
+}

--- a/internal/casting/collectionagent/ecsterraformcasting/templates/versions.tf.json.gotmpl
+++ b/internal/casting/collectionagent/ecsterraformcasting/templates/versions.tf.json.gotmpl
@@ -1,0 +1,11 @@
+{
+  "terraform": {
+    "required_version": ">= 1.4.0",
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "~> 5.0"
+      }
+    }
+  }
+}

--- a/internal/casting/collectionagent/registry.go
+++ b/internal/casting/collectionagent/registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/signoz/foundry/api/v1alpha1"
 	"github.com/signoz/foundry/internal/casting/collectionagent/dockercomposecasting"
 	"github.com/signoz/foundry/internal/casting/collectionagent/dockerswarmcasting"
+	"github.com/signoz/foundry/internal/casting/collectionagent/ecsterraformcasting"
 	"github.com/signoz/foundry/internal/casting/collectionagent/kuberneteskustomizecasting"
 	foundryerrors "github.com/signoz/foundry/internal/errors"
 	"github.com/signoz/foundry/internal/tooler"
@@ -13,6 +14,7 @@ import (
 	"github.com/signoz/foundry/internal/tooler/dockerswarmtooler"
 	"github.com/signoz/foundry/internal/tooler/dockertooler"
 	"github.com/signoz/foundry/internal/tooler/kubectltooler"
+	"github.com/signoz/foundry/internal/tooler/terraformtooler"
 )
 
 type CastingItem struct {
@@ -47,6 +49,14 @@ func NewRegistry(logger *slog.Logger) *Registry {
 			}: {
 				Casting: kuberneteskustomizecasting.New(logger),
 				Toolers: []tooler.Tooler{kubectltooler.New()},
+			},
+			{
+				Platform: v1alpha1.PlatformECS,
+				Flavor:   v1alpha1.FlavorTerraform,
+				Mode:     v1alpha1.ModeEC2,
+			}: {
+				Casting: ecsterraformcasting.New(logger),
+				Toolers: []tooler.Tooler{terraformtooler.New()},
 			},
 		},
 	}

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,0 +1,9 @@
+{
+  "version": 4,
+  "terraform_version": "1.14.7",
+  "serial": 1,
+  "lineage": "265e8a28-e222-7adf-cf9c-496c40ee70c2",
+  "outputs": {},
+  "resources": [],
+  "check_results": null
+}

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,9 +1,0 @@
-{
-  "version": 4,
-  "terraform_version": "1.14.7",
-  "serial": 1,
-  "lineage": "265e8a28-e222-7adf-cf9c-496c40ee70c2",
-  "outputs": {},
-  "resources": [],
-  "check_results": null
-}


### PR DESCRIPTION
#### Features

- Runs the collection agent as an ECS daemon service on the EC2 launch type: one task per container instance, in host networking so tasks on the instance send OTLP to `localhost:4317` and `:4318`.
- Collects container metrics through `docker_stats`, instance metrics through `hostmetrics`, container logs from the Docker json-file directory with the ECS cluster, task and family lifted from the labels onto each record, and the instance's own logs as `service.name=ecs-host`, with `ec2` resource attributes.
- Delivers the agent configuration through AWS AppConfig; a change replaces the task through a digest on the task definition.
- States the cluster and region as annotations, validated by terraform at plan; creates the task and execution roles under the workload's name unless their ARNs are stated.
- Cast runs `terraform init`, `plan -out=tfplan`, `apply tfplan` on the root; every resource label carries the collector kind.

#### Tests

- Covers render validity, identifier resolution, the annotation-free forge, the variables and tfvars contract, role ownership, and the agent config's detectors and label tolerance.

#### Chores

- Adds the example under `docs/examples/collectionagent/ecs/ec2/terraform/agent/` with a README in the shape of the other collection agent examples.

#### Example
```yaml
apiVersion: v1alpha1
kind: CollectionAgent
metadata:
  name: signoz
  annotations:
    foundry.signoz.io/ecs-region: us-east-1
    foundry.signoz.io/ecs-cluster-arn: arn:aws:ecs:us-east-1:123456789012:cluster/signoz
spec:
  deployment:
    platform: ecs
    mode: ec2
    flavor: terraform
  collector:
    kind: agent
    spec:
      env:
        SIGNOZ_INGESTION_ENDPOINT: "https://ingest.us.signoz.cloud:443"
```
Related: https://github.com/SigNoz/platform-pod/issues/1973
