### PR TITLE
fix(healthcheck): prevent ClickHouse broken-pipe errors in the telemetrystore healthcheck

### DIFF
--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -293,8 +293,8 @@ services:
       test:
       - CMD
       - wget
-      - --spider
       - -q
+      - -O-
       - 0.0.0.0:8123/ping
       timeout: 5s
     image: clickhouse/clickhouse-server:25.12.5

--- a/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore.tf.json
+++ b/docs/examples/ecs/ec2/terraform/pours/deployment/module/telemetrystore.tf.json
@@ -66,7 +66,7 @@
         "memory": 512,
         "memoryReservation": 512,
         "healthCheck": {
-          "command": ["CMD-SHELL", "wget --spider -q 0.0.0.0:8123/ping || exit 1"],
+          "command": ["CMD-SHELL", "wget -q -O- 0.0.0.0:8123/ping || exit 1"],
           "interval": 30,
           "timeout": 5,
           "retries": 3,

--- a/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
+++ b/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
@@ -108,8 +108,8 @@ services:
       test:
         - CMD
         - wget
-        - --spider
         - -q
+        - -O-
         - 0.0.0.0:8123/ping
       interval: 30s
       timeout: 5s

--- a/internal/casting/ecsterraformcasting/templates/module/telemetrystore.tf.json.gotmpl
+++ b/internal/casting/ecsterraformcasting/templates/module/telemetrystore.tf.json.gotmpl
@@ -71,7 +71,7 @@
         "memory": 512,
         "memoryReservation": 512,
         "healthCheck": {
-          "command": ["CMD-SHELL", "wget --spider -q 0.0.0.0:8123/ping || exit 1"],
+          "command": ["CMD-SHELL", "wget -q -O- 0.0.0.0:8123/ping || exit 1"],
           "interval": 30,
           "timeout": 5,
           "retries": 3,


### PR DESCRIPTION
#### Fixes

- Stop the ClickHouse healthcheck from writing broken-pipe errors into the ClickHouse log.

### Problem

The ClickHouse healthcheck uses `wget --spider`. The `--spider` option closes the connection before it reads the response body. ClickHouse then fails to write the `/ping` response, and records the failure as an `Error` with a full C++ stack trace.

The healthcheck runs every 30 seconds, and each failure writes two error lines. This adds about 5,700 stack traces a day. The container stays `healthy` the whole time, because the check still exits 0, so nothing surfaces the problem. The noise hides real ClickHouse errors.

This is the cause of the long-standing report in SigNoz/signoz#5140 (open since June 2024). A user identified the healthcheck there in September 2025, and a maintainer asked for a PR. This is that PR.

### Fix

Replace `--spider` with `-O-`, so `wget` reads the response body.

### Measurements

On `clickhouse-server:25.5.6`, running each command 25 times and counting new `StaticRequestHandler` error lines:

| command | errors |
|---|---|
| `wget --spider -q 0.0.0.0:8123/ping` | 22/25 |
| `wget -q -O- 0.0.0.0:8123/ping` | **0/25** |

Verified on a live single-node deployment: the error count went from a steady stream to zero, and the container stays `healthy` with `FailingStreak=0`.

### Scope

Only the `coolify` and `ecsterraform` castings are affected, because they use the `0.0.0.0` host. The `dockercompose` and `dockerswarm` castings use `http://localhost:8123/ping` and are left unchanged.

### One thing worth flagging

Please do **not** fix this by changing the host to `localhost`. In the ClickHouse image, `/etc/hosts` resolves `localhost` to `::1` first. On a host with IPv6 disabled, the connection is refused:

```
$ wget -q -O- http://localhost:8123/ping
wget: can't connect to remote host: Connection refused     # rc=1

$ wget -q -O- 0.0.0.0:8123/ping
Ok.                                                        # rc=0
```

That variant produces no broken-pipe errors only because the request never reaches ClickHouse, and it would make the healthcheck fail. It may be worth a separate look at whether the `dockercompose` and `dockerswarm` castings are exposed to this on IPv6-disabled hosts. I have not tested those flavors, so I left them alone.

Refs SigNoz/signoz#5140
