### PR TITLE
fix(casting/coolify): bring the stack to compose parity and route ingress the Coolify way

### DIFF
--- a/docs/examples/coolify/stack/README.md
+++ b/docs/examples/coolify/stack/README.md
@@ -21,6 +21,7 @@ Generates a `coolify.yaml` stack definition for deploying SigNoz on a Coolify-ma
 
 ```yaml
 apiVersion: v1alpha1
+kind: Installation
 metadata:
   name: signoz
 spec:
@@ -37,6 +38,8 @@ foundryctl forge -f casting.yaml
 ```
 
 After forging, deploy the generated `coolify.yaml` using the [Coolify stack feature](https://coolify.io/docs/knowledge-base/docker/compose).
+
+Nothing is published on host ports. Coolify routes each endpoint through a magic environment key, and you assign its domain in the Coolify dashboard: `SERVICE_URL_SIGNOZ0_8080` for the UI, `SERVICE_URL_INGESTER_4318` for OTLP HTTP, and `SERVICE_URL_MCP_8000` for the MCP server. OTLP gRPC on port `4317` is reachable only inside the stack unless a [patch](../../../concepts/patches.md) adds a host port.
 
 ## Generated output
 
@@ -63,7 +66,7 @@ spec:
       enabled: true
 ```
 
-This adds a `signoz-mcp` service to the stack listening on port `8000`. Expose that port from the Coolify dashboard to reach it from AI clients; the MCP endpoint is the exposed URL plus `/mcp`.
+This adds an `mcp` service to the stack listening on port `8000`, carrying the `SERVICE_URL_MCP_8000` key. Assign a domain for it in the Coolify dashboard to reach it from AI clients; the MCP endpoint is that URL plus `/mcp`.
 
 To connect an AI client (mint an API key, configure Claude Code or Claude Desktop), see [MCP server](../../../concepts/mcp-server.md).
 

--- a/docs/examples/coolify/stack/README.md
+++ b/docs/examples/coolify/stack/README.md
@@ -39,7 +39,7 @@ foundryctl forge -f casting.yaml
 
 After forging, deploy the generated `coolify.yaml` using the [Coolify stack feature](https://coolify.io/docs/knowledge-base/docker/compose).
 
-Nothing is published on host ports. Coolify routes each endpoint through a magic environment key, and you assign its domain in the Coolify dashboard: `SERVICE_URL_SIGNOZ0_8080` for the UI, `SERVICE_URL_INGESTER_4318` for OTLP HTTP, and `SERVICE_URL_MCP_8000` for the MCP server. OTLP gRPC on port `4317` is reachable only inside the stack unless a [patch](../../../concepts/patches.md) adds a host port.
+Nothing is published on host ports. Coolify routes each endpoint through a magic environment key, and you assign its domain in the Coolify dashboard: `SERVICE_URL_SIGNOZ0_8080` for the UI, `SERVICE_URL_INGESTER0_4318` for OTLP HTTP, and `SERVICE_URL_MCP0_8000` for the MCP server. OTLP gRPC on port `4317` is reachable only inside the stack unless a [patch](../../../concepts/patches.md) adds a host port.
 
 ## Generated output
 
@@ -66,7 +66,7 @@ spec:
       enabled: true
 ```
 
-This adds an `mcp` service to the stack listening on port `8000`, carrying the `SERVICE_URL_MCP_8000` key. Assign a domain for it in the Coolify dashboard to reach it from AI clients; the MCP endpoint is that URL plus `/mcp`.
+This adds a `signoz-mcp-0` service to the stack listening on port `8000`, carrying the `SERVICE_URL_MCP0_8000` key. Assign a domain for it in the Coolify dashboard to reach it from AI clients; the MCP endpoint is that URL plus `/mcp`.
 
 To connect an AI client (mint an API key, configure Claude Code or Claude Desktop), see [MCP server](../../../concepts/mcp-server.md).
 

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -1,16 +1,14 @@
 services:
-  ingester:
+  signoz-ingester-0:
     command:
     - -c
     - |
       /signoz-otel-collector migrate sync check &&
       /signoz-otel-collector --config=/etc/otel-collector-config.yaml --manager-config=/etc/opamp-config.yaml --copy-path=/var/tmp/collector-config.yaml
-    deploy:
-      replicas: 1
     entrypoint:
     - /bin/sh
     environment:
-    - SERVICE_URL_INGESTER_4318
+    - SERVICE_URL_INGESTER0_4318
     - OTEL_RESOURCE_ATTRIBUTES=host.name=signoz-host,os.type=linux
     - SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN=tcp://signoz-telemetrystore-clickhouse-0-0:9000
     - SIGNOZ_OTEL_COLLECTOR_TIMEOUT=10m

--- a/docs/examples/coolify/stack/pours/deployment/coolify.yaml
+++ b/docs/examples/coolify/stack/pours/deployment/coolify.yaml
@@ -5,20 +5,14 @@ services:
     - |
       /signoz-otel-collector migrate sync check &&
       /signoz-otel-collector --config=/etc/otel-collector-config.yaml --manager-config=/etc/opamp-config.yaml --copy-path=/var/tmp/collector-config.yaml
-    depends_on:
-      signoz-signoz-0:
-        condition: service_started
-      signoz-telemetrystore-clickhouse-0-0:
-        condition: service_healthy
-      signoz-telemetrystore-migrator:
-        condition: service_completed_successfully
     deploy:
       replicas: 1
     entrypoint:
     - /bin/sh
     environment:
+    - SERVICE_URL_INGESTER_4318
     - OTEL_RESOURCE_ATTRIBUTES=host.name=signoz-host,os.type=linux
-    - LOW_CARDINAL_EXCEPTION_GROUPING=false
+    - SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN=tcp://signoz-telemetrystore-clickhouse-0-0:9000
     - SIGNOZ_OTEL_COLLECTOR_TIMEOUT=10m
     image: signoz/signoz-otel-collector:latest
     logging:
@@ -29,6 +23,7 @@ services:
       default:
         aliases:
         - signoz-ingester
+    restart: unless-stopped
     volumes:
     - content: |
         connectors:
@@ -179,29 +174,24 @@ services:
     healthcheck:
       interval: 30s
       retries: 3
+      start_period: 30s
       test:
       - CMD-SHELL
       - pg_isready -U signoz -d signoz
-      timeout: 5s
+      timeout: 10s
     image: postgres:16
     logging:
       options:
         max-file: "3"
         max-size: 50m
+    restart: unless-stopped
     volumes:
-    - source: signoz-metastore-0-data
+    - source: signoz-metastore-postgres-0-data
       target: /var/lib/postgresql/data
       type: volume
   signoz-signoz-0:
-    container_name: signoz-signoz-0
-    depends_on:
-      signoz-metastore-postgres-0:
-        condition: service_healthy
-      signoz-telemetrystore-clickhouse-0-0:
-        condition: service_healthy
-      signoz-telemetrystore-migrator:
-        condition: service_completed_successfully
     environment:
+    - SERVICE_URL_SIGNOZ0_8080
     - SIGNOZ_SQLSTORE_POSTGRES_DSN=postgres://signoz:signoz@signoz-metastore-postgres-0:5432/signoz?sslmode=disable
     - SIGNOZ_SQLSTORE_PROVIDER=postgres
     - SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_DSN=tcp://signoz-telemetrystore-clickhouse-0-0:9000
@@ -209,22 +199,20 @@ services:
     healthcheck:
       interval: 30s
       retries: 3
+      start_period: 60s
       test:
       - CMD
       - wget
       - --spider
       - -q
-      - localhost:8080/api/v1/health
-      timeout: 5s
+      - http://localhost:8080/api/v1/health
+      timeout: 10s
     image: signoz/signoz:latest
     logging:
       options:
         max-file: "3"
         max-size: 50m
-    volumes:
-    - source: signoz-signoz-0-data
-      target: /var/lib/signoz/
-      type: volume
+    restart: unless-stopped
   signoz-telemetrykeeper-clickhousekeeper-0:
     entrypoint:
     - /usr/bin/clickhouse-keeper
@@ -248,6 +236,7 @@ services:
       options:
         max-file: "3"
         max-size: 50m
+    restart: unless-stopped
     volumes:
     - source: signoz-telemetrykeeper-0-data
       target: /var/lib/clickhouse-keeper
@@ -290,18 +279,20 @@ services:
     healthcheck:
       interval: 30s
       retries: 3
+      start_period: 40s
       test:
       - CMD
       - wget
-      - --spider
       - -q
+      - -O-
       - 0.0.0.0:8123/ping
-      timeout: 5s
+      timeout: 10s
     image: clickhouse/clickhouse-server:25.12.5
     logging:
       options:
         max-file: "3"
         max-size: 50m
+    restart: unless-stopped
     volumes:
     - source: signoz-telemetrystore-0-0-data
       target: /var/lib/clickhouse/
@@ -446,23 +437,23 @@ services:
       options:
         max-file: "3"
         max-size: 50m
-    restart: "no"
+    restart: on-failure
     volumes:
     - source: signoz-telemetrystore-user-scripts
       target: /var/lib/clickhouse/user_scripts
       type: volume
   signoz-telemetrystore-migrator:
     command:
-    - /signoz-otel-collector migrate bootstrap --clickhouse-dsn tcp://signoz-telemetrystore-clickhouse-0-0:9000
-    - /signoz-otel-collector migrate sync up --clickhouse-dsn tcp://signoz-telemetrystore-clickhouse-0-0:9000
-    - /signoz-otel-collector migrate async up --clickhouse-dsn tcp://signoz-telemetrystore-clickhouse-0-0:9000
-    depends_on:
-      signoz-telemetrystore-clickhouse-0-0:
-        condition: service_healthy
+    - -c
+    - |
+      /signoz-otel-collector migrate ready &&
+      /signoz-otel-collector migrate bootstrap &&
+      /signoz-otel-collector migrate sync up &&
+      /signoz-otel-collector migrate async up
     entrypoint:
     - /bin/sh
-    - -c
     environment:
+    - SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN=tcp://signoz-telemetrystore-clickhouse-0-0:9000
     - SIGNOZ_OTEL_COLLECTOR_TIMEOUT=10m
     exclude_from_hc: true
     image: signoz/signoz-otel-collector:latest
@@ -472,10 +463,8 @@ services:
         max-size: 50m
     restart: on-failure
 volumes:
-  signoz-metastore-0-data:
-    name: signoz-metastore-0-data
-  signoz-signoz-0-data:
-    name: signoz-signoz-0-data
+  signoz-metastore-postgres-0-data:
+    name: signoz-metastore-postgres-0-data
   signoz-telemetrykeeper-0-data:
     name: signoz-telemetrykeeper-0-data
   signoz-telemetrystore-0-0-data:

--- a/internal/casting/coolifycasting/casting.go
+++ b/internal/casting/coolifycasting/casting.go
@@ -49,7 +49,7 @@ func (c *coolifyCasting) Forge(ctx context.Context, config installation.Casting,
 }
 
 func (c *coolifyCasting) Cast(ctx context.Context, config installation.Casting, poursPath string) error {
-	c.logger.InfoContext(ctx, "Please run 'forge' first to generate the Coolify Casting",
+	c.logger.InfoContext(ctx, "coolify.yaml is forged, deploy it in Coolify as a Docker Compose resource",
 		slog.String("pours_path", poursPath))
 	c.logger.InfoContext(ctx, "After forging, deploy coolify.yaml to Coolify using the stack feature",
 		slog.String("docs", "https://coolify.io/docs/knowledge-base/docker/compose"))

--- a/internal/casting/coolifycasting/enricher.go
+++ b/internal/casting/coolifycasting/enricher.go
@@ -119,9 +119,6 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 			return nil
 		}
 
-		// The ingester is scaled via `deploy.replicas` and reached through the
-		// `<metadata.name>-ingester` network alias on the default network,
-		// which compose load-balances across all replicas.
 		config.Spec.Ingester.Status.Addresses.OTLP = []string{
 			domain.MustNewAddress("tcp", config.Metadata.Name+"-ingester", 4318).String(),
 			domain.MustNewAddress("tcp", config.Metadata.Name+"-ingester", 4317).String(),
@@ -131,9 +128,6 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 			return nil
 		}
 
-		// The mcp server is scaled via `deploy.replicas` and reached through the
-		// `<metadata.name>-mcp` network alias on the default network,
-		// which compose load-balances across all replicas.
 		config.Spec.MCP.Status.Addresses.HTTP = []string{
 			domain.MustNewAddress("http", config.Metadata.Name+"-mcp", 8000).String(),
 		}

--- a/internal/casting/coolifycasting/enricher.go
+++ b/internal/casting/coolifycasting/enricher.go
@@ -30,6 +30,9 @@ func newCoolifyMoldingEnricher(config *installation.Casting) (*coolifyMoldingEnr
 func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v1alpha1.MoldingKind, config *installation.Casting) error {
 	switch kind {
 	case v1alpha1.MoldingKindTelemetryStore:
+		if !config.Spec.TelemetryStore.Spec.IsEnabled() {
+			return nil
+		}
 		containerNames, err := enricher.material.GetStringSlice("services|@keys")
 		if err != nil {
 			return errors.Wrapf(err, errors.TypeInternal, "failed to get telemetrystore container names")
@@ -44,6 +47,9 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		config.Spec.TelemetryStore.Status.Addresses.TCP = telemetrystoreContainerNames
 
 	case v1alpha1.MoldingKindSignoz:
+		if !config.Spec.Signoz.Spec.IsEnabled() {
+			return nil
+		}
 		containerNames, err := enricher.material.GetStringSlice("services|@keys")
 		if err != nil {
 			return errors.Wrapf(err, errors.TypeInternal, "failed to get signoz container names")
@@ -61,6 +67,9 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		config.Spec.Signoz.Status.Addresses.Opamp = opampAddr
 
 	case v1alpha1.MoldingKindTelemetryKeeper:
+		if !config.Spec.TelemetryKeeper.Spec.IsEnabled() {
+			return nil
+		}
 		containerNames, err := enricher.material.GetStringSlice("services|@keys")
 		if err != nil {
 			return errors.Wrapf(err, errors.TypeInternal, "failed to get telemetrykeeper container names")
@@ -89,7 +98,7 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 
 	case v1alpha1.MoldingKindMetaStore:
 		// Skip molding enrichment if sqlite
-		if config.Spec.MetaStore.Kind == installation.MetaStoreKindSQLite {
+		if !config.Spec.MetaStore.Spec.IsEnabled() || config.Spec.MetaStore.Kind == installation.MetaStoreKindSQLite {
 			return nil
 		}
 		containerNames, err := enricher.material.GetStringSlice("services|@keys")
@@ -106,13 +115,16 @@ func (enricher *coolifyMoldingEnricher) EnrichStatus(ctx context.Context, kind v
 		config.Spec.MetaStore.Status.Addresses.DSN = metastoreContainerNames
 
 	case v1alpha1.MoldingKindIngester:
+		if !config.Spec.Ingester.Spec.IsEnabled() {
+			return nil
+		}
+
 		// The ingester is scaled via `deploy.replicas` and reached through the
 		// `<metadata.name>-ingester` network alias on the default network,
 		// which compose load-balances across all replicas.
 		config.Spec.Ingester.Status.Addresses.OTLP = []string{
 			domain.MustNewAddress("tcp", config.Metadata.Name+"-ingester", 4318).String(),
 			domain.MustNewAddress("tcp", config.Metadata.Name+"-ingester", 4317).String(),
-
 		}
 	case v1alpha1.MoldingKindMCP:
 		if !config.Spec.MCP.Spec.IsEnabled() {

--- a/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
+++ b/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
@@ -224,8 +224,8 @@ services:
   {{- end }}
   {{- end }}
   {{- if derefBool $.Spec.MCP.Spec.Enabled }}
-  {{- $mcpReplicas := int $.Spec.MCP.Spec.Cluster.Replicas }}
-  mcp:
+  {{- range $replicaIdx := until (int $.Spec.MCP.Spec.Cluster.Replicas) }}
+  {{ $.Metadata.Name }}-mcp-{{ $replicaIdx }}:
     image: {{ $.Spec.MCP.Spec.Image }}
     restart: unless-stopped
     networks:
@@ -233,7 +233,7 @@ services:
         aliases:
           - {{ $.Metadata.Name }}-mcp
     environment:
-      - SERVICE_URL_MCP_8000
+      - SERVICE_URL_MCP{{ $replicaIdx }}_8000
       {{- range $key, $value := $.Spec.MCP.Spec.Env }}
       - {{ $key }}={{ $value }}
       {{- end }}
@@ -241,14 +241,13 @@ services:
       options:
         max-size: 50m
         max-file: "3"
-    deploy:
-      replicas: {{ $mcpReplicas }}
+  {{- end }}
   {{- end }}
   {{- if derefBool $.Spec.Ingester.Spec.Enabled }}
-  {{- $ingesterReplicas := int $.Spec.Ingester.Spec.Cluster.Replicas }}
   {{- $ingesterConfig := index $.Spec.Ingester.Spec.Config.Data "ingester.yaml" }}
   {{- $opampConfig := index $.Spec.Ingester.Spec.Config.Data "opamp.yaml" }}
-  ingester:
+  {{- range $replicaIdx := until (int $.Spec.Ingester.Spec.Cluster.Replicas) }}
+  {{ $.Metadata.Name }}-ingester-{{ $replicaIdx }}:
     image: {{ $.Spec.Ingester.Spec.Image }}
     restart: unless-stopped
     networks:
@@ -256,7 +255,7 @@ services:
         aliases:
           - {{ $.Metadata.Name }}-ingester
     environment:
-      - SERVICE_URL_INGESTER_4318
+      - SERVICE_URL_INGESTER{{ $replicaIdx }}_4318
       - OTEL_RESOURCE_ATTRIBUTES=host.name=signoz-host,os.type=linux
       {{- if and (derefBool $.Spec.TelemetryStore.Spec.Enabled) $.Spec.TelemetryStore.Status.Addresses.TCP (index $.Spec.TelemetryStore.Status.Addresses.TCP 0) }}
       - SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN={{ index $.Spec.TelemetryStore.Status.Addresses.TCP 0 }}
@@ -286,8 +285,7 @@ services:
       options:
         max-size: 50m
         max-file: "3"
-    deploy:
-      replicas: {{ $ingesterReplicas }}
+  {{- end }}
   {{- end }}
   {{- if derefBool $.Spec.TelemetryStore.Spec.Enabled }}
   {{ $.Metadata.Name }}-telemetrystore-migrator:

--- a/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
+++ b/internal/casting/coolifycasting/templates/coolify.yaml.gotmpl
@@ -5,9 +5,11 @@
 # port: 8080
 
 services:
+  {{- if derefBool $.Spec.TelemetryKeeper.Spec.Enabled }}
   {{- range $replicaIdx := until (int $.Spec.TelemetryKeeper.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-telemetrykeeper-{{ $.Spec.TelemetryKeeper.Kind }}-{{ $replicaIdx }}:
     image: {{ $.Spec.TelemetryKeeper.Spec.Image }}
+    restart: unless-stopped
     {{- if eq $.Spec.TelemetryKeeper.Kind.String "zookeeper" }}
     environment:
       - ZOO_SERVER_ID={{ add $replicaIdx 1 }}
@@ -34,6 +36,14 @@ services:
         max-size: 50m
         max-file: "3"
     {{- else }}
+    {{- $keeperConfigKey := printf "keeper-%d.yaml" $replicaIdx }}
+    {{- $keeperConfig := index $.Spec.TelemetryKeeper.Spec.Config.Data $keeperConfigKey }}
+    {{- if $.Spec.TelemetryKeeper.Spec.Env }}
+    environment:
+      {{- range $key, $value := $.Spec.TelemetryKeeper.Spec.Env }}
+      - {{ $key }}={{ $value }}
+      {{- end }}
+    {{- end }}
     healthcheck:
       test:
         - CMD
@@ -53,10 +63,10 @@ services:
         source: {{ $.Metadata.Name }}-telemetrykeeper-{{ $replicaIdx }}-data
         target: /var/lib/clickhouse-keeper
       - type: bind
-        source: ./configs/telemetrykeeper/keeper-{{ $replicaIdx }}.yaml
+        source: ./configs/telemetrykeeper/{{ $keeperConfigKey }}
         target: /etc/clickhouse-keeper/keeper.yaml
         content: |
-{{ index $.Spec.TelemetryKeeper.Spec.Config.Data (printf "keeper-%d.yaml" $replicaIdx) | indent 10 }}
+{{ $keeperConfig | indent 10 }}
     entrypoint:
       - /usr/bin/clickhouse-keeper
       - --config-file=/etc/clickhouse-keeper/keeper.yaml
@@ -66,9 +76,11 @@ services:
         max-file: "3"
     {{- end }}
   {{- end }}
+  {{- end }}
+  {{- if derefBool $.Spec.TelemetryStore.Spec.Enabled }}
   {{ $.Metadata.Name }}-telemetrystore-{{ $.Spec.TelemetryStore.Kind }}-user-scripts:
     image: {{ $.Spec.TelemetryStore.Spec.Image }}
-    restart: "no"
+    restart: on-failure
     command:
       - bash
       - -c
@@ -94,26 +106,36 @@ services:
   {{- range $replicaIdx := add $.Spec.TelemetryStore.Spec.Cluster.Replicas 1 }}
   {{ $.Metadata.Name }}-telemetrystore-{{ $.Spec.TelemetryStore.Kind }}-{{ $shardIdx }}-{{ $replicaIdx }}:
     image: {{ $.Spec.TelemetryStore.Spec.Image }}
+    restart: unless-stopped
     depends_on:
       {{ $.Metadata.Name }}-telemetrystore-{{ $.Spec.TelemetryStore.Kind }}-user-scripts:
         condition: service_completed_successfully
+      {{- if derefBool $.Spec.TelemetryKeeper.Spec.Enabled }}
       {{- range $keeperIdx := until (int $.Spec.TelemetryKeeper.Spec.Cluster.Replicas) }}
       {{ $.Metadata.Name }}-telemetrykeeper-{{ $.Spec.TelemetryKeeper.Kind }}-{{ $keeperIdx }}:
         condition: service_healthy
       {{- end }}
+      {{- end }}
     environment:
       - CLICKHOUSE_SKIP_USER_SETUP=1
       - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml
+      {{- range $key, $value := $.Spec.TelemetryStore.Spec.Env }}
+      - {{ $key }}={{ $value }}
+      {{- end }}
     healthcheck:
       test:
         - CMD
         - wget
-        - --spider
         - -q
+        - -O-
         - 0.0.0.0:8123/ping
       interval: 30s
-      timeout: 5s
+      timeout: 10s
       retries: 3
+      start_period: 40s
+    {{- $storeConfigKey := printf "config-%d-%d.yaml" $shardIdx $replicaIdx }}
+    {{- $storeConfig := index $.Spec.TelemetryStore.Spec.Config.Data $storeConfigKey }}
+    {{- $storeFunctions := index $.Spec.TelemetryStore.Spec.Config.Data "functions.yaml" }}
     volumes:
       - type: volume
         source: {{ $.Metadata.Name }}-telemetrystore-{{ $shardIdx }}-{{ $replicaIdx }}-data
@@ -123,25 +145,27 @@ services:
         target: /var/lib/clickhouse/user_scripts
         read_only: true
       - type: bind
-        source: ./configs/telemetrystore/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml
-        target: /etc/clickhouse-server/config-{{ $shardIdx }}-{{ $replicaIdx }}.yaml
+        source: ./configs/telemetrystore/{{ $storeConfigKey }}
+        target: /etc/clickhouse-server/{{ $storeConfigKey }}
         content: |
-{{ index $.Spec.TelemetryStore.Spec.Config.Data (printf "config-%d-%d.yaml" $shardIdx $replicaIdx) | indent 10 }}
+{{ $storeConfig | indent 10 }}
       - type: bind
         source: ./configs/telemetrystore/functions.yaml
         target: /etc/clickhouse-server/functions.yaml
         content: |
-{{ index $.Spec.TelemetryStore.Spec.Config.Data "functions.yaml" | indent 10 }}
+{{ $storeFunctions | indent 10 }}
     logging:
       options:
         max-size: 50m
         max-file: "3"
   {{- end }}
   {{- end }}
-  {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
+  {{- end }}
+  {{- if and (derefBool $.Spec.MetaStore.Spec.Enabled) (ne $.Spec.MetaStore.Kind.String "sqlite") }}
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}:
     image: {{ $.Spec.MetaStore.Spec.Image }}
+    restart: unless-stopped
     {{- if $.Spec.MetaStore.Spec.Env }}
     environment:
       {{- range $key, $value := $.Spec.MetaStore.Spec.Env }}
@@ -153,11 +177,12 @@ services:
         - CMD-SHELL
         - pg_isready -U signoz -d signoz
       interval: 30s
-      timeout: 5s
+      timeout: 10s
       retries: 3
+      start_period: 30s
     volumes:
       - type: volume
-        source: {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data
+        source: {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data
         target: /var/lib/postgresql/data
     logging:
       options:
@@ -165,64 +190,53 @@ services:
         max-file: "3"
   {{- end }}
   {{- end }}
+  {{- if derefBool $.Spec.Signoz.Spec.Enabled }}
   {{- range $replicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}:
-    container_name: {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}
     image: {{ $.Spec.Signoz.Spec.Image }}
-    depends_on:
-      {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
-      {{- range $metaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
-      {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $metaIdx }}:
-        condition: service_healthy
-      {{- end }}
-      {{- end }}
-      {{- range $shardIdx := $.Spec.TelemetryStore.Spec.Cluster.Shards }}
-      {{- range $storeReplicaIdx := add $.Spec.TelemetryStore.Spec.Cluster.Replicas 1 }}
-      {{ $.Metadata.Name }}-telemetrystore-{{ $.Spec.TelemetryStore.Kind }}-{{ $shardIdx }}-{{ $storeReplicaIdx }}:
-        condition: service_healthy
-      {{- end }}
-      {{- end }}
-      {{ $.Metadata.Name }}-telemetrystore-migrator:
-        condition: service_completed_successfully
+    restart: unless-stopped
     healthcheck:
       test:
         - CMD
         - wget
         - --spider
         - -q
-        - localhost:8080/api/v1/health
+        - http://localhost:8080/api/v1/health
       interval: 30s
-      timeout: 5s
+      timeout: 10s
       retries: 3
+      start_period: 60s
     environment:
-      {{- if $.Spec.Signoz.Spec.Env }}
+      - SERVICE_URL_SIGNOZ{{ $replicaIdx }}_8080
       {{- range $key, $value := $.Spec.Signoz.Spec.Env }}
       - {{ $key }}={{ $value }}
       {{- end }}
-      {{- end }}
+    {{- if eq $.Spec.MetaStore.Kind.String "sqlite" }}
     volumes:
       - type: volume
-        source: {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}-data
-        target: /var/lib/signoz/
+        source: {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data
+        target: {{ dir (index $.Spec.Signoz.Spec.Env "SIGNOZ_SQLSTORE_SQLITE_PATH") }}
+    {{- end }}
     logging:
       options:
         max-size: 50m
         max-file: "3"
   {{- end }}
+  {{- end }}
   {{- if derefBool $.Spec.MCP.Spec.Enabled }}
   {{- $mcpReplicas := int $.Spec.MCP.Spec.Cluster.Replicas }}
   mcp:
     image: {{ $.Spec.MCP.Spec.Image }}
+    restart: unless-stopped
     networks:
       default:
         aliases:
           - {{ $.Metadata.Name }}-mcp
-    {{- if $.Spec.MCP.Spec.Env }}
     environment:
+      - SERVICE_URL_MCP_8000
       {{- range $key, $value := $.Spec.MCP.Spec.Env }}
       - {{ $key }}={{ $value }}
       {{- end }}
-    {{- end }}
     logging:
       options:
         max-size: 50m
@@ -230,33 +244,25 @@ services:
     deploy:
       replicas: {{ $mcpReplicas }}
   {{- end }}
+  {{- if derefBool $.Spec.Ingester.Spec.Enabled }}
   {{- $ingesterReplicas := int $.Spec.Ingester.Spec.Cluster.Replicas }}
+  {{- $ingesterConfig := index $.Spec.Ingester.Spec.Config.Data "ingester.yaml" }}
+  {{- $opampConfig := index $.Spec.Ingester.Spec.Config.Data "opamp.yaml" }}
   ingester:
     image: {{ $.Spec.Ingester.Spec.Image }}
+    restart: unless-stopped
     networks:
       default:
         aliases:
           - {{ $.Metadata.Name }}-ingester
-    depends_on:
-      {{- range $shardIdx := $.Spec.TelemetryStore.Spec.Cluster.Shards }}
-      {{- range $storeReplicaIdx := add $.Spec.TelemetryStore.Spec.Cluster.Replicas 1 }}
-      {{ $.Metadata.Name }}-telemetrystore-{{ $.Spec.TelemetryStore.Kind }}-{{ $shardIdx }}-{{ $storeReplicaIdx }}:
-        condition: service_healthy
-      {{- end }}
-      {{- end }}
-      {{ $.Metadata.Name }}-telemetrystore-migrator:
-        condition: service_completed_successfully
-      {{- range $signozReplicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
-      {{ $.Metadata.Name }}-signoz-{{ $signozReplicaIdx }}:
-        condition: service_started
-      {{- end }}
     environment:
+      - SERVICE_URL_INGESTER_4318
       - OTEL_RESOURCE_ATTRIBUTES=host.name=signoz-host,os.type=linux
-      - LOW_CARDINAL_EXCEPTION_GROUPING=false
-      {{- if $.Spec.Ingester.Spec.Env }}
+      {{- if and (derefBool $.Spec.TelemetryStore.Spec.Enabled) $.Spec.TelemetryStore.Status.Addresses.TCP (index $.Spec.TelemetryStore.Status.Addresses.TCP 0) }}
+      - SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN={{ index $.Spec.TelemetryStore.Status.Addresses.TCP 0 }}
+      {{- end }}
       {{- range $key, $value := $.Spec.Ingester.Spec.Env }}
       - {{ $key }}={{ $value }}
-      {{- end }}
       {{- end }}
     entrypoint:
       - /bin/sh
@@ -270,52 +276,53 @@ services:
         source: ./configs/ingester/ingester.yaml
         target: /etc/otel-collector-config.yaml
         content: |
-{{ index $.Spec.Ingester.Spec.Config.Data "ingester.yaml" | indent 10 }}
+{{ $ingesterConfig | indent 10 }}
       - type: bind
         source: ./configs/ingester/opamp.yaml
         target: /etc/opamp-config.yaml
         content: |
-{{ index $.Spec.Ingester.Spec.Config.Data "opamp.yaml" | indent 10 }}
+{{ $opampConfig | indent 10 }}
     logging:
       options:
         max-size: 50m
         max-file: "3"
     deploy:
       replicas: {{ $ingesterReplicas }}
+  {{- end }}
+  {{- if derefBool $.Spec.TelemetryStore.Spec.Enabled }}
   {{ $.Metadata.Name }}-telemetrystore-migrator:
     image: {{ $.Spec.Ingester.Spec.Image }}
-    depends_on:
-      {{- range $shardIdx := $.Spec.TelemetryStore.Spec.Cluster.Shards }}
-      {{- range $replicaIdx := add $.Spec.TelemetryStore.Spec.Cluster.Replicas 1 }}
-      {{ $.Metadata.Name }}-telemetrystore-{{ $.Spec.TelemetryStore.Kind }}-{{ $shardIdx }}-{{ $replicaIdx }}:
-        condition: service_healthy
-      {{- end }}
-      {{- end }}
-    {{- if $.Spec.Ingester.Spec.Env }}
+    restart: on-failure
     environment:
+      {{- if and (derefBool $.Spec.TelemetryStore.Spec.Enabled) $.Spec.TelemetryStore.Status.Addresses.TCP (index $.Spec.TelemetryStore.Status.Addresses.TCP 0) }}
+      - SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN={{ index $.Spec.TelemetryStore.Status.Addresses.TCP 0 }}
+      {{- end }}
       {{- range $key, $value := $.Spec.Ingester.Spec.Env }}
       - {{ $key }}={{ $value }}
       {{- end }}
-    {{- end }}
-    restart: on-failure
     exclude_from_hc: true
-    {{- $clickhouseDSN := printf "%s-telemetrystore-%s-0-0" $.Metadata.Name $.Spec.TelemetryStore.Kind }}
     entrypoint:
-      - "/bin/sh"
-      - "-c"
+      - /bin/sh
     command:
-      - /signoz-otel-collector migrate bootstrap --clickhouse-dsn tcp://{{ $clickhouseDSN }}:9000
-      - /signoz-otel-collector migrate sync up --clickhouse-dsn tcp://{{ $clickhouseDSN }}:9000
-      - /signoz-otel-collector migrate async up --clickhouse-dsn tcp://{{$clickhouseDSN }}:9000
+      - -c
+      - |
+        /signoz-otel-collector migrate ready &&
+        /signoz-otel-collector migrate bootstrap &&
+        /signoz-otel-collector migrate sync up &&
+        /signoz-otel-collector migrate async up
     logging:
       options:
         max-size: 50m
         max-file: "3"
+  {{- end }}
 volumes:
+  {{- if derefBool $.Spec.TelemetryKeeper.Spec.Enabled }}
   {{- range $replicaIdx := until (int $.Spec.TelemetryKeeper.Spec.Cluster.Replicas) }}
   {{ $.Metadata.Name }}-telemetrykeeper-{{ $replicaIdx }}-data:
     name: {{ $.Metadata.Name }}-telemetrykeeper-{{ $replicaIdx }}-data
   {{- end }}
+  {{- end }}
+  {{- if derefBool $.Spec.TelemetryStore.Spec.Enabled }}
   {{- range $shardIdx := $.Spec.TelemetryStore.Spec.Cluster.Shards }}
   {{- range $replicaIdx := add $.Spec.TelemetryStore.Spec.Cluster.Replicas 1 }}
   {{ $.Metadata.Name }}-telemetrystore-{{ $shardIdx }}-{{ $replicaIdx }}-data:
@@ -324,13 +331,16 @@ volumes:
   {{- end }}
   {{ $.Metadata.Name }}-telemetrystore-user-scripts:
     name: {{ $.Metadata.Name }}-telemetrystore-user-scripts
-  {{- if ne $.Spec.MetaStore.Kind.String "sqlite" }}
+  {{- end }}
+  {{- if and (derefBool $.Spec.MetaStore.Spec.Enabled) (ne $.Spec.MetaStore.Kind.String "sqlite") }}
   {{- range $replicaIdx := until (int $.Spec.MetaStore.Spec.Cluster.Replicas) }}
-  {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data:
-    name: {{ $.Metadata.Name }}-metastore-{{ $replicaIdx }}-data
+  {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data:
+    name: {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data
   {{- end }}
   {{- end }}
+  {{- if and (derefBool $.Spec.Signoz.Spec.Enabled) (eq $.Spec.MetaStore.Kind.String "sqlite") }}
   {{- range $replicaIdx := until (int $.Spec.Signoz.Spec.Cluster.Replicas) }}
-  {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}-data:
-    name: {{ $.Metadata.Name }}-signoz-{{ $replicaIdx }}-data
+  {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data:
+    name: {{ $.Metadata.Name }}-metastore-{{ $.Spec.MetaStore.Kind }}-{{ $replicaIdx }}-data
+  {{- end }}
   {{- end }}


### PR DESCRIPTION
#### Fixes

- Fixes the stack not telling Coolify which ports to put behind its proxy, so the UI, OTLP HTTP and MCP now each get a domain users assign in their dashboard instead of exposing ports themselves
- Fixes the telemetrystore migrator running only `migrate bootstrap`; the four commands now chain in one shell
- Fixes the ingester and the migrator not receiving `SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN`, so `migrate sync check` dialled the collector's default DSN and exited
- Fixes `deploy.replicas` for the ingester and mcp, which Coolify rejects because it stamps a `container_name` on every service; each replica is its own service now (coollabsio/coolify#3862)
- Fixes `telemetrykeeper.spec.env` and `telemetrystore.spec.env` being dropped
- Fixes the sqlite volume mounting at a hardcoded path instead of `SIGNOZ_SQLSTORE_SQLITE_PATH`
- Fixes `spec.<molding>.spec.enabled` being ignored for every service and its volumes
- Fixes every long-running service having no restart policy
- Fixes the ClickHouse healthcheck logging broken pipes (SigNoz/signoz#5140)

Related: #194, https://github.com/SigNoz/platform-pod/issues/1774
